### PR TITLE
LPD-42023 Do not allow an object definition to be published if it's the root of a tree that has entries

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -41,6 +41,7 @@ import com.liferay.object.exception.ObjectDefinitionStatusException;
 import com.liferay.object.exception.ObjectDefinitionSystemException;
 import com.liferay.object.exception.ObjectDefinitionVersionException;
 import com.liferay.object.exception.ObjectFieldRelationshipTypeException;
+import com.liferay.object.exception.ObjectRelationshipEdgeException;
 import com.liferay.object.exception.RequiredObjectDefinitionException;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.internal.dao.db.ObjectDBManagerUtil;
@@ -1971,6 +1972,28 @@ public class ObjectDefinitionLocalServiceImpl
 				"At least one object field must be added when publishing the " +
 					"object definition",
 				"at-least-one-object-field-must-be-added");
+		}
+
+		if ((objectDefinition.getStatus() == WorkflowConstants.STATUS_DRAFT) &&
+			objectDefinition.isRootNode()) {
+
+			for (ObjectRelationship objectRelationship :
+					_objectRelationshipLocalService.getObjectRelationships(
+						objectDefinition.getObjectDefinitionId())) {
+
+				int objectEntriesCount =
+					_objectEntryLocalService.getObjectEntriesCount(
+						objectRelationship.getObjectDefinitionId2());
+
+				if (objectEntriesCount > 0) {
+					throw new ObjectRelationshipEdgeException(
+						StringBundler.concat(
+							"There must be no unrelated object entries when ",
+							"both object definitions are published so that ",
+							"the object relationship can be an edge to a root ",
+							"context"));
+				}
+			}
 		}
 
 		objectDefinition.setActive(true);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -580,11 +580,55 @@ public class ObjectRelationshipLocalServiceTest {
 			_objectDefinitionLocalService, new String[] {"C_AA", "C_A"},
 			_objectEntryLocalService);
 
-		// Bind a draft object definition tree to a published object definition
-		// tree
+		// Bind a draft object definition to a published object definition
+		// with entries
+
+		objectDefinitionAA = _addAndPublishCustomObjectDefinition("AA");
+
+		_addObjectEntry(objectDefinitionAA, Collections.emptyMap());
 
 		ObjectDefinition objectDefinitionA =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition("A");
+
+		_testBindObjectDefinitions(
+			objectDefinitionA, objectDefinitionAA,
+			(objectDefinition1, objectDefinition2) -> {
+				TreeTestUtil.assertObjectDefinitionTree(
+					LinkedHashMapBuilder.put(
+						"A", new String[0]
+					).build(),
+					_objectDefinitionTreeFactory.create(
+						objectDefinition1.getObjectDefinitionId()),
+					_objectDefinitionLocalService);
+				TreeTestUtil.assertObjectDefinitionTree(
+					LinkedHashMapBuilder.put(
+						"AA", new String[0]
+					).build(),
+					_objectDefinitionTreeFactory.create(
+						objectDefinition2.getObjectDefinitionId()),
+					_objectDefinitionLocalService);
+			});
+
+		long objectDefinitionId = objectDefinitionA.getObjectDefinitionId();
+
+		AssertUtils.assertFailure(
+			ObjectRelationshipEdgeException.class,
+			StringBundler.concat(
+				"There must be no unrelated object entries when both object ",
+				"definitions are published so that the object relationship ",
+				"can be an edge to a root context"),
+			() -> _objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(), objectDefinitionId));
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService, new String[] {"C_AA", "C_A"},
+			_objectEntryLocalService);
+
+		// Bind a draft object definition tree to a published object definition
+		// tree
+
+		objectDefinitionA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
+			"A");
 		objectDefinitionAA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
 			"AA");
 


### PR DESCRIPTION
Related ticket: [LPD-42023](https://liferay.atlassian.net/browse/LPD-42023)

[LPD-42023]: https://liferay.atlassian.net/browse/LPD-42023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ