### PR TITLE
LPD-38883 Avoid sending duplicated values when submitting the form

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -234,13 +234,15 @@ export default function FieldBase({
 						!!localizedValueEdited?.[editingLanguageId]
 					}
 					key={locale}
-					name={updateFieldNameLocale(
-						editingLanguageId,
-						locale,
-						name
-					)}
 					type="hidden"
 					value={normalizeInputValue(type, value)}
+					{...(locale !== editingLanguageId && {
+						name: updateFieldNameLocale(
+							editingLanguageId,
+							locale,
+							name
+						),
+					})}
 				/>
 			);
 		});


### PR DESCRIPTION
related issue: https://liferay.atlassian.net/browse/LPD-38883

the following tests already covers this case:
- Forms#SubmitFormWithMultipleFieldsAndViewEntriesViaDescriptiveDisplay
- FormsSubmissions#CanBeSubmittedWithARequiredField

hi reviewer! :cherry_blossom: 

here is a brief explanation about this bug (that is also on the commit message):

_before we had a condition to return null instead of a hidden input when the locale was the same as the editingLanguageId, avoiding the value to be submitted twice._

_this condition was necessary because the current inputs the user is editing already have the values on the screen (and also on the DOM), thus there isn't a need for hidden values for the current editingLanguageId. when this condition was removed, values started to be sent twice._

_since the web content translation manager now needs all the hidden inputs to calculate their translations, the condition was changed to not add the name attribute into the input hidden that has the same locale as the current editingLanguageId; this way, the value from the input hidden won't be submitted and the value will be sent only once._

if you have any questions please let me know, thanks!

cc: @cgmonte