### PR TITLE
LPD-42393 Exception during "Fix Issue" for "Order split by catalog action"

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -48,6 +48,8 @@ public interface ObjectDefinition
 
 		};
 
+	public java.util.Locale getDefaultLocale();
+
 	public String getDestinationName();
 
 	public String getExtensionDBTableName();

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -409,6 +409,11 @@ public class ObjectDefinitionWrapper
 		return model.getDefaultLanguageId();
 	}
 
+	@Override
+	public java.util.Locale getDefaultLocale() {
+		return model.getDefaultLocale();
+	}
+
 	/**
 	 * Returns the description object field ID of this object definition.
 	 *

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
@@ -1,1 +1,1 @@
-version 9.4.0
+version 9.5.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -15,10 +15,12 @@ import com.liferay.object.service.ObjectFolderLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -35,6 +37,11 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 		}
 
 		return shortName;
+	}
+
+	@Override
+	public Locale getDefaultLocale() {
+		return LocaleUtil.fromLanguageId(getDefaultLanguageId());
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -23,7 +23,6 @@ import com.liferay.object.exception.ObjectActionActiveException;
 import com.liferay.object.exception.ObjectActionConditionExpressionException;
 import com.liferay.object.exception.ObjectActionErrorMessageException;
 import com.liferay.object.exception.ObjectActionExecutorKeyException;
-import com.liferay.object.exception.ObjectActionLabelException;
 import com.liferay.object.exception.ObjectActionNameException;
 import com.liferay.object.exception.ObjectActionParametersException;
 import com.liferay.object.exception.ObjectActionSystemException;
@@ -64,6 +63,7 @@ import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -114,7 +114,6 @@ public class ObjectActionLocalServiceImpl
 			objectDefinitionId);
 
 		_validateErrorMessage(errorMessageMap, objectActionTriggerKey);
-		_validateLabel(labelMap);
 		_validateName(0, objectDefinitionId, name);
 		_validateObjectActionExecutorKey(
 			objectActionExecutorKey, objectDefinition);
@@ -145,7 +144,9 @@ public class ObjectActionLocalServiceImpl
 		objectAction.setDescription(description);
 		objectAction.setErrorMessageMap(
 			errorMessageMap, LocaleUtil.getSiteDefault());
-		objectAction.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
+		objectAction.setLabelMap(
+			_fillLabelMap(labelMap, name, objectDefinition.getDefaultLocale()),
+			objectDefinition.getDefaultLocale());
 		objectAction.setName(name);
 		objectAction.setObjectActionExecutorKey(objectActionExecutorKey);
 		objectAction.setObjectActionTriggerKey(objectActionTriggerKey);
@@ -340,12 +341,18 @@ public class ObjectActionLocalServiceImpl
 		ObjectAction objectAction = objectActionPersistence.findByPrimaryKey(
 			objectActionId);
 
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(
+				objectAction.getObjectDefinitionId());
+
 		if (objectAction.isSystem() &&
 			!ObjectDefinitionUtil.isInvokerBundleAllowed()) {
 
-			_validateLabel(labelMap);
-
-			objectAction.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
+			objectAction.setLabelMap(
+				_fillLabelMap(
+					labelMap, objectAction.getName(),
+					objectDefinition.getDefaultLocale()),
+				objectDefinition.getDefaultLocale());
 
 			return objectActionPersistence.update(objectAction);
 		}
@@ -354,14 +361,9 @@ public class ObjectActionLocalServiceImpl
 			externalReferenceCode, objectAction.getObjectActionId(),
 			objectAction.getCompanyId(), objectAction.getObjectDefinitionId());
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(
-				objectAction.getObjectDefinitionId());
-
 		_validateActive(active, objectAction, objectDefinition);
 
 		_validateErrorMessage(errorMessageMap, objectActionTriggerKey);
-		_validateLabel(labelMap);
 
 		_validateObjectActionExecutorKey(
 			objectActionExecutorKey, objectDefinition);
@@ -380,7 +382,15 @@ public class ObjectActionLocalServiceImpl
 		objectAction.setDescription(description);
 		objectAction.setErrorMessageMap(
 			errorMessageMap, LocaleUtil.getSiteDefault());
-		objectAction.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
+
+		if (objectDefinition.isApproved()) {
+			objectAction.setLabelMap(
+				_fillLabelMap(
+					labelMap, objectAction.getName(),
+					objectDefinition.getDefaultLocale()),
+				objectDefinition.getDefaultLocale());
+		}
+
 		objectAction.setObjectActionExecutorKey(objectActionExecutorKey);
 		objectAction.setParameters(parametersUnicodeProperties.toString());
 		objectAction.setStatus(ObjectActionConstants.STATUS_NEVER_RAN);
@@ -394,6 +404,9 @@ public class ObjectActionLocalServiceImpl
 		_validateObjectActionTriggerKey(
 			conditionExpression, objectActionTriggerKey, objectDefinition);
 
+		objectAction.setLabelMap(
+			_fillLabelMap(labelMap, name, objectDefinition.getDefaultLocale()),
+			objectDefinition.getDefaultLocale());
 		objectAction.setName(name);
 		objectAction.setObjectActionTriggerKey(objectActionTriggerKey);
 
@@ -433,6 +446,32 @@ public class ObjectActionLocalServiceImpl
 			LockManagerUtil.unlock(
 				ObjectAction.class.getName(), objectActionId);
 		}
+	}
+
+	private Map<Locale, String> _fillLabelMap(
+		Map<Locale, String> labelMap, String name, Locale locale) {
+
+		if ((labelMap == null) || labelMap.isEmpty()) {
+			return HashMapBuilder.put(
+				locale, name
+			).build();
+		}
+
+		if (Validator.isNotNull(labelMap.get(locale))) {
+			return labelMap;
+		}
+
+		if (labelMap.size() == 1) {
+			for (Map.Entry<Locale, String> entry : labelMap.entrySet()) {
+				labelMap.put(locale, entry.getValue());
+			}
+
+			return labelMap;
+		}
+
+		labelMap.put(locale, name);
+
+		return labelMap;
 	}
 
 	private boolean _isUsePreferredLanguageForGuestsSupported(
@@ -535,17 +574,6 @@ public class ObjectActionLocalServiceImpl
 		}
 
 		throw new ObjectActionSystemException(message);
-	}
-
-	private void _validateLabel(Map<Locale, String> labelMap)
-		throws PortalException {
-
-		Locale locale = LocaleUtil.getSiteDefault();
-
-		if ((labelMap == null) || Validator.isNull(labelMap.get(locale))) {
-			throw new ObjectActionLabelException(
-				"Label is null for locale " + locale.getDisplayName());
-		}
 	}
 
 	private void _validateName(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -2158,7 +2158,8 @@ public class ObjectDefinitionLocalServiceImpl
 		objectDefinition.setEnableComments(enableComments);
 		objectDefinition.setEnableObjectEntryDraft(enableObjectEntryDraft);
 		objectDefinition.setEnableObjectEntryHistory(enableObjectEntryHistory);
-		objectDefinition.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
+		objectDefinition.setLabelMap(
+			labelMap, objectDefinition.getDefaultLocale());
 		objectDefinition.setPanelAppOrder(panelAppOrder);
 		objectDefinition.setPanelCategoryKey(panelCategoryKey);
 		objectDefinition.setPluralLabelMap(pluralLabelMap);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -46,7 +46,6 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.exception.ObjectActionErrorMessageException;
 import com.liferay.object.exception.ObjectActionExecutorKeyException;
-import com.liferay.object.exception.ObjectActionLabelException;
 import com.liferay.object.exception.ObjectActionNameException;
 import com.liferay.object.exception.ObjectActionParametersException;
 import com.liferay.object.exception.ObjectActionSystemException;
@@ -395,13 +394,6 @@ public class ObjectActionLocalServiceTest {
 					false));
 		}
 
-		AssertUtils.assertFailure(
-			ObjectActionLabelException.class,
-			"Label is null for locale " + LocaleUtil.US.getDisplayName(),
-			() -> _addObjectAction(
-				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, RandomTestUtil.randomString(),
-				ObjectActionTriggerConstants.KEY_ON_AFTER_ADD, false));
 		AssertUtils.assertFailure(
 			ObjectActionSystemException.class, false,
 			"Only allowed bundles can add system object actions",

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -2100,6 +2100,71 @@ public class ObjectActionLocalServiceTest {
 	}
 
 	@Test
+	public void testFillLabelMap() throws Exception {
+
+		// label map as null
+
+		ObjectAction objectAction1 = _addObjectAction(
+			StringPool.BLANK, null, RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_GROOVY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE,
+			new UnicodeProperties(), false);
+
+		Assert.assertEquals(
+			Collections.singletonMap(
+				_objectDefinition.getDefaultLocale(), objectAction1.getName()),
+			objectAction1.getLabelMap());
+
+		// label map with many values without default locale value
+
+		ObjectAction objectAction2 = _addObjectAction(
+			StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.BRAZIL, "pt_BR objectAction2Label"
+			).put(
+				LocaleUtil.SPAIN, "es_ES objectAction2Label"
+			).build(),
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_GROOVY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE,
+			new UnicodeProperties(), false);
+
+		Assert.assertEquals(
+			HashMapBuilder.put(
+				_objectDefinition.getDefaultLocale(), objectAction2.getName()
+			).put(
+				LocaleUtil.BRAZIL, "pt_BR objectAction2Label"
+			).put(
+				LocaleUtil.SPAIN, "es_ES objectAction2Label"
+			).build(),
+			objectAction2.getLabelMap());
+
+		// label map with one value without default locale value
+
+		ObjectAction objectAction3 = _addObjectAction(
+			StringPool.BLANK,
+			HashMapBuilder.put(
+				LocaleUtil.BRAZIL, "pt_BR objectAction3Label"
+			).build(),
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_GROOVY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE,
+			new UnicodeProperties(), false);
+
+		Assert.assertEquals(
+			HashMapBuilder.put(
+				_objectDefinition.getDefaultLocale(), "pt_BR objectAction3Label"
+			).put(
+				LocaleUtil.BRAZIL, "pt_BR objectAction3Label"
+			).build(),
+			objectAction3.getLabelMap());
+
+		_objectActionLocalService.deleteObjectAction(objectAction1);
+		_objectActionLocalService.deleteObjectAction(objectAction2);
+		_objectActionLocalService.deleteObjectAction(objectAction3);
+	}
+
+	@Test
 	@TestInfo("LPS-189995")
 	public void testOnAfterUpdateObjectActionWithAttachmentObjectField()
 		throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -1063,7 +1063,9 @@ public class ObjectActionLocalServiceTest {
 		_publishCustomObjectDefinition();
 
 		ObjectAction objectAction1 = _addObjectAction(
-			"equals(firstName, \"João\")", RandomTestUtil.randomString(),
+			"equals(firstName, \"João\")",
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
 			ObjectActionExecutorConstants.KEY_GROOVY,
 			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE,
 			UnicodePropertiesBuilder.put(
@@ -1102,7 +1104,9 @@ public class ObjectActionLocalServiceTest {
 		_objectActionLocalService.deleteObjectAction(objectAction1);
 
 		ObjectAction objectAction2 = _addObjectAction(
-			"currentUserId == creator", RandomTestUtil.randomString(),
+			"currentUserId == creator",
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
 			ObjectActionExecutorConstants.KEY_UPDATE_OBJECT_ENTRY,
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
 			UnicodePropertiesBuilder.put(
@@ -1121,7 +1125,9 @@ public class ObjectActionLocalServiceTest {
 			).build(),
 			false);
 		ObjectAction objectAction3 = _addObjectAction(
-			"currentUserId != creator", RandomTestUtil.randomString(),
+			"currentUserId != creator",
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
 			ObjectActionExecutorConstants.KEY_UPDATE_OBJECT_ENTRY,
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
 			UnicodePropertiesBuilder.put(
@@ -1167,6 +1173,7 @@ public class ObjectActionLocalServiceTest {
 
 		ObjectAction objectAction4 = _addObjectAction(
 			"oldValue(\"firstName\") == \"Paulo\"",
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 			RandomTestUtil.randomString(),
 			ObjectActionExecutorConstants.KEY_ADD_OBJECT_ENTRY,
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
@@ -2187,7 +2194,9 @@ public class ObjectActionLocalServiceTest {
 		_publishCustomObjectDefinition();
 
 		ObjectAction objectAction1 = _addObjectAction(
-			null, RandomTestUtil.randomString(),
+			null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
 			ObjectActionExecutorConstants.KEY_UPDATE_OBJECT_ENTRY,
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
 			UnicodePropertiesBuilder.put(
@@ -2206,7 +2215,9 @@ public class ObjectActionLocalServiceTest {
 			).build(),
 			false);
 		ObjectAction objectAction2 = _addObjectAction(
-			null, RandomTestUtil.randomString(),
+			null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
 			ObjectActionExecutorConstants.KEY_UPDATE_OBJECT_ENTRY,
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE,
 			UnicodePropertiesBuilder.put(
@@ -2514,6 +2525,22 @@ public class ObjectActionLocalServiceTest {
 			objectActionTriggerKey, parametersUnicodeProperties, false);
 	}
 
+	private ObjectAction _addObjectAction(
+			String conditionExpression, Map<Locale, String> labelMap,
+			String name, String objectActionExecutorKey,
+			String objectActionTriggerKey, UnicodeProperties unicodeProperties,
+			boolean system)
+		throws Exception {
+
+		return _objectActionLocalService.addObjectAction(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), true,
+			conditionExpression, RandomTestUtil.randomString(),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			labelMap, name, objectActionExecutorKey, objectActionTriggerKey,
+			unicodeProperties, system);
+	}
+
 	private void _addObjectAction(
 			String errorMessage, String externalReferenceCode, String label,
 			String name, String objectActionTriggerKey, boolean system)
@@ -2530,30 +2557,16 @@ public class ObjectActionLocalServiceTest {
 	}
 
 	private ObjectAction _addObjectAction(
-			String conditionExpression, String name,
-			String objectActionExecutorKey, String objectActionTriggerKey,
-			UnicodeProperties unicodeProperties, boolean system)
-		throws Exception {
-
-		return _objectActionLocalService.addObjectAction(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			_objectDefinition.getObjectDefinitionId(), true,
-			conditionExpression, RandomTestUtil.randomString(),
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			name, objectActionExecutorKey, objectActionTriggerKey,
-			unicodeProperties, system);
-	}
-
-	private ObjectAction _addObjectAction(
 			String name, String objectActionExecutorKey,
 			String objectActionTriggerKey, UnicodeProperties unicodeProperties,
 			boolean system)
 		throws Exception {
 
 		return _addObjectAction(
-			StringPool.BLANK, name, objectActionExecutorKey,
-			objectActionTriggerKey, unicodeProperties, system);
+			StringPool.BLANK,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			name, objectActionExecutorKey, objectActionTriggerKey,
+			unicodeProperties, system);
 	}
 
 	private void _assertGroovyObjectActionExecutorArguments(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -94,6 +94,7 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -2339,23 +2340,50 @@ public class ObjectDefinitionLocalServiceTest {
 				true
 			).build());
 
-		objectDefinition =
-			_objectDefinitionLocalService.updateCustomObjectDefinition(
-				null, objectDefinition.getObjectDefinitionId(), 0,
-				objectField.getObjectFieldId(), 0,
-				objectField.getObjectFieldId(), false,
-				objectDefinition.isActive(), objectDefinition.getClassName(),
-				true, false, true, false, false, false,
-				LocalizedMapUtil.getLocalizedMap("Able"), "Able", null, null,
-				false, LocalizedMapUtil.getLocalizedMap("Ables"),
-				objectDefinition.getScope(), objectDefinition.getStatus());
+		Locale locale = LocaleUtil.getDefault();
 
-		Assert.assertEquals(
-			objectField.getObjectFieldId(),
-			objectDefinition.getDescriptionObjectFieldId());
-		Assert.assertEquals(
-			objectField.getObjectFieldId(),
-			objectDefinition.getTitleObjectFieldId());
+		try {
+			LocaleUtil.setDefault(
+				LocaleUtil.BRAZIL.getLanguage(), LocaleUtil.BRAZIL.getCountry(),
+				LocaleUtil.BRAZIL.getVariant());
+
+			String defaultLanguageId = objectDefinition.getDefaultLanguageId();
+
+			objectDefinition =
+				_objectDefinitionLocalService.updateCustomObjectDefinition(
+					null, objectDefinition.getObjectDefinitionId(), 0,
+					objectField.getObjectFieldId(), 0,
+					objectField.getObjectFieldId(), false,
+					objectDefinition.isActive(),
+					objectDefinition.getClassName(), true, false, true, false,
+					false, false,
+					HashMapBuilder.put(
+						locale, RandomTestUtil.randomString()
+					).put(
+						LocaleUtil.BRAZIL, RandomTestUtil.randomString()
+					).build(),
+					"Able", null, null, false,
+					HashMapBuilder.put(
+						locale, RandomTestUtil.randomString()
+					).put(
+						LocaleUtil.BRAZIL, RandomTestUtil.randomString()
+					).build(),
+					objectDefinition.getScope(), objectDefinition.getStatus());
+
+			Assert.assertEquals(
+				defaultLanguageId, objectDefinition.getDefaultLanguageId());
+
+			Assert.assertEquals(
+				objectField.getObjectFieldId(),
+				objectDefinition.getDescriptionObjectFieldId());
+			Assert.assertEquals(
+				objectField.getObjectFieldId(),
+				objectDefinition.getTitleObjectFieldId());
+		}
+		finally {
+			LocaleUtil.setDefault(
+				locale.getLanguage(), locale.getCountry(), locale.getVariant());
+		}
 
 		String externalReferenceCode = RandomTestUtil.randomString();
 


### PR DESCRIPTION
[LPD-42393](https://liferay.atlassian.net/browse/LPD-42393)

This change refines locale label validation by making it smarter and avoiding explicit validation steps. The base default language will now always align with the default language ID of the object definition, which will be immutable going forward.

[LPD-42393]: https://liferay.atlassian.net/browse/LPD-42393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ