### PR TITLE
LPD-43122 Object definitions bound to a root model can't be deployed on portal startup

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -304,7 +304,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				RESTContextPathResolver.class,
 				new RESTContextPathResolverImpl(
-					"/o" + objectDefinition.getRESTContextPath(),
+					objectDefinition,
 					_objectScopeProviderRegistry.getObjectScopeProvider(
 						objectDefinition.getScope()),
 					false),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/rest/context/path/RESTContextPathResolverImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/rest/context/path/RESTContextPathResolverImpl.java
@@ -5,9 +5,11 @@
 
 package com.liferay.object.internal.rest.context.path;
 
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.context.path.RESTContextPathResolver;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Marco Leo
@@ -15,21 +17,30 @@ import com.liferay.portal.kernel.util.StringUtil;
 public class RESTContextPathResolverImpl implements RESTContextPathResolver {
 
 	public RESTContextPathResolverImpl(
+		ObjectDefinition objectDefinition,
+		ObjectScopeProvider objectScopeProvider, boolean system) {
+
+		_objectDefinition = objectDefinition;
+		_objectScopeProvider = objectScopeProvider;
+		_system = system;
+	}
+
+	public RESTContextPathResolverImpl(
 		String contextPath, ObjectScopeProvider objectScopeProvider,
 		boolean system) {
 
 		_objectScopeProvider = objectScopeProvider;
+		_system = system;
 
-		if (objectScopeProvider.isGroupAware() && !system) {
-			_contextPath = contextPath + "/scopes/{scopeKey}";
-		}
-		else {
-			_contextPath = contextPath;
-		}
+		_initContextPath(contextPath);
 	}
 
 	@Override
 	public String getRESTContextPath(long groupId) {
+		if (Validator.isNull(_contextPath)) {
+			_initContextPath("/o" + _objectDefinition.getRESTContextPath());
+		}
+
 		if (!_objectScopeProvider.isGroupAware() ||
 			!_objectScopeProvider.isValidGroupId(groupId)) {
 
@@ -41,7 +52,17 @@ public class RESTContextPathResolverImpl implements RESTContextPathResolver {
 			new String[] {String.valueOf(groupId), String.valueOf(groupId)});
 	}
 
-	private final String _contextPath;
+	private void _initContextPath(String contextPath) {
+		_contextPath = contextPath;
+
+		if (_objectScopeProvider.isGroupAware() && !_system) {
+			_contextPath = _contextPath + "/scopes/{scopeKey}";
+		}
+	}
+
+	private String _contextPath;
+	private ObjectDefinition _objectDefinition;
 	private final ObjectScopeProvider _objectScopeProvider;
+	private final boolean _system;
 
 }


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-43122

In this PR we are deferring the invocation of `getRESTContextPath()` method in the `ObjectDefinitionImpl` class to the moment such REST context path is actually requested. 

Reason to do this is that [current implementation](https://github.com/liferay/liferay-portal/blob/e4e180f5e3a68a53210f74242f532bae6250c573/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java#L143-L145) relies on the `ObjectDefinitionLocalServiceUtil` class to be properly initialized. As this is invoked when object service is being initialized [when aop proxy is being set](https://github.com/liferay/liferay-portal/blob/a73ca21f8b1d8bea7859d30e33c2870b195edc0f/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java#L1005) at startup time, there exists a chicken-egg problem as the `ObjectDefinitionLocalServiceUtil` can't yet have a reference to the service implementation.

To avoid this, proposed solution allows to create a `RESTContextPathResolverImpl` object at deploy time where such invocations are not needed. When the actual REST path needs to be resolved, then computation will take place and service will be ready then.

**Notes**: 

- The above statement "service will be ready then" is just an assumption I've made while debugging the product. This needs a review from some team member familiar with the object definition deployment lifecycle.
- This is blocking the release of the Data Set Manager feature, commited for this milestone.

Thanks for your time
