### PR TITLE
LPP-56280 Fix Accessibility Issue in Workflow Approval page

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_metadata/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_metadata/page.jsp
@@ -11,7 +11,7 @@
 String[] metadataFields = (String[])request.getAttribute("liferay-asset:asset-metadata:metadataFields");
 %>
 
-<dl class="taglib-asset-metadata">
+<div class="taglib-asset-metadata">
 	<c:choose>
 		<c:when test="<%= metadataFields.length == 1 %>">
 
@@ -61,4 +61,4 @@ String[] metadataFields = (String[])request.getAttribute("liferay-asset:asset-me
 			</c:if>
 		</c:otherwise>
 	</c:choose>
-</dl>
+</div>

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/edit_workflow_task.jsp
@@ -181,8 +181,14 @@ renderResponse.setTitle(workflowTaskDisplayContext.getHeaderTitle(workflowTask))
 									</portlet:renderURL>
 
 									<c:if test="<%= !workflowTaskDisplayContext.isReadOnly() %>">
-										<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "view[action]") %>">
+
+										<%
+										String viewTaskContentActionLabel = LanguageUtil.get(request, "view[action]");
+										%>
+
+										<span class="lfr-portal-tooltip" title="<%= viewTaskContentActionLabel %>">
 											<clay:link
+												aria-label="<%= viewTaskContentActionLabel %>"
 												cssClass="btn btn-monospaced btn-outline-secondary lfr-icon-item taglib-icon"
 												href="<%= assetRenderer.isPreviewInContext() ? workflowHandler.getURLViewInContext(assetRenderer.getClassPK(), liferayPortletRequest, liferayPortletResponse, null) : viewFullContentURL.toString() %>"
 												icon="view"
@@ -193,11 +199,18 @@ renderResponse.setTitle(workflowTaskDisplayContext.getHeaderTitle(workflowTask))
 										</span>
 
 										<c:if test="<%= workflowTaskDisplayContext.hasViewDiffsPortletURL(workflowTask) %>">
-											<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "diffs") %>">
+
+											<%
+											String diffsTaskContentsActionLabel = LanguageUtil.get(request, "diffs");
+											%>
+
+											<span class="lfr-portal-tooltip" title="<%= diffsTaskContentsActionLabel %>">
 												<clay:link
+													aria-label="<%= diffsTaskContentsActionLabel %>"
 													cssClass="btn btn-monospaced btn-outline-secondary lfr-icon-item taglib-icon"
 													href="<%= workflowTaskDisplayContext.getTaglibViewDiffsURL(workflowTask) %>"
 													icon="paste"
+													id='<%= liferayPortletResponse.getNamespace() + "diffs" %>'
 												/>
 											</span>
 										</c:if>
@@ -211,11 +224,17 @@ renderResponse.setTitle(workflowTaskDisplayContext.getHeaderTitle(workflowTask))
 												<portlet:param name="workflowTaskId" value="<%= String.valueOf(workflowTask.getWorkflowTaskId()) %>" />
 											</portlet:renderURL>
 
-											<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "view-usages") %>">
+											<%
+											String viewUsagesTaskContentActionLabel = LanguageUtil.get(request, "view-usages");
+											%>
+
+											<span class="lfr-portal-tooltip" title="<%= viewUsagesTaskContentActionLabel %>">
 												<clay:link
+													aria-label="<%= viewUsagesTaskContentActionLabel %>"
 													cssClass="btn btn-monospaced btn-outline-secondary lfr-icon-item taglib-icon"
 													href="<%= viewLayoutClassedModelUsagesURL %>"
 													icon="list"
+													id='<%= liferayPortletResponse.getNamespace() + "viewUsages" %>'
 												/>
 											</span>
 										</c:if>
@@ -225,8 +244,14 @@ renderResponse.setTitle(workflowTaskDisplayContext.getHeaderTitle(workflowTask))
 								<c:if test="<%= workflowTaskDisplayContext.hasEditPortletURL(workflowTask) %>">
 									<c:choose>
 										<c:when test="<%= assetRenderer.hasEditPermission(permissionChecker) && workflowTaskDisplayContext.isShowEditURL(workflowTask) %>">
-											<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "edit") %>">
+
+											<%
+											String editTaskContentActionLabel = LanguageUtil.get(request, "edit");
+											%>
+
+											<span class="lfr-portal-tooltip" title="<%= editTaskContentActionLabel %>">
 												<clay:link
+													aria-label="<%= editTaskContentActionLabel %>"
 													cssClass="btn btn-monospaced btn-outline-secondary lfr-icon-item taglib-icon"
 													href="<%= workflowTaskDisplayContext.getTaglibEditURL(workflowTask) %>"
 													icon="pencil"

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_action.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/workflow_task_action.jsp
@@ -28,7 +28,7 @@ PortletURL redirectURL = PortletURLBuilder.createRenderURL(
 	direction="left-side"
 	icon="<%= StringPool.BLANK %>"
 	markupView="lexicon"
-	message="<%= StringPool.BLANK %>"
+	message='<%= LanguageUtil.get(request, "open-actions-menu") %>'
 	showExpanded="<%= row == null %>"
 >
 	<c:if test="<%= !workflowTask.isCompleted() %>">

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
@@ -8,6 +8,9 @@ import {FrameLocator, Locator, Page} from '@playwright/test';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {WorkflowTasksPage} from './WorkflowTasksPage';
 
+const MY_WORKFLOW_TASK_PORTLET_NAMESPACE =
+	'_com_liferay_portal_workflow_task_web_portlet_MyWorkflowTaskPortlet_';
+
 export class WorkflowTaskDetailsPage {
 	readonly activitiesButton: Locator;
 	readonly approveMenuItem: Locator;
@@ -22,6 +25,7 @@ export class WorkflowTaskDetailsPage {
 	readonly doneButton: Locator;
 	readonly editAssetButton: Locator;
 	readonly page: Page;
+	readonly portletNameSpace: string;
 	readonly previewMessageBoards: Locator;
 	readonly rejectMenuItem: Locator;
 	readonly replyButton: Locator;
@@ -34,7 +38,7 @@ export class WorkflowTaskDetailsPage {
 		this.activitiesButton = page.getByRole('button', {name: 'Activities'});
 		this.approveMenuItem = page.getByRole('menuitem', {name: 'approve'});
 		this.assignToDialogIFRAME = page.frameLocator(
-			'iframe[name="_com_liferay_portal_workflow_task_web_portlet_MyWorkflowTaskPortlet_assignToDialog_iframe_"]'
+			`iframe[name="${MY_WORKFLOW_TASK_PORTLET_NAMESPACE}assignToDialog_iframe_"]`
 		);
 		this.assignToMenuItem = page.getByRole('link', {name: 'Assign to...'});
 		this.assignToSingleSelect =
@@ -51,13 +55,14 @@ export class WorkflowTaskDetailsPage {
 		this.doneButton = page.getByRole('button', {name: 'Done'});
 		this.editAssetButton = page.locator('[title="Edit"]');
 		this.page = page;
+		this.portletNameSpace = MY_WORKFLOW_TASK_PORTLET_NAMESPACE;
 		this.previewMessageBoards = page.getByRole('button', {
 			name: 'Preview of Message Boards',
 		});
 		this.rejectMenuItem = page.getByRole('menuitem', {name: 'reject'});
 		this.replyButton = page.getByRole('button', {name: 'Reply'});
 		this.reviewActionMenu = page.locator(
-			'[id="_com_liferay_portal_workflow_task_web_portlet_MyWorkflowTaskPortlet_kldx___menu"]'
+			`[id="${MY_WORKFLOW_TASK_PORTLET_NAMESPACE}kldx___menu"]`
 		);
 		this.reviewComment = page.getByRole('textbox', {name: 'Comment'});
 		this.subscribeButton = page.getByLabel('Subscribe to Comments');

--- a/modules/test/playwright/tests/portal-workflow-task-web/accessibility.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/accessibility.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import {checkAccessibility} from '../../utils/checkAccessibility';
+import clearInvalidUserNotifications from '../../utils/clearInvalidUserNotifications';
+import retryGetWorkflowTasksBySubmittingUser from '../../utils/retryGetWorkflowTasksBySubmittingUser';
+
+export const test = mergeTests(apiHelpersTest, loginTest(), workflowPagesTest);
+
+interface CreatedEntities {
+	blogPosts?: TBlogPost[];
+}
+
+const createdEntities: CreatedEntities = {};
+
+test.afterEach(async ({apiHelpers, configurationTabPage, page}) => {
+	await configurationTabPage.goTo();
+
+	await configurationTabPage.unassignWorkflowFromAssetType('Blogs Entry');
+
+	if (createdEntities.blogPosts?.length) {
+		for (const blog of createdEntities.blogPosts) {
+			await apiHelpers.headlessDelivery.deleteBlog(blog.id);
+		}
+	}
+
+	delete createdEntities.blogPosts;
+
+	await clearInvalidUserNotifications(page);
+});
+
+test('Workflow task view page is accessible', async ({
+	apiHelpers,
+	configurationTabPage,
+	page,
+	workflowTaskDetailsPage,
+}) => {
+	await configurationTabPage.goTo();
+
+	await configurationTabPage.assignWorkflowToAssetType(
+		'Single Approver',
+		'Blogs Entry'
+	);
+
+	const site = await apiHelpers.headlessSite.getSiteByERC('L_GUEST');
+
+	const blogPost = await apiHelpers.headlessDelivery.postBlog(site.id);
+
+	createdEntities.blogPosts = [blogPost];
+
+	const submittingUserId = blogPost.creator.id;
+
+	const workflowTaskDefinitions = await retryGetWorkflowTasksBySubmittingUser(
+		{
+			expectedNumberOfTasks: 1,
+			page,
+			submittingUser: submittingUserId,
+		}
+	);
+
+	const workflowTaskDefinition = workflowTaskDefinitions.items[0];
+
+	await apiHelpers.headlessAdminWorkflow.postAssignTaskToUser(
+		workflowTaskDefinition.id,
+		submittingUserId
+	);
+
+	await page.getByTitle('User Profile Menu').click();
+
+	await page.getByRole('menuitem', {name: 'My Workflow Tasks'}).click();
+
+	await page
+		.getByRole('link', {
+			name: workflowTaskDefinition.objectReviewed.assetTitle,
+		})
+		.click();
+
+	await page.waitForLoadState();
+
+	const taskContentActionsSelectors = ['edit', 'view', 'viewUsages'].map(
+		(sufix) => `#${workflowTaskDetailsPage.portletNameSpace + sufix}`
+	);
+
+	const openActionsMenuLinkSelector =
+		'a[title="Open Actions Menu"][role="button"]';
+
+	await checkAccessibility({
+		page,
+		selectors: [
+			...taskContentActionsSelectors,
+			openActionsMenuLinkSelector,
+		],
+	});
+
+	expect(test.info().errors).toHaveLength(0);
+});

--- a/modules/test/playwright/tests/portal-workflow-task-web/accessibility.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/accessibility.spec.ts
@@ -84,17 +84,20 @@ test('Workflow task view page is accessible', async ({
 
 	await page.waitForLoadState();
 
-	const taskContentActionsSelectors = ['edit', 'view', 'viewUsages'].map(
-		(sufix) => `#${workflowTaskDetailsPage.portletNameSpace + sufix}`
-	);
+	const assetMetadataWrapperElementSelector = 'div.taglib-asset-metadata';
 
 	const openActionsMenuLinkSelector =
 		'a[title="Open Actions Menu"][role="button"]';
+
+	const taskContentActionsSelectors = ['edit', 'view', 'viewUsages'].map(
+		(sufix) => `#${workflowTaskDetailsPage.portletNameSpace + sufix}`
+	);
 
 	await checkAccessibility({
 		page,
 		selectors: [
 			...taskContentActionsSelectors,
+			assetMetadataWrapperElementSelector,
 			openActionsMenuLinkSelector,
 		],
 	});

--- a/modules/test/playwright/utils/checkAccessibility.ts
+++ b/modules/test/playwright/utils/checkAccessibility.ts
@@ -38,19 +38,25 @@ export async function checkAccessibility({
 }: Params) {
 	const tags = bestPractices ? [...TAGS, 'best-practice'] : TAGS;
 
+	const axeBuilder = new AxeBuilder({page});
+
 	if (selectors) {
 		for (const selector of selectors) {
-			page.locator(selector).waitFor();
+			await page.locator(selector).waitFor();
+
+			axeBuilder.include(selector);
 		}
 	}
 
-	const results = await new AxeBuilder({page})
-		.withTags(tags)
-		.include(selectors)
-		.exclude(selectorsToExclude)
-		.analyze();
+	if (selectorsToExclude) {
+		for (const selector of selectorsToExclude) {
+			axeBuilder.exclude(selector);
+		}
+	}
 
-	await (soft ? expect.soft : expect)(
+	const results = await axeBuilder.withTags(tags).analyze();
+
+	(soft ? expect.soft : expect)(
 		results.violations,
 		'Accessibility issues'
 	).toEqual([]);


### PR DESCRIPTION
This fixes two accessibility bugs related to [LPP-56280](https://liferay.atlassian.net/browse/LPP-56280):

[LPD-39861](https://liferay.atlassian.net/browse/LPD-39861)
[LPD-39862](https://liferay.atlassian.net/browse/LPD-39862)

It also adds related functional tests, and while adding those, I found some bugs in the `checkAccessibility` utility function, which I fixed [here](https://github.com/liferay-bpm/liferay-portal/commit/e9064afe42489a48ad5d957077df8d71906e669b). For this reason I would like to ask @ethib137 to review these changes.

For further context on why I have changed `checkAccessibility`, please check [this document](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/playwright/README.md) from axe-core. There, you will see that "arrays with more than one index when passing multiple CSS selectors are not currently supported" as arguments to the `include` and `exclude` methods. 

Thanks!

[LPP-56280]: https://liferay.atlassian.net/browse/LPP-56280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-39861]: https://liferay.atlassian.net/browse/LPD-39861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-39862]: https://liferay.atlassian.net/browse/LPD-39862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ