### PR TITLE
LPD-38769

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1649,7 +1649,7 @@ public class DefaultObjectEntryManagerImplTest
 						objectEntryId2)));
 
 			_updateAndAssertObjectEntryWithPicklistObjectField(
-				null, null, objectDefinition, objectEntryId1);
+				null, "", objectDefinition, objectEntryId1);
 			_updateAndAssertObjectEntryWithPicklistObjectField(
 				StringPool.BLANK, StringPool.BLANK, objectDefinition,
 				objectEntryId2);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3293,7 +3293,7 @@ public class ObjectEntryLocalServiceImpl
 				result = _getValue(
 					entryValues, scalarDSLQueryAlias.getSQLType());
 
-				if (result == null) {
+				if (Validator.isNull(result)) {
 					result = "0";
 				}
 				else {


### PR DESCRIPTION
This is a follow up from [https://liferay.atlassian.net/browse/LPD-38769](LPD-38769). 

In some cases when are using aggregation fields the value retrieved from the database are null and should be returned as "0" in the _getResult method to don't break the logic from others components that are using it, so using the "validator" method we still supporting this. 