### PR TITLE
LPD-38644 No need to initialize the company

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionVulcanBatchEngineTaskItemDelegateTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionVulcanBatchEngineTaskItemDelegateTest.java
@@ -20,8 +20,8 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -62,7 +62,7 @@ public class ObjectDefinitionVulcanBatchEngineTaskItemDelegateTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany(true);
+		_company = CompanyTestUtil.addCompany();
 
 		User user = UserTestUtil.addCompanyAdminUser(_company);
 
@@ -103,6 +103,8 @@ public class ObjectDefinitionVulcanBatchEngineTaskItemDelegateTest {
 		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
 
 		PrincipalThreadLocal.setName(_originalName);
+
+		_companyLocalService.deleteCompany(_company);
 	}
 
 	@Test
@@ -224,7 +226,9 @@ public class ObjectDefinitionVulcanBatchEngineTaskItemDelegateTest {
 		};
 	}
 
-	@DeleteAfterTestRun
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
 	private Company _company;
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-38644

![image](https://github.com/user-attachments/assets/b8cf17d1-da2c-40e0-a68f-2122c76b2848)

While I couldn't reproduce the failure locally, I suspect that setting the initialization flag to **false** might address the issue. 

- The change is based on the fact that the `CompanyTestUtil.addCompany(true)` is being used in two other tests that are also occasionally failing on Testray with a similar error:

1. [BatchEngineBrokerTest](https://testray.liferay.com/#/project/35392/routines/1288939/build/41790304/case-result/42127845)

![image](https://github.com/user-attachments/assets/3e8f204a-7ae2-44ae-ab3e-6cb186ea5938)

2. [BatchEngineBundleTrackerTest](https://testray.liferay.com/#/project/35392/routines/1288939/build/41790304/case-result/42127829)

![image](https://github.com/user-attachments/assets/e2a40847-091d-4545-b608-6d5259546196)

**Obs.:** When the initialization flag is set to **true**, the company is created inside a `TransactionInvokerUtil`.