### PR TITLE
LPD-42407 User should be notifiable after the workflow task in completed, so that they can still click on the notification

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
@@ -725,10 +725,6 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 			_kaleoTaskInstanceTokenLocalService.getKaleoTaskInstanceToken(
 				workflowTaskId);
 
-		if (kaleoTaskInstanceToken.isCompleted()) {
-			return false;
-		}
-
 		Collection<KaleoTaskAssignment> kaleoTaskAssignments =
 			_aggregateKaleoTaskAssignmentSelector.getKaleoTaskAssignments(
 				_kaleoTaskAssignmentLocalService.getKaleoTaskAssignments(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -990,6 +990,32 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 		Assert.assertTrue(
 			_workflowTaskManager.isNotifiableUser(
 				user.getUserId(), workflowTask.getWorkflowTaskId()));
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+
+			_workflowTaskManager.assignWorkflowTaskToUser(
+				_company.getCompanyId(), user.getUserId(),
+				workflowTask.getWorkflowTaskId(), user.getUserId(),
+				StringPool.BLANK, null, null);
+
+			_workflowTaskManager.completeWorkflowTask(
+				_company.getCompanyId(), user.getUserId(),
+				workflowTask.getWorkflowTaskId(), Constants.APPROVE,
+				StringPool.BLANK, null);
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertTrue(
+			_workflowTaskManager.isNotifiableUser(
+				user.getUserId(), workflowTask.getWorkflowTaskId()));
 	}
 
 	@Test


### PR DESCRIPTION
Related ticket: [LPD-42407](https://liferay.atlassian.net/browse/LPD-42407)

[LPD-42407]: https://liferay.atlassian.net/browse/LPD-42407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ