### PR TITLE
LPD-39701 - "Copy" button overflows in Notification templates table

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTermsContainer/DefinitionOfTerms.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTermsContainer/DefinitionOfTerms.tsx
@@ -91,6 +91,7 @@ export function DefinitionOfTerms({
 						itemsActions={[
 							{
 								href: 'copyTerm',
+								icon: 'copy',
 								id: 'copyTerm',
 								label: Liferay.Language.get('copy'),
 								onClick: copyTerm,

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTermsContainer/GeneralTerms.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTermsContainer/GeneralTerms.tsx
@@ -50,6 +50,7 @@ export function GeneralTerms({baseResourceURL}: GeneralTermsProps) {
 					itemsActions={[
 						{
 							href: 'copyTerm',
+							icon: 'copy',
 							id: 'copyTerm',
 							label: Liferay.Language.get('copy'),
 							onClick: copyTerm,

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTermsContainer/RelationshipSection.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTermsContainer/RelationshipSection.tsx
@@ -97,6 +97,7 @@ export default function RelationshipSection({
 					itemsActions={[
 						{
 							href: 'copyTerm',
+							icon: 'copy',
 							id: 'copyTerm',
 							label: Liferay.Language.get('copy'),
 							onClick: copyTerm,


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-39701
Original PR: https://github.com/liferay-platform-experience/liferay-portal/pull/803

## Motivation
Fix overflowing button in Notification templates

## Proposed Solution
This proposed solution is to remove the text `copy` and add the icon equivalent. 
## Steps to Verify

1. Enable FF: LPS-193005.
2.  Navigate to the Notification templates section under control panel
3. Locate the table displaying notification templates
4. Observe the "Copy" CTA button in the table

## Screenshots/videos 
![image](https://github.com/user-attachments/assets/c9bf3d01-ee80-404a-ae42-0f28e55ad870)

