### PR TITLE
LPD-37516 Prevent more than one ThemeCSSCET from being applied at the instance level at the same time

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -62,8 +62,18 @@ public class ClientExtensionsServicePreAction extends Action {
 
 		themeDisplay.setFaviconURL(_getFaviconURL(layout));
 
-		_setThemeDisplayCSSURLs(
-			httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
+		ThemeCSSCET themeCSSCET = _getThemeCSSCET(layout);
+
+		if (themeCSSCET != null) {
+			if (_portal.isRightToLeft(httpServletRequest)) {
+				themeDisplay.setClayCSSURL(themeCSSCET.getClayRTLURL());
+				themeDisplay.setMainCSSURL(themeCSSCET.getMainRTLURL());
+			}
+			else {
+				themeDisplay.setClayCSSURL(themeCSSCET.getClayURL());
+				themeDisplay.setMainCSSURL(themeCSSCET.getMainURL());
+			}
+		}
 
 		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(layout);
 
@@ -276,22 +286,6 @@ public class ClientExtensionsServicePreAction extends Action {
 		}
 
 		return null;
-	}
-
-	private void _setThemeDisplayCSSURLs(
-		HttpServletRequest httpServletRequest, ThemeCSSCET themeCSSCET,
-		ThemeDisplay themeDisplay) {
-
-		if (themeCSSCET != null) {
-			if (_portal.isRightToLeft(httpServletRequest)) {
-				themeDisplay.setClayCSSURL(themeCSSCET.getClayRTLURL());
-				themeDisplay.setMainCSSURL(themeCSSCET.getMainRTLURL());
-			}
-			else {
-				themeDisplay.setClayCSSURL(themeCSSCET.getClayURL());
-				themeDisplay.setMainCSSURL(themeCSSCET.getMainURL());
-			}
-		}
 	}
 
 	@Reference

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -89,7 +89,7 @@ public class ClientExtensionsServicePreAction extends Action {
 				httpServletRequest, "p_l_mode", Constants.VIEW);
 
 			if (!Objects.equals(mode, Constants.PREVIEW)) {
-				return;
+				return layout;
 			}
 
 			long selPlid = ParamUtil.getLong(
@@ -100,11 +100,13 @@ public class ClientExtensionsServicePreAction extends Action {
 					"_selPlid"));
 
 			if (selPlid <= 0) {
-				return;
+				return layout;
 			}
 
 			layout = _layoutLocalService.fetchLayout(selPlid);
 		}
+
+		return layout;
 	}
 
 	private CET _getCET(

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -72,38 +72,6 @@ public class ClientExtensionsServicePreAction extends Action {
 		}
 	}
 
-	private Layout _getLayout(HttpServletRequest httpServletRequest) {
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		Layout layout = themeDisplay.getLayout();
-
-		if (layout.isTypeControlPanel()) {
-			String mode = ParamUtil.getString(
-				httpServletRequest, "p_l_mode", Constants.VIEW);
-
-			if (!Objects.equals(mode, Constants.PREVIEW)) {
-				return layout;
-			}
-
-			long selPlid = ParamUtil.getLong(
-				httpServletRequest,
-				StringBundler.concat(
-					StringPool.UNDERLINE,
-					ParamUtil.getString(httpServletRequest, "p_p_id"),
-					"_selPlid"));
-
-			if (selPlid <= 0) {
-				return layout;
-			}
-
-			layout = _layoutLocalService.fetchLayout(selPlid);
-		}
-
-		return layout;
-	}
-
 	private CET _getCET(
 		long classNameId, long classPK, long companyId, String type) {
 
@@ -200,6 +168,38 @@ public class ClientExtensionsServicePreAction extends Action {
 		}
 
 		return null;
+	}
+
+	private Layout _getLayout(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isTypeControlPanel()) {
+			String mode = ParamUtil.getString(
+				httpServletRequest, "p_l_mode", Constants.VIEW);
+
+			if (!Objects.equals(mode, Constants.PREVIEW)) {
+				return layout;
+			}
+
+			long selPlid = ParamUtil.getLong(
+				httpServletRequest,
+				StringBundler.concat(
+					StringPool.UNDERLINE,
+					ParamUtil.getString(httpServletRequest, "p_p_id"),
+					"_selPlid"));
+
+			if (selPlid <= 0) {
+				return layout;
+			}
+
+			layout = _layoutLocalService.fetchLayout(selPlid);
+		}
+
+		return layout;
 	}
 
 	private ThemeCSSCET _getThemeCSSCET(Layout layout) {

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -50,6 +50,31 @@ public class ClientExtensionsServicePreAction extends Action {
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
+		Layout layout = _getLayout(httpServletRequest);
+
+		if (layout == null) {
+			return;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		themeDisplay.setFaviconURL(_getFaviconURL(layout));
+
+		if (!layout.isTypeControlPanel()) {
+			_setThemeDisplayCSSURLs(
+				httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
+		}
+
+		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(layout);
+
+		if (themeSpritemapCET != null) {
+			themeDisplay.setPathThemeSpritemap(themeSpritemapCET.getURL());
+		}
+	}
+
+	private Layout _getLayout(HttpServletRequest httpServletRequest) {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -79,23 +104,6 @@ public class ClientExtensionsServicePreAction extends Action {
 			}
 
 			layout = _layoutLocalService.fetchLayout(selPlid);
-		}
-
-		if (layout == null) {
-			return;
-		}
-
-		themeDisplay.setFaviconURL(_getFaviconURL(layout));
-
-		if (!layout.isTypeControlPanel()) {
-			_setThemeDisplayCSSURLs(
-				httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
-		}
-
-		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(layout);
-
-		if (themeSpritemapCET != null) {
-			themeDisplay.setPathThemeSpritemap(themeSpritemapCET.getURL());
 		}
 	}
 

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -50,15 +50,15 @@ public class ClientExtensionsServicePreAction extends Action {
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
-		Layout layout = _getLayout(httpServletRequest);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Layout layout = _getLayout(httpServletRequest, themeDisplay);
 
 		if (layout == null) {
 			return;
 		}
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
 
 		themeDisplay.setFaviconURL(_getFaviconURL(layout));
 
@@ -170,10 +170,8 @@ public class ClientExtensionsServicePreAction extends Action {
 		return null;
 	}
 
-	private Layout _getLayout(HttpServletRequest httpServletRequest) {
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
+	private Layout _getLayout(
+		HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay) {
 
 		Layout layout = themeDisplay.getLayout();
 

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -17,6 +17,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.events.Action;
 import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -27,6 +28,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
+import java.util.List;
 import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,6 +57,9 @@ public class ClientExtensionsServicePreAction extends Action {
 		Layout layout = themeDisplay.getLayout();
 
 		if (layout.isTypeControlPanel()) {
+			_setThemeDisplayCSSURLs(
+				httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
+
 			String mode = ParamUtil.getString(
 				httpServletRequest, "p_l_mode", Constants.VIEW);
 
@@ -82,17 +87,9 @@ public class ClientExtensionsServicePreAction extends Action {
 
 		themeDisplay.setFaviconURL(_getFaviconURL(layout));
 
-		ThemeCSSCET themeCSSCET = _getThemeCSSCET(layout);
-
-		if (themeCSSCET != null) {
-			if (_portal.isRightToLeft(httpServletRequest)) {
-				themeDisplay.setClayCSSURL(themeCSSCET.getClayRTLURL());
-				themeDisplay.setMainCSSURL(themeCSSCET.getMainRTLURL());
-			}
-			else {
-				themeDisplay.setClayCSSURL(themeCSSCET.getClayURL());
-				themeDisplay.setMainCSSURL(themeCSSCET.getMainURL());
-			}
+		if (!layout.isTypeControlPanel()) {
+			_setThemeDisplayCSSURLs(
+				httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
 		}
 
 		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(layout);
@@ -115,6 +112,32 @@ public class ClientExtensionsServicePreAction extends Action {
 
 		return _cetManager.getCET(
 			companyId, clientExtensionEntryRel.getCETExternalReferenceCode());
+	}
+
+	private ThemeCSSCET _getControlPanelThemeCSSCET(Layout layout) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				layout.getCompanyId(), "LPD-34650")) {
+
+			return null;
+		}
+
+		List<ClientExtensionEntryRel> clientExtensionEntryRels =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				_portal.getClassNameId(Layout.class), layout.getPlid(),
+				ClientExtensionEntryConstants.TYPE_THEME_CSS);
+
+		if ((clientExtensionEntryRels == null) ||
+			(clientExtensionEntryRels.size() != 1)) {
+
+			return null;
+		}
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			clientExtensionEntryRels.get(0);
+
+		return (ThemeCSSCET)_cetManager.getCET(
+			layout.getCompanyId(),
+			clientExtensionEntryRel.getCETExternalReferenceCode());
 	}
 
 	private String _getFaviconURL(Layout layout) {
@@ -175,6 +198,10 @@ public class ClientExtensionsServicePreAction extends Action {
 	}
 
 	private ThemeCSSCET _getThemeCSSCET(Layout layout) {
+		if (layout.isTypeControlPanel()) {
+			return _getControlPanelThemeCSSCET(layout);
+		}
+
 		CET cet = _getCET(
 			_portal.getClassNameId(Layout.class), layout.getPlid(),
 			layout.getCompanyId(),
@@ -246,6 +273,22 @@ public class ClientExtensionsServicePreAction extends Action {
 		}
 
 		return null;
+	}
+
+	private void _setThemeDisplayCSSURLs(
+		HttpServletRequest httpServletRequest, ThemeCSSCET themeCSSCET,
+		ThemeDisplay themeDisplay) {
+
+		if (themeCSSCET != null) {
+			if (_portal.isRightToLeft(httpServletRequest)) {
+				themeDisplay.setClayCSSURL(themeCSSCET.getClayRTLURL());
+				themeDisplay.setMainCSSURL(themeCSSCET.getMainRTLURL());
+			}
+			else {
+				themeDisplay.setClayCSSURL(themeCSSCET.getClayURL());
+				themeDisplay.setMainCSSURL(themeCSSCET.getMainURL());
+			}
+		}
 	}
 
 	@Reference

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -62,10 +62,8 @@ public class ClientExtensionsServicePreAction extends Action {
 
 		themeDisplay.setFaviconURL(_getFaviconURL(layout));
 
-		if (!layout.isTypeControlPanel()) {
-			_setThemeDisplayCSSURLs(
-				httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
-		}
+		_setThemeDisplayCSSURLs(
+			httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
 
 		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(layout);
 
@@ -82,9 +80,6 @@ public class ClientExtensionsServicePreAction extends Action {
 		Layout layout = themeDisplay.getLayout();
 
 		if (layout.isTypeControlPanel()) {
-			_setThemeDisplayCSSURLs(
-				httpServletRequest, _getThemeCSSCET(layout), themeDisplay);
-
 			String mode = ParamUtil.getString(
 				httpServletRequest, "p_l_mode", Constants.VIEW);
 

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
@@ -6,6 +6,9 @@
 package com.liferay.client.extension.type.internal.configuration.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.feature.flag.test.util.FeatureFlagTestHelper;
@@ -14,18 +17,34 @@ import com.liferay.osgi.util.service.OSGiServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SystemProperties;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.TimeoutException;
@@ -107,6 +126,109 @@ public class CETConfigurationFactoryTest {
 
 			SystemProperties.set("liferay.mode", liferayMode);
 		}
+	}
+
+	@Test
+	public void testControlPanelThemeCSSCET() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		String pid1 = ConfigurationTestUtil.createFactoryConfiguration(
+			_PID, _getThemeCSSConfigurationProperties(company.getCompanyId()));
+
+		String pid2 = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.client.extension.type.internal.configuration." +
+					"CETConfigurationFactory",
+				LoggerTestUtil.ERROR)) {
+
+			Layout layout = _getControlPanelLayout(company.getCompanyId());
+
+			List<ClientExtensionEntryRel> clientExtensionEntryRels =
+				_clientExtensionEntryRelLocalService.
+					getClientExtensionEntryRels(
+						_portal.getClassNameId(Layout.class), layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_THEME_CSS);
+
+			Assert.assertEquals(
+				clientExtensionEntryRels.toString(), 1,
+				clientExtensionEntryRels.size());
+
+			pid2 = ConfigurationTestUtil.createFactoryConfiguration(
+				_PID,
+				_getThemeCSSConfigurationProperties(company.getCompanyId()));
+
+			clientExtensionEntryRels =
+				_clientExtensionEntryRelLocalService.
+					getClientExtensionEntryRels(
+						_portal.getClassNameId(Layout.class), layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_THEME_CSS);
+
+			Assert.assertEquals(
+				clientExtensionEntryRels.toString(), 2,
+				clientExtensionEntryRels.size());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Only one theme CSS client extension can be applied at a " +
+					"time. To avoid conflicts, none of them will be applied.",
+				logEntry.getMessage());
+		}
+		finally {
+			ConfigurationTestUtil.deleteConfiguration(pid1);
+			ConfigurationTestUtil.deleteConfiguration(pid2);
+		}
+	}
+
+	private Layout _getControlPanelLayout(long companyId)
+		throws PortalException {
+
+		Group group = _groupLocalService.fetchGroup(
+			companyId, GroupConstants.CONTROL_PANEL);
+
+		List<Layout> layouts = _layoutLocalService.getLayouts(
+			group.getGroupId(), true);
+
+		if (ListUtil.isEmpty(layouts)) {
+			throw new NoSuchLayoutException(
+				"Unable to get control panel layout");
+		}
+
+		return layouts.get(0);
+	}
+
+	private HashMapDictionary<String, Object>
+			_getThemeCSSConfigurationProperties(long companyId)
+		throws Exception {
+
+		String name = RandomTestUtil.randomString();
+
+		return HashMapDictionaryBuilder.<String, Object>put(
+			"baseURL", "${portalURL}/o/" + name
+		).put(
+			"companyId", companyId
+		).put(
+			"name", name
+		).put(
+			"projectId", name
+		).put(
+			"projectName", name
+		).put(
+			"service.pid", _PID + "~" + name
+		).put(
+			"type", ClientExtensionEntryConstants.TYPE_THEME_CSS
+		).put(
+			"typeSettings", Collections.singletonList("scope=controlPanel")
+		).put(
+			"userId", TestPropsValues.getUserId()
+		).put(
+			"webContextPath", "/" + name
+		).build();
 	}
 
 	private void _testActivate() throws Exception {
@@ -199,6 +321,9 @@ public class CETConfigurationFactoryTest {
 		}
 	}
 
+	private static final String _PID =
+		"com.liferay.client.extension.type.configuration.CETConfiguration";
+
 	private static final String _VIRTUAL_HOSTNAME =
 		RandomTestUtil.randomString() + ".localtest.me";
 
@@ -211,5 +336,18 @@ public class CETConfigurationFactoryTest {
 
 	@Inject
 	private CETManager _cetManager;
+
+	@Inject
+	private ClientExtensionEntryRelLocalService
+		_clientExtensionEntryRelLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private Portal _portal;
 
 }

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -5,15 +5,36 @@
 
 package com.liferay.client.extension.type.internal.configuration;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.client.extension.type.configuration.CETConfiguration;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -46,6 +67,13 @@ public class CETConfigurationFactory {
 				_cet = _cetManager.addCET(
 					cetConfiguration, companyId,
 					_getExternalReferenceCode(properties));
+
+				if (Objects.equals(
+						_cet.getType(),
+						ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+
+					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
+				}
 			});
 	}
 
@@ -53,7 +81,13 @@ public class CETConfigurationFactory {
 	protected void deactivate() {
 		ConfigurationFactoryUtil.executeAsCompany(
 			_companyLocalService, _properties,
-			companyId -> _cetManager.deleteCET(_cet));
+			companyId -> {
+				_cetManager.deleteCET(_cet);
+
+				_clientExtensionEntryRelLocalService.
+					deleteClientExtensionEntryRels(
+						companyId, _cet.getExternalReferenceCode());
+			});
 
 		_properties = null;
 	}
@@ -74,7 +108,78 @@ public class CETConfigurationFactory {
 				_cet = _cetManager.addCET(
 					cetConfiguration, companyId,
 					_getExternalReferenceCode(properties));
+
+				if (Objects.equals(
+						_cet.getType(),
+						ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+
+					_clientExtensionEntryRelLocalService.
+						deleteClientExtensionEntryRels(
+							companyId, _cet.getExternalReferenceCode());
+
+					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
+				}
 			});
+	}
+
+	private void _addControlPanelThemeCSSClientExtensionEntryRel(Long companyId)
+		throws PortalException {
+
+		ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
+
+		if (!Objects.equals(themeCSSCET.getScope(), "controlPanel")) {
+			return;
+		}
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			_clientExtensionEntryRelLocalService.
+				fetchClientExtensionEntryRelByExternalReferenceCode(
+					themeCSSCET.getExternalReferenceCode(), companyId);
+
+		if (clientExtensionEntryRel != null) {
+			return;
+		}
+
+		Company company = _companyLocalService.getCompany(companyId);
+
+		User guestUser = company.getGuestUser();
+
+		Layout layout = _getControlPanelLayout(companyId);
+
+		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+			guestUser.getUserId(), layout.getGroupId(),
+			_portal.getClassNameId(Layout.class), layout.getPlid(),
+			_cet.getExternalReferenceCode(), _cet.getType(), StringPool.BLANK,
+			new ServiceContext());
+
+		int clientExtensionEntryRelsCount =
+			_clientExtensionEntryRelLocalService.
+				getClientExtensionEntryRelsCount(
+					_portal.getClassNameId(Layout.class), layout.getPlid(),
+					ClientExtensionEntryConstants.TYPE_THEME_CSS);
+
+		if (clientExtensionEntryRelsCount > 1) {
+			_log.error(
+				"Only one theme CSS client extension can be applied at a " +
+					"time. To avoid conflicts, none of them will be applied.");
+		}
+	}
+
+	private Layout _getControlPanelLayout(long companyId)
+		throws PortalException {
+
+		Group group = _groupLocalService.fetchGroup(
+			companyId, GroupConstants.CONTROL_PANEL);
+
+		List<Layout> layouts = _layoutLocalService.getLayouts(
+			group.getGroupId(), true);
+
+		if (ListUtil.isEmpty(layouts)) {
+			throw new NoSuchLayoutException(
+				"Unable to get control panel layout");
+		}
+
+		return layouts.get(0);
 	}
 
 	private String _getExternalReferenceCode(Map<String, Object> properties) {
@@ -82,16 +187,32 @@ public class CETConfigurationFactory {
 			ConfigurationFactoryUtil.getExternalReferenceCode(properties);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		CETConfigurationFactory.class);
+
 	private volatile CET _cet;
 
 	@Reference
 	private CETManager _cetManager;
 
 	@Reference
+	private ClientExtensionEntryRelLocalService
+		_clientExtensionEntryRelLocalService;
+
+	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
+	@Reference
+	private Portal _portal;
 
 	private volatile Map<String, Object> _properties;
 

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -8,6 +8,7 @@ package com.liferay.client.extension.type.item.selector.web.internal.item.select
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.GlobalJSCET;
+import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.client.extension.type.item.selector.CETItemSelectorReturnType;
 import com.liferay.client.extension.type.item.selector.criterion.CETItemSelectorCriterion;
 import com.liferay.client.extension.type.manager.CETManager;
@@ -18,13 +19,14 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -79,24 +81,7 @@ public class CETItemSelectorViewDescriptor
 			_cetItemSelectorCriterion.getType(),
 			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
 
-		if (Objects.equals(
-				_cetItemSelectorCriterion.getType(),
-				ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
-
-			List<CET> filteredCETs = new ArrayList<>();
-
-			for (CET cet : cets) {
-				GlobalJSCET globalJSCET = (GlobalJSCET)cet;
-
-				if (!StringUtil.equalsIgnoreCase(
-						globalJSCET.getScope(), "company")) {
-
-					filteredCETs.add(cet);
-				}
-			}
-
-			cets = filteredCETs;
-		}
+		cets = _filterCETs(cets, _cetItemSelectorCriterion.getType());
 
 		searchContainer.setResultsAndTotal(cets);
 
@@ -111,6 +96,41 @@ public class CETItemSelectorViewDescriptor
 	@Override
 	public boolean isShowBreadcrumb() {
 		return false;
+	}
+
+	private List<CET> _filterCETs(List<CET> cets, String type) {
+		Predicate<CET> filterPredicate = _getFilterPredicate(type);
+
+		if (filterPredicate == null) {
+			return cets;
+		}
+
+		return ListUtil.filter(cets, filterPredicate);
+	}
+
+	private Predicate<CET> _getFilterPredicate(String type) {
+		if (Objects.equals(
+				type, ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
+
+			return cet -> {
+				GlobalJSCET globalJSCET = (GlobalJSCET)cet;
+
+				return !StringUtil.equalsIgnoreCase(
+					globalJSCET.getScope(), "company");
+			};
+		}
+		else if (Objects.equals(
+					type, ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+
+			return cet -> {
+				ThemeCSSCET themeCSSCET = (ThemeCSSCET)cet;
+
+				return !StringUtil.equalsIgnoreCase(
+					themeCSSCET.getScope(), "controlPanel");
+			};
+		}
+
+		return null;
 	}
 
 	private static final ItemSelectorReturnType

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -81,7 +81,12 @@ public class CETItemSelectorViewDescriptor
 			_cetItemSelectorCriterion.getType(),
 			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
 
-		cets = _filterCETs(cets, _cetItemSelectorCriterion.getType());
+		Predicate<CET> filterPredicate = _getFilterPredicate(
+			_cetItemSelectorCriterion.getType());
+
+		if (filterPredicate != null) {
+			cets = ListUtil.filter(cets, filterPredicate);
+		}
 
 		searchContainer.setResultsAndTotal(cets);
 
@@ -96,16 +101,6 @@ public class CETItemSelectorViewDescriptor
 	@Override
 	public boolean isShowBreadcrumb() {
 		return false;
-	}
-
-	private List<CET> _filterCETs(List<CET> cets, String type) {
-		Predicate<CET> filterPredicate = _getFilterPredicate(type);
-
-		if (filterPredicate == null) {
-			return cets;
-		}
-
-		return ListUtil.filter(cets, filterPredicate);
 	}
 
 	private Predicate<CET> _getFilterPredicate(String type) {


### PR DESCRIPTION
Sending here as part of the collaboration between BPM and Platform Experience regarding backend reviews.

--

https://liferay.atlassian.net/browse/LPD-37516

# Background

We are now able to apply ThemeCSS Client Extensions to control panel pages, similar to admin themes in OSGI.

# Goal

Inject the ThemeCSS CX urls into the `ThemeDisplay` (ClientExtensionsServicePreAction.java) and prevent more than one CX from being applied at the same time

cc: @ethib137 