### PR TITLE
LPD-42705 Support same Object Portlet ID when copying virtual instances

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -623,13 +623,13 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<InactiveObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_inactiveObjectDefinitionsServiceRegistrationsMaps.
 						entrySet()) {
 
 			InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
 				entry.getKey();
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable =
@@ -637,7 +637,8 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId(),
 					objectDefinitionId ->
 						inactiveObjectDefinitionDeployer.deploy(
 							objectDefinition));
@@ -651,18 +652,19 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_serviceRegistrationsMaps.entrySet()) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 					objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId(),
 					objectDefinitionId -> objectDefinitionDeployer.deploy(
 						objectDefinition));
 			}
@@ -898,14 +900,14 @@ public class ObjectDefinitionLocalServiceImpl
 	public void setAopProxy(Object aopProxy) {
 		super.setAopProxy(aopProxy);
 
-		Map<Long, List<ServiceRegistration<?>>> activeServiceRegistrationsMap =
-			new ConcurrentHashMap<>();
+		Map<String, List<ServiceRegistration<?>>>
+			activeServiceRegistrationsMap = new ConcurrentHashMap<>();
 		InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
 			new InactiveObjectDefinitionDeployerImpl(
 				_bundleContext, _objectEntryService, _objectFieldLocalService,
 				_objectRelatedModelsProviderRegistrarHelper,
 				_objectRelationshipLocalService);
-		Map<Long, List<ServiceRegistration<?>>>
+		Map<String, List<ServiceRegistration<?>>>
 			inactiveServiceRegistrationsMap = new ConcurrentHashMap<>();
 		ObjectDefinitionDeployer objectDefinitionDeployer =
 			new ObjectDefinitionDeployerImpl(
@@ -934,12 +936,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						activeServiceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 					else {
 						inactiveServiceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							inactiveObjectDefinitionDeployer.deploy(
 								objectDefinition));
 					}
@@ -992,7 +996,7 @@ public class ObjectDefinitionLocalServiceImpl
 							}
 						});
 
-					Map<Long, List<ServiceRegistration<?>>>
+					Map<String, List<ServiceRegistration<?>>>
 						serviceRegistrationsMap =
 							_serviceRegistrationsMaps.remove(
 								objectDefinitionDeployer);
@@ -1028,19 +1032,20 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_serviceRegistrationsMaps.entrySet()) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
 
 			objectDefinitionDeployer.undeploy(objectDefinition);
 
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			List<ServiceRegistration<?>> serviceRegistrations =
 				serviceRegistrationsMap.remove(
-					objectDefinition.getObjectDefinitionId());
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId());
 
 			if (serviceRegistrations != null) {
 				for (ServiceRegistration<?> serviceRegistration :
@@ -1302,7 +1307,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private ObjectDefinitionDeployer _addingObjectDefinitionDeployer(
 		ObjectDefinitionDeployer objectDefinitionDeployer) {
 
-		Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
 		_companyLocalService.forEachCompanyId(
@@ -1313,7 +1318,8 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						serviceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 				}
@@ -2672,7 +2678,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 	private final Map
 		<InactiveObjectDefinitionDeployer,
-		 Map<Long, List<ServiceRegistration<?>>>>
+		 Map<String, List<ServiceRegistration<?>>>>
 			_inactiveObjectDefinitionsServiceRegistrationsMaps =
 				Collections.synchronizedMap(new LinkedHashMap<>());
 
@@ -2769,7 +2775,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private SearchLocalizationHelper _searchLocalizationHelper;
 
 	private final Map
-		<ObjectDefinitionDeployer, Map<Long, List<ServiceRegistration<?>>>>
+		<ObjectDefinitionDeployer, Map<String, List<ServiceRegistration<?>>>>
 			_serviceRegistrationsMaps = Collections.synchronizedMap(
 				new LinkedHashMap<>());
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -99,6 +99,7 @@ import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -637,8 +638,7 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getCompanyId() + StringPool.AT +
-						objectDefinition.getObjectDefinitionId(),
+					_getObjectDefinitionKey(objectDefinition),
 					objectDefinitionId ->
 						inactiveObjectDefinitionDeployer.deploy(
 							objectDefinition));
@@ -663,8 +663,7 @@ public class ObjectDefinitionLocalServiceImpl
 					objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getCompanyId() + StringPool.AT +
-						objectDefinition.getObjectDefinitionId(),
+					_getObjectDefinitionKey(objectDefinition),
 					objectDefinitionId -> objectDefinitionDeployer.deploy(
 						objectDefinition));
 			}
@@ -936,14 +935,12 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						activeServiceRegistrationsMap.put(
-							companyId + StringPool.AT +
-								objectDefinition.getObjectDefinitionId(),
+							_getObjectDefinitionKey(objectDefinition),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 					else {
 						inactiveServiceRegistrationsMap.put(
-							companyId + StringPool.AT +
-								objectDefinition.getObjectDefinitionId(),
+							_getObjectDefinitionKey(objectDefinition),
 							inactiveObjectDefinitionDeployer.deploy(
 								objectDefinition));
 					}
@@ -1044,8 +1041,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 			List<ServiceRegistration<?>> serviceRegistrations =
 				serviceRegistrationsMap.remove(
-					objectDefinition.getCompanyId() + StringPool.AT +
-						objectDefinition.getObjectDefinitionId());
+					_getObjectDefinitionKey(objectDefinition));
 
 			if (serviceRegistrations != null) {
 				for (ServiceRegistration<?> serviceRegistration :
@@ -1318,8 +1314,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						serviceRegistrationsMap.put(
-							companyId + StringPool.AT +
-								objectDefinition.getObjectDefinitionId(),
+							_getObjectDefinitionKey(objectDefinition),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 				}
@@ -1737,6 +1732,16 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		return name;
+	}
+
+	private String _getObjectDefinitionKey(ObjectDefinition objectDefinition) {
+		String key = String.valueOf(objectDefinition.getObjectDefinitionId());
+
+		if (DBPartition.isPartitionEnabled()) {
+			key = key + StringPool.AT + objectDefinition.getCompanyId();
+		}
+
+		return key;
 	}
 
 	private long _getObjectFolderId(long companyId, long objectFolderId)

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
@@ -56,7 +56,9 @@ public class ObjectEntriesPanelApp extends BasePanelApp {
 		if (portlet == null) {
 			portlet = _supplier.get();
 
-			_portlet = portlet;
+			if (portlet.getCompanyId() == _objectDefinition.getCompanyId()) {
+				_portlet = portlet;
+			}
 		}
 
 		return portlet;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -17,13 +17,18 @@ import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.persistence.PortletPersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -654,6 +659,57 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testPortlets() throws Exception {
+		Company company = companyLocalService.fetchCompanyByVirtualHost(
+			TestPropsValues.COMPANY_WEB_ID);
+
+		String portletName = RandomTestUtil.randomString();
+
+		try {
+			_deployRemotePortlet(company.getCompanyId(), portletName);
+
+			long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+			_deployRemotePortlet(defaultCompanyId, portletName);
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						company.getCompanyId())) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(
+					company.getCompanyId(), portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						defaultCompanyId)) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(defaultCompanyId, portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						COMPANY_IDS[0])) {
+
+				Assert.assertNull(
+					_portletLocalService.getPortletById(portletName));
+			}
+		}
+		finally {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> _destroyRemotePortlet(companyId, portletName));
+		}
+	}
+
+	@Test
 	public void testRegenerateViews() throws Exception {
 		try {
 			DBPartitionUtil.forEachCompanyId(
@@ -805,6 +861,28 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
+	private void _deployRemotePortlet(long companyId, String portletName)
+		throws Exception {
+
+		Portlet portlet = _portletPersistence.create(0);
+
+		portlet.setCompanyId(companyId);
+		portlet.setPortletId(portletName);
+
+		_portletLocalService.deployRemotePortlet(
+			new long[] {companyId}, portlet, new String[] {"category.hidden"},
+			true, true);
+	}
+
+	private void _destroyRemotePortlet(long companyId, String portletName) {
+		Portlet portlet = _portletLocalService.getPortletById(
+			companyId, portletName);
+
+		if (portlet != null) {
+			_portletLocalService.destroyRemotePortlet(portlet);
+		}
+	}
+
 	private static final String _CLASS_NAME = DBPartitionTest.class.getName();
 
 	@Inject
@@ -815,5 +893,11 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@Inject
 	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private PortletPersistence _portletPersistence;
 
 }

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -520,6 +520,57 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testDeployRemotePortlet() throws Exception {
+		Company company = companyLocalService.fetchCompanyByVirtualHost(
+			TestPropsValues.COMPANY_WEB_ID);
+
+		String portletName = RandomTestUtil.randomString();
+
+		try {
+			_deployRemotePortlet(company.getCompanyId(), portletName);
+
+			long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+			_deployRemotePortlet(defaultCompanyId, portletName);
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						company.getCompanyId())) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(
+					company.getCompanyId(), portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						defaultCompanyId)) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(defaultCompanyId, portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						COMPANY_IDS[0])) {
+
+				Assert.assertNull(
+					_portletLocalService.getPortletById(portletName));
+			}
+		}
+		finally {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> _destroyRemotePortlet(companyId, portletName));
+		}
+	}
+
+	@Test
 	public void testDropIndexControlTable() throws Exception {
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -656,57 +707,6 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	public void testInitResourceActions() throws Exception {
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> StartupHelperUtil.initResourceActions());
-	}
-
-	@Test
-	public void testPortlets() throws Exception {
-		Company company = companyLocalService.fetchCompanyByVirtualHost(
-			TestPropsValues.COMPANY_WEB_ID);
-
-		String portletName = RandomTestUtil.randomString();
-
-		try {
-			_deployRemotePortlet(company.getCompanyId(), portletName);
-
-			long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
-
-			_deployRemotePortlet(defaultCompanyId, portletName);
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						company.getCompanyId())) {
-
-				Portlet portlet = _portletLocalService.getPortletById(
-					portletName);
-
-				Assert.assertNotNull(portlet);
-				Assert.assertEquals(
-					company.getCompanyId(), portlet.getCompanyId());
-			}
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						defaultCompanyId)) {
-
-				Portlet portlet = _portletLocalService.getPortletById(
-					portletName);
-
-				Assert.assertNotNull(portlet);
-				Assert.assertEquals(defaultCompanyId, portlet.getCompanyId());
-			}
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						COMPANY_IDS[0])) {
-
-				Assert.assertNull(
-					_portletLocalService.getPortletById(portletName));
-			}
-		}
-		finally {
-			DBPartitionUtil.forEachCompanyId(
-				companyId -> _destroyRemotePortlet(companyId, portletName));
-		}
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -523,6 +523,18 @@ public class DBPartitionUtil {
 								"companyId = ", fromCompanyId));
 					}
 
+					if (fromTableName.startsWith("Object") &&
+						dbInspector.hasColumn(fromTableName, "dbTableName")) {
+
+						statement.executeUpdate(
+							StringBundler.concat(
+								"update ", partitionTableName, " set ",
+								"dbTableName = REPLACE(dbTableName, ",
+								fromCompanyId, ", ", toCompanyId,
+								") where dbTableName like '%", fromCompanyId,
+								"%'"));
+					}
+
 					if (StringUtil.equalsIgnoreCase(fromTableName, "Group_")) {
 						statement.executeUpdate(
 							StringBundler.concat(

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2927,7 +2927,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		new ConcurrentHashMap<>();
 	private static volatile Map<String, String> _portletIdsByStrutsPath;
 	private static final Map<String, Portlet> _portletsMap =
-		new GlobalPortletsMap();
+		new ShardedPortletsMap();
 	private static final Map<Long, Map<String, Portlet>> _portletsMaps =
 		new ConcurrentHashMap<>();
 
@@ -2961,7 +2961,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 	private ServiceTracker<FriendlyURLMapper, String[]> _serviceTracker;
 	private ServiceTrackerList<Consumer<Long>> _serviceTrackerList;
 
-	private static class GlobalPortletsMap
+	private static class ShardedPortletsMap
 		extends ConcurrentHashMap<String, Portlet> {
 
 		@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2927,7 +2927,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		new ConcurrentHashMap<>();
 	private static volatile Map<String, String> _portletIdsByStrutsPath;
 	private static final Map<String, Portlet> _portletsMap =
-		new ConcurrentHashMap<>();
+		new GlobalPortletsMap();
 	private static final Map<Long, Map<String, Portlet>> _portletsMaps =
 		new ConcurrentHashMap<>();
 
@@ -2960,6 +2960,50 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 	private ServiceTracker<FriendlyURLMapper, String[]> _serviceTracker;
 	private ServiceTrackerList<Consumer<Long>> _serviceTrackerList;
+
+	private static class GlobalPortletsMap
+		extends ConcurrentHashMap<String, Portlet> {
+
+		@Override
+		public Portlet get(Object key) {
+			Portlet portlet = super.get(key);
+
+			if ((portlet != null) &&
+				(portlet.getCompanyId() == CompanyConstants.SYSTEM)) {
+
+				return portlet;
+			}
+
+			return super.get(
+				key + StringPool.AT +
+					CompanyThreadLocal.getNonsystemCompanyId());
+		}
+
+		@Override
+		public Portlet put(String key, Portlet value) {
+			if ((value == null) ||
+				(value.getCompanyId() == CompanyConstants.SYSTEM)) {
+
+				return super.put(key, value);
+			}
+
+			return super.put(key + StringPool.AT + value.getCompanyId(), value);
+		}
+
+		@Override
+		public Portlet remove(Object key) {
+			Portlet portlet = super.remove(
+				key + StringPool.AT +
+					CompanyThreadLocal.getNonsystemCompanyId());
+
+			if (portlet != null) {
+				return portlet;
+			}
+
+			return super.remove(key);
+		}
+
+	}
 
 	private class FriendlyURLMapperServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer<FriendlyURLMapper, String[]> {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -2968,8 +2969,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		public Portlet get(Object key) {
 			Portlet portlet = super.get(key);
 
-			if ((portlet != null) &&
-				(portlet.getCompanyId() == CompanyConstants.SYSTEM)) {
+			if (!DBPartition.isPartitionEnabled() ||
+				((portlet != null) &&
+				 (portlet.getCompanyId() == CompanyConstants.SYSTEM))) {
 
 				return portlet;
 			}
@@ -2981,7 +2983,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		@Override
 		public Portlet put(String key, Portlet value) {
-			if ((value == null) ||
+			if (!DBPartition.isPartitionEnabled() || (value == null) ||
 				(value.getCompanyId() == CompanyConstants.SYSTEM)) {
 
 				return super.put(key, value);
@@ -2992,12 +2994,14 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		@Override
 		public Portlet remove(Object key) {
-			Portlet portlet = super.remove(
-				key + StringPool.AT +
-					CompanyThreadLocal.getNonsystemCompanyId());
+			if (DBPartition.isPartitionEnabled()) {
+				Portlet portlet = super.remove(
+					key + StringPool.AT +
+						CompanyThreadLocal.getNonsystemCompanyId());
 
-			if (portlet != null) {
-				return portlet;
+				if (portlet != null) {
+					return portlet;
+				}
 			}
 
 			return super.remove(key);


### PR DESCRIPTION
- **LPD-42705 Adding test to expose the issue of company scoped portlets in database partitioning with the same portlet id**
- **LPD-42705 Replacing companyId references in dbTableName fields**
- **LPD-42705 The key for the object definition must include the companyId. This also impact regular db partitioning since ids can collide**
- **LPD-42705 Wrapper for the map to partition it**
- **LPD-42705 Binding the portlet only if it belongs to the company of the object definition**
- **LPD-42705 Applying the sharding only when database partitioning is enabled**
- **LPD-42705 Rename**
- **LPD-42705 Applying the sharded cache only when database partitioning is enabled**
- **LPD-42705 SF**
