### PR TITLE
LPD-38643 [Test Fix] ObjectFieldLocalServiceTest

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -1056,7 +1056,7 @@ public class ObjectFieldLocalServiceTest {
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
 				TestPropsValues.getUserId(), null, true,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"Test", null, null,
+				"Test" + RandomTestUtil.randomString(), null, null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
 				Collections.emptyList());
@@ -1285,7 +1285,7 @@ public class ObjectFieldLocalServiceTest {
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
 				TestPropsValues.getUserId(), null, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"Test", null, null,
+				"Test" + RandomTestUtil.randomString(), null, null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
 				Collections.emptyList());
@@ -1528,7 +1528,7 @@ public class ObjectFieldLocalServiceTest {
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
 				TestPropsValues.getUserId(), null, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"Test", null, null,
+				"Test" + RandomTestUtil.randomString(), null, null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
 				Collections.emptyList());


### PR DESCRIPTION
# Jira Link
- https://liferay.atlassian.net/browse/LPD-38643
# Additional Information
- I'm unable to remove the `Test` prefix, otherwise it will throw `com.liferay.object.exception.ObjectDefinitionNameException$ForbiddenModifiableSystemObjectDefinitionName: Forbidden modifiable system object definition name`
- The validation called in `ObjectDefinitionLocalServiceImpl` on the [_validateName](https://github.com/liferay-bpm/liferay-portal/blob/24ae5874756ae6e1436657aee45bb41fd0581b3c/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java#L2508C3-L2514C4) method comes from the method [isAllowedModifiableSystemObjectDefinitionName](https://github.com/liferay-bpm/liferay-portal/blob/24ae5874756ae6e1436657aee45bb41fd0581b3c/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java#L33C2-L41C3) in `ObjectDefinitionUtil`