### PR TITLE
LPD-43502 Remove max-width style from scheduler event popover

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -460,10 +460,6 @@
 	}
 }
 
-.col-md-4 .calendar-portlet .popover.scheduler-event-recorder-popover {
-	max-width: 232px;
-}
-
 .portal-popup .calendar-portlet .fieldset {
 	margin-bottom: 2em;
 }


### PR DESCRIPTION
Hello reviewer, please see these two tickets:

1. https://liferay.atlassian.net/browse/LPD-43502
2. https://liferay.atlassian.net/browse/LPS-127316

Also, see this comment: https://github.com/liferay-workflow/liferay-portal/pull/287#discussion_r598958299

I did the necessary tests and was unable to reproduce the problem of a page with two 70/30 columns after remove that code.