### PR TITLE
LPD-43403 Do not rely on kaleoDefinitionVersionId to retrieve the latest version of each workflow definition, rely on version column instead

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/model/impl/KaleoDefinitionVersionImpl.java
@@ -9,7 +9,6 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.cache.CacheField;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.workflow.kaleo.definition.util.WorkflowDefinitionContentUtil;
@@ -41,12 +40,8 @@ public class KaleoDefinitionVersionImpl extends KaleoDefinitionVersionBaseImpl {
 
 	@Override
 	public KaleoDefinition getKaleoDefinition() throws PortalException {
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setCompanyId(getCompanyId());
-
 		return KaleoDefinitionLocalServiceUtil.getKaleoDefinition(
-			getName(), serviceContext);
+			getKaleoDefinitionId());
 	}
 
 	@Override

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
@@ -6,16 +6,16 @@
 package com.liferay.portal.workflow.kaleo.service.impl;
 
 import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.Junction;
-import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.ProjectionList;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.workflow.exception.IncompleteWorkflowInstancesException;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersionTable;
 import com.liferay.portal.workflow.kaleo.service.KaleoConditionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoNodeLocalService;
@@ -360,62 +361,76 @@ public class KaleoDefinitionVersionLocalServiceImpl
 		return kaleoDefinitionVersionIds.size();
 	}
 
-	private void _addKeywordsCriterion(
-		DynamicQuery dynamicQuery, String keywords) {
-
-		if (Validator.isNull(keywords)) {
-			return;
-		}
-
-		Junction junction = RestrictionsFactoryUtil.disjunction();
-
-		for (String keyword : _customSQL.keywords(keywords)) {
-			junction.add(RestrictionsFactoryUtil.ilike("description", keyword));
-			junction.add(RestrictionsFactoryUtil.ilike("name", keyword));
-			junction.add(RestrictionsFactoryUtil.ilike("title", keyword));
-		}
-
-		dynamicQuery.add(junction);
-	}
-
-	private void _addStatusCriterion(DynamicQuery dynamicQuery, int status) {
-		if (status != WorkflowConstants.STATUS_ANY) {
-			Junction junction = RestrictionsFactoryUtil.disjunction();
-
-			junction.add(RestrictionsFactoryUtil.eq("status", status));
-
-			dynamicQuery.add(junction);
-		}
-	}
-
 	private List<Long> _getKaleoDefinitionVersionIds(
 		long companyId, String keywords, int status) {
 
+		KaleoDefinitionVersionTable aliasKaleoDefinitionVersionTable =
+			KaleoDefinitionVersionTable.INSTANCE.as(
+				"aliasKaleoDefinitionVersionTable");
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			aliasKaleoDefinitionVersionTable.kaleoDefinitionVersionId
+		).from(
+			aliasKaleoDefinitionVersionTable
+		).where(
+			aliasKaleoDefinitionVersionTable.companyId.eq(
+				companyId
+			).and(
+				() -> {
+					if (Validator.isNull(keywords)) {
+						return null;
+					}
+
+					Predicate predicate = null;
+
+					for (String keyword : _customSQL.keywords(keywords)) {
+						predicate =
+							aliasKaleoDefinitionVersionTable.description.like(
+								keyword
+							).or(
+								aliasKaleoDefinitionVersionTable.name.like(
+									keyword)
+							).or(
+								aliasKaleoDefinitionVersionTable.title.like(
+									keyword)
+							);
+					}
+
+					return predicate.withParentheses();
+				}
+			).and(
+				() -> {
+					if (status == WorkflowConstants.STATUS_ANY) {
+						return null;
+					}
+
+					return aliasKaleoDefinitionVersionTable.status.eq(status);
+				}
+			).and(
+				aliasKaleoDefinitionVersionTable.version.in(
+					DSLQueryFactoryUtil.select(
+						DSLFunctionFactoryUtil.max(
+							DSLFunctionFactoryUtil.castLong(
+								KaleoDefinitionVersionTable.INSTANCE.version)
+						).as(
+							"latestVersion"
+						)
+					).from(
+						KaleoDefinitionVersionTable.INSTANCE
+					).where(
+						KaleoDefinitionVersionTable.INSTANCE.name.eq(
+							aliasKaleoDefinitionVersionTable.name)
+					))
+			)
+		);
+
+		List<Object> entriesValues = kaleoDefinitionVersionPersistence.dslQuery(
+			dslQuery);
+
 		List<Long> kaleoDefinitionVersionIds = new ArrayList<>();
 
-		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
-			KaleoDefinitionVersion.class, getClassLoader());
-
-		Property companyIdProperty = PropertyFactoryUtil.forName("companyId");
-
-		dynamicQuery.add(companyIdProperty.eq(companyId));
-
-		_addKeywordsCriterion(dynamicQuery, keywords);
-
-		_addStatusCriterion(dynamicQuery, status);
-
-		ProjectionList projectionList = ProjectionFactoryUtil.projectionList();
-
-		projectionList.add(
-			ProjectionFactoryUtil.max("kaleoDefinitionVersionId"));
-		projectionList.add(ProjectionFactoryUtil.groupProperty("name"));
-
-		dynamicQuery.setProjection(projectionList);
-
-		List<Object[]> results = dynamicQuery(dynamicQuery);
-
-		for (Object[] result : results) {
-			kaleoDefinitionVersionIds.add((Long)result[0]);
+		for (Object result : entriesValues) {
+			kaleoDefinitionVersionIds.add((Long)result);
 		}
 
 		return kaleoDefinitionVersionIds;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionLocalServiceTest.java
@@ -62,42 +62,85 @@ public class KaleoDefinitionVersionLocalServiceTest
 
 	@Test
 	public void testGetLatestKaleoDefinitionVersions() throws Exception {
+		KaleoDefinition kaleoDefinition1 = addKaleoDefinition(
+			StringUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		KaleoDefinitionVersion kaleoDefinition1LatestKaleoDefinitionVersion =
+			kaleoDefinitionVersionLocalService.addKaleoDefinitionVersion(
+				kaleoDefinition1.getKaleoDefinitionId(),
+				"KaleoDefinitionVersionName1", kaleoDefinition1.getTitle(),
+				"KaleoDefinitionVersionDescription1",
+				kaleoDefinition1.getContent(), "2.0", serviceContext);
+
+		KaleoDefinition kaleoDefinition2 = addKaleoDefinition(
+			StringUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		KaleoDefinitionVersion kaleoDefinition2LatestKaleoDefinitionVersion =
+			kaleoDefinitionVersionLocalService.addKaleoDefinitionVersion(
+				kaleoDefinition2.getKaleoDefinitionId(),
+				"KaleoDefinitionVersionName2", "KaleoDefinitionVersionTitle2",
+				kaleoDefinition2.getDescription(),
+				kaleoDefinition2.getContent(), "2.0", serviceContext);
+
+		KaleoDefinition kaleoDefinition3 = addKaleoDefinition(
+			StringUtil.randomString(), StringUtil.randomString(),
+			StringUtil.randomString(), RandomTestUtil.randomString());
+
+		KaleoDefinitionVersion kaleoDefinition3LatestKaleoDefinitionVersion =
+			kaleoDefinitionVersionLocalService.addKaleoDefinitionVersion(
+				kaleoDefinition3.getKaleoDefinitionId(),
+				kaleoDefinition3.getName(), "KaleoDefinitionVersionTitle3",
+				"KaleoDefinitionVersionDescription3",
+				kaleoDefinition3.getContent(), "3.0", serviceContext);
+
+		KaleoDefinitionVersion kaleoDefinition3SecondKaleoDefinitionVersion =
+			kaleoDefinitionVersionLocalService.addKaleoDefinitionVersion(
+				kaleoDefinition3.getKaleoDefinitionId(),
+				kaleoDefinition3.getName(), kaleoDefinition3.getTitle(),
+				kaleoDefinition3.getDescription(),
+				kaleoDefinition3.getContent(), "2.0", serviceContext);
+
+		long kaleoDefinition3SecondKaleoDefinitionVersionId =
+			kaleoDefinition3SecondKaleoDefinitionVersion.
+				getKaleoDefinitionVersionId();
+
+		long kaleoDefinition3LatestKaleoDefinitionVersionId =
+			kaleoDefinition3LatestKaleoDefinitionVersion.
+				getKaleoDefinitionVersionId();
+
+		Assert.assertTrue(
+			kaleoDefinition3SecondKaleoDefinitionVersionId >
+				kaleoDefinition3LatestKaleoDefinitionVersionId);
+
 		KaleoDefinitionVersionTitleComparator
 			kaleoDefinitionVersionTitleComparator =
 				new KaleoDefinitionVersionTitleComparator(true);
-		KaleoDefinitionVersion kaleoDefinitionVersion1 =
-			getLatestKaleoDefinitionVersion(
-				addKaleoDefinition(
-					StringUtil.randomString(), "Name 1", "First definition",
-					"Description 1"));
-		KaleoDefinitionVersion kaleoDefinitionVersion2 =
-			getLatestKaleoDefinitionVersion(
-				addKaleoDefinition(
-					StringUtil.randomString(), "Name 2", "My title 2",
-					RandomTestUtil.randomString()));
-		KaleoDefinitionVersion kaleoDefinitionVersion3 =
-			getLatestKaleoDefinitionVersion(
-				addKaleoDefinition(
-					StringUtil.randomString(), RandomTestUtil.randomString(),
-					"My title 3", "Description 3"));
 
 		Assert.assertEquals(
-			Arrays.asList(kaleoDefinitionVersion1, kaleoDefinitionVersion3),
+			Arrays.asList(
+				kaleoDefinition1LatestKaleoDefinitionVersion,
+				kaleoDefinition3LatestKaleoDefinitionVersion),
 			kaleoDefinitionVersionLocalService.getLatestKaleoDefinitionVersions(
-				kaleoDefinitionVersion1.getCompanyId(), "desc",
+				kaleoDefinition1.getCompanyId(),
+				"kaleodefinitionversiondescription",
 				WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, kaleoDefinitionVersionTitleComparator));
 		Assert.assertEquals(
-			Arrays.asList(kaleoDefinitionVersion2, kaleoDefinitionVersion3),
+			Arrays.asList(
+				kaleoDefinition1LatestKaleoDefinitionVersion,
+				kaleoDefinition2LatestKaleoDefinitionVersion),
 			kaleoDefinitionVersionLocalService.getLatestKaleoDefinitionVersions(
-				kaleoDefinitionVersion1.getCompanyId(), "my",
+				kaleoDefinition1.getCompanyId(), "kaleodefinitionversionname",
 				WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, kaleoDefinitionVersionTitleComparator));
-
 		Assert.assertEquals(
-			Arrays.asList(kaleoDefinitionVersion1, kaleoDefinitionVersion2),
+			Arrays.asList(
+				kaleoDefinition2LatestKaleoDefinitionVersion,
+				kaleoDefinition3LatestKaleoDefinitionVersion),
 			kaleoDefinitionVersionLocalService.getLatestKaleoDefinitionVersions(
-				kaleoDefinitionVersion1.getCompanyId(), "name",
+				kaleoDefinition1.getCompanyId(), "kaleodefinitionversiontitle",
 				WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, kaleoDefinitionVersionTitleComparator));
 	}


### PR DESCRIPTION
Related: https://liferay.atlassian.net/browse/LPD-43403

## Situation

The query to retrieve the latest versions of each workflow definition was relying on the `kaleoDefinitionVersionId` instead of the `version`, it will not work well when an upgrade process inserts those definition version asynchronous.

## Fix

Get the latest versions of each workflow definition relying on version column.