### PR TITLE
LPD-41062 Limit columns width to avoid unnecessary oversizing of permission inheritance column

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.scss
@@ -61,6 +61,45 @@
 	}
 }
 
+// TODO: remove the css customization bellow along with the removal of feature flag LPS-193005
+
+.dnd-table {
+	.dnd-td,
+	.dnd-th {
+		&.cell-actions {
+			max-width: 72px;
+		}
+
+		&.cell-dateModified {
+			min-width: 230px;
+		}
+
+		&.cell-label {
+			min-width: 250px;
+		}
+
+		&.cell-permissionInheritance {
+			max-width: 130px;
+		}
+
+		&.cell-scope {
+			min-width: 109px;
+		}
+
+		&.cell-status {
+			min-width: 113px;
+		}
+
+		&.cell-system {
+			max-width: 100px;
+		}
+
+		&.cell-type {
+			min-width: 107px;
+		}
+	}
+}
+
 .cursor-pointer {
 	cursor: pointer;
 }


### PR DESCRIPTION
This is a follow up to: https://github.com/liferay-bpm/liferay-portal/pull/3823
Since now we are not going to wait on clay's table FF, we need to manipulate the table width on our side a little bit to match the expected result on our mockups. This should be just an temporary patch until their FF is released. 

Ideally, we would manipulate only permission inheritance column's width, but I haven't been able to do it the way they [suggested](https://liferay.atlassian.net/browse/PTR-5744) , the mentioned example is [here](https://github.com/liferay-bpm/liferay-portal/blob/f5622597a246a420a973db4f0631fa74877b3aba/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/css/minium/overrides/_data-set-display.scss#L92), customizing an commerce table, so it should be something like this for our case: 
```
.dnd-table {
		.dnd-td,
		.dnd-th {
			&.cell-permissionInheritance {
				max-width: 150px;
			}
		}
	}
```

But that code was never applied to the cell even using !important, so instead of manipulating only the cell, I've limited the whole card to the maximum width that will keep the column's title in two lines instead of one. Please let me know your thoughts on this, thanks!