### PR TITLE
LPD-43403 Perform this query via ES instead of relational database due to the complexity of retrieving the latest process definition versions

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:account:account-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-engine-adapter-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/KaleoDefinitionVersionModelSearchConfigurator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/KaleoDefinitionVersionModelSearchConfigurator.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.search;
+
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchConfigurator;
+import com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contributor.KaleoDefinitionVersionModelIndexerWriterContributor;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
+import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Feliphe Marinho
+ */
+@Component(service = ModelSearchConfigurator.class)
+public class KaleoDefinitionVersionModelSearchConfigurator
+	implements ModelSearchConfigurator<KaleoDefinitionVersion> {
+
+	@Override
+	public String getClassName() {
+		return KaleoDefinitionVersion.class.getName();
+	}
+
+	@Override
+	public ModelIndexerWriterContributor<KaleoDefinitionVersion>
+		getModelIndexerWriterContributor() {
+
+		return _modelIndexWriterContributor;
+	}
+
+	@Activate
+	protected void activate() {
+		_modelIndexWriterContributor =
+			new KaleoDefinitionVersionModelIndexerWriterContributor(
+				_dynamicQueryBatchIndexingActionableFactory,
+				_kaleoDefinitionVersionLocalService);
+	}
+
+	@Reference
+	private DynamicQueryBatchIndexingActionableFactory
+		_dynamicQueryBatchIndexingActionableFactory;
+
+	@Reference
+	private KaleoDefinitionVersionLocalService
+		_kaleoDefinitionVersionLocalService;
+
+	private ModelIndexerWriterContributor<KaleoDefinitionVersion>
+		_modelIndexWriterContributor;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoDefinitionVersionModelDocumentContributor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoDefinitionVersionModelDocumentContributor.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contributor;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Feliphe Marinho
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion",
+	service = ModelDocumentContributor.class
+)
+public class KaleoDefinitionVersionModelDocumentContributor
+	implements ModelDocumentContributor<KaleoDefinitionVersion> {
+
+	@Override
+	public void contribute(
+		Document document, KaleoDefinitionVersion kaleoDefinitionVersion) {
+
+		document.addKeyword(
+			Field.DESCRIPTION, kaleoDefinitionVersion.getDescription());
+		document.addKeyword(Field.NAME, kaleoDefinitionVersion.getName());
+		document.addLocalizedKeyword(
+			Field.TITLE, kaleoDefinitionVersion.getTitleMap());
+
+		int[] versionParts = StringUtil.split(
+			kaleoDefinitionVersion.getVersion(), StringPool.PERIOD, 0);
+
+		document.addNumber(Field.VERSION, versionParts[0]);
+	}
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoDefinitionVersionModelIndexerWriterContributor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/index/contributor/KaleoDefinitionVersionModelIndexerWriterContributor.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.search.spi.model.index.contributor;
+
+import com.liferay.portal.search.batch.BatchIndexingActionable;
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
+import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalService;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class KaleoDefinitionVersionModelIndexerWriterContributor
+	implements ModelIndexerWriterContributor<KaleoDefinitionVersion> {
+
+	public KaleoDefinitionVersionModelIndexerWriterContributor(
+		DynamicQueryBatchIndexingActionableFactory
+			dynamicQueryBatchIndexingActionableFactory,
+		KaleoDefinitionVersionLocalService kaleoDefinitionVersionLocalService) {
+
+		_dynamicQueryBatchIndexingActionableFactory =
+			dynamicQueryBatchIndexingActionableFactory;
+		_kaleoDefinitionVersionLocalService =
+			kaleoDefinitionVersionLocalService;
+	}
+
+	@Override
+	public void customize(
+		BatchIndexingActionable batchIndexingActionable,
+		ModelIndexerWriterDocumentHelper modelIndexerWriterDocumentHelper) {
+
+		batchIndexingActionable.setPerformActionMethod(
+			(KaleoDefinitionVersion kaleoDefinitionVersion) ->
+				batchIndexingActionable.addDocuments(
+					modelIndexerWriterDocumentHelper.getDocument(
+						kaleoDefinitionVersion)));
+	}
+
+	@Override
+	public BatchIndexingActionable getBatchIndexingActionable() {
+		return _dynamicQueryBatchIndexingActionableFactory.
+			getBatchIndexingActionable(
+				_kaleoDefinitionVersionLocalService.
+					getIndexableActionableDynamicQuery());
+	}
+
+	@Override
+	public long getCompanyId(KaleoDefinitionVersion kaleoDefinitionVersion) {
+		return kaleoDefinitionVersion.getCompanyId();
+	}
+
+	private final DynamicQueryBatchIndexingActionableFactory
+		_dynamicQueryBatchIndexingActionableFactory;
+	private final KaleoDefinitionVersionLocalService
+		_kaleoDefinitionVersionLocalService;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
@@ -6,12 +6,8 @@
 package com.liferay.portal.workflow.kaleo.service.impl;
 
 import com.liferay.exportimport.kernel.staging.Staging;
-import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.petra.sql.dsl.query.DSLQuery;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
-import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -20,18 +16,40 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.aggregation.AggregationResult;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregation;
+import com.liferay.portal.search.aggregation.bucket.TermsAggregationResult;
+import com.liferay.portal.search.aggregation.metrics.TopHitsAggregation;
+import com.liferay.portal.search.aggregation.metrics.TopHitsAggregationResult;
+import com.liferay.portal.search.engine.adapter.search.SearchRequestExecutor;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchRequest;
+import com.liferay.portal.search.engine.adapter.search.SearchSearchResponse;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.index.IndexNameBuilder;
+import com.liferay.portal.search.localization.SearchLocalizationHelper;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.sort.SortOrder;
+import com.liferay.portal.search.sort.Sorts;
 import com.liferay.portal.workflow.exception.IncompleteWorkflowInstancesException;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
-import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersionTable;
 import com.liferay.portal.workflow.kaleo.service.KaleoConditionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoNodeLocalService;
@@ -44,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -366,82 +385,98 @@ public class KaleoDefinitionVersionLocalServiceImpl
 
 		List<Long> kaleoDefinitionVersionIds = new ArrayList<>();
 
-		KaleoDefinitionVersionTable aliasKaleoDefinitionVersionTable =
-			KaleoDefinitionVersionTable.INSTANCE.as(
-				"aliasKaleoDefinitionVersionTable");
+		SearchSearchRequest searchSearchRequest = new SearchSearchRequest();
 
-		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			aliasKaleoDefinitionVersionTable.kaleoDefinitionVersionId
-		).from(
-			aliasKaleoDefinitionVersionTable
-		).where(
-			aliasKaleoDefinitionVersionTable.companyId.eq(
-				companyId
-			).and(
-				() -> {
-					if (Validator.isNull(keywords)) {
-						return null;
-					}
+		searchSearchRequest.setIndexNames(
+			_indexNameBuilder.getIndexName(companyId));
 
-					Predicate predicate = null;
+		BooleanQuery mustBooleanQuery = _queries.booleanQuery();
 
-					for (String keyword : _customSQL.keywords(keywords)) {
-						predicate =
-							aliasKaleoDefinitionVersionTable.description.like(
-								keyword
-							).or(
-								aliasKaleoDefinitionVersionTable.name.like(
-									keyword)
-							).or(
-								aliasKaleoDefinitionVersionTable.title.like(
-									keyword)
-							);
-					}
+		mustBooleanQuery.addMustQueryClauses(
+			_queries.term(Field.COMPANY_ID, companyId),
+			_queries.term(
+				Field.ENTRY_CLASS_NAME,
+				KaleoDefinitionVersion.class.getName()));
 
-					return predicate.withParentheses();
-				}
-			).and(
-				() -> {
-					if (status == WorkflowConstants.STATUS_ANY) {
-						return null;
-					}
+		if (Validator.isNotNull(keywords)) {
+			BooleanQuery shouldBooleanQuery = _queries.booleanQuery();
 
-					return aliasKaleoDefinitionVersionTable.status.eq(status);
-				}
-			).and(
-				aliasKaleoDefinitionVersionTable.version.in(
-					DSLQueryFactoryUtil.select(
-						DSLFunctionFactoryUtil.max(
-							DSLFunctionFactoryUtil.castLong(
-								KaleoDefinitionVersionTable.INSTANCE.version)
-						).as(
-							"latestVersion"
-						)
-					).from(
-						KaleoDefinitionVersionTable.INSTANCE
-					).where(
-						KaleoDefinitionVersionTable.INSTANCE.companyId.eq(
-							companyId
-						).and(
-							KaleoDefinitionVersionTable.INSTANCE.name.eq(
-								aliasKaleoDefinitionVersionTable.name)
-						)
-					))
-			)
-		);
+			keywords =
+				StringPool.STAR + StringUtil.toLowerCase(keywords) +
+					StringPool.STAR;
 
-		List<Object> entriesValues = kaleoDefinitionVersionPersistence.dslQuery(
-			dslQuery);
+			shouldBooleanQuery.addShouldQueryClauses(
+				_queries.wildcard(Field.DESCRIPTION, keywords),
+				_queries.wildcard(Field.NAME, keywords));
 
-		for (Object result : entriesValues) {
-			kaleoDefinitionVersionIds.add((Long)result);
+			String[] localizedFieldNames =
+				_searchLocalizationHelper.getLocalizedFieldNames(
+					new String[] {Field.TITLE}, new SearchContext());
+
+			for (String localizedFieldName : localizedFieldNames) {
+				shouldBooleanQuery.addShouldQueryClauses(
+					_queries.wildcard(localizedFieldName, keywords));
+			}
+
+			mustBooleanQuery.addMustQueryClauses(shouldBooleanQuery);
+		}
+
+		if (status != WorkflowConstants.STATUS_ANY) {
+			mustBooleanQuery.addMustQueryClauses(
+				_queries.term(Field.STATUS, status));
+		}
+
+		searchSearchRequest.setQuery(mustBooleanQuery);
+
+		TermsAggregation termsAggregation = _aggregations.terms(
+			"processDefinitionLatestVersions",
+			Field.getSortableFieldName(Field.NAME));
+
+		TopHitsAggregation topHitsAggregation = _aggregations.topHits(
+			"topHits");
+
+		topHitsAggregation.addSortFields(
+			_sorts.field(
+				Field.getSortableFieldName(Field.VERSION), SortOrder.DESC));
+
+		topHitsAggregation.setSize(1);
+
+		termsAggregation.addChildrenAggregations(topHitsAggregation);
+
+		searchSearchRequest.addAggregation(termsAggregation);
+
+		SearchSearchResponse searchSearchResponse =
+			_searchRequestExecutor.executeSearchRequest(searchSearchRequest);
+
+		Map<String, AggregationResult> aggregationResultsMap =
+			searchSearchResponse.getAggregationResultsMap();
+
+		TermsAggregationResult termsAggregationResult =
+			(TermsAggregationResult)aggregationResultsMap.get(
+				"processDefinitionLatestVersions");
+
+		for (Bucket bucket : termsAggregationResult.getBuckets()) {
+			TopHitsAggregationResult topHitsAggregationResult =
+				(TopHitsAggregationResult)bucket.getChildAggregationResult(
+					"topHits");
+
+			SearchHits searchHits = topHitsAggregationResult.getSearchHits();
+
+			for (SearchHit searchHit : searchHits.getSearchHits()) {
+				kaleoDefinitionVersionIds.add(
+					MapUtil.getLong(
+						searchHit.getSourcesMap(), Field.ENTRY_CLASS_PK));
+			}
 		}
 
 		return kaleoDefinitionVersionIds;
 	}
 
 	@Reference
-	private CustomSQL _customSQL;
+	private Aggregations _aggregations;
+
+	@Reference
+	private IndexNameBuilder _indexNameBuilder;
 
 	@Reference
 	private KaleoConditionLocalService _kaleoConditionLocalService;
@@ -459,7 +494,22 @@ public class KaleoDefinitionVersionLocalServiceImpl
 	private KaleoTransitionLocalService _kaleoTransitionLocalService;
 
 	@Reference
+	private Queries _queries;
+
+	@Reference
+	private QueryHelper _queryHelper;
+
+	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private SearchLocalizationHelper _searchLocalizationHelper;
+
+	@Reference
+	private SearchRequestExecutor _searchRequestExecutor;
+
+	@Reference
+	private Sorts _sorts;
 
 	@Reference
 	private Staging _staging;


### PR DESCRIPTION
Related: https://liferay.atlassian.net/browse/LPD-43403

## Situation

CAST_LONG function cannot be applied for VARCHAR columns that has the content like 1.1 or 1.0 on PostegreSQL, so to avoid situations with many relational databases peculiarities I decided to perform this query on ES due to its complexity.

`SQL Error [22P02]: ERROR: invalid input syntax for type bigint: "1.0"`

## Fix

CAST_LONG function was being used to retrieve the latest version of each process definition ([see](https://github.com/liferay-bpm/liferay-portal/pull/3978/files#diff-5e43287d614ea6b5789af4187f0a5c95f572ac6031d15f401549d9a44b61141dL412-L429)) but as mentioned above, it is not supported by PostgreSQL so to achieve the same result via ES I used a nested aggregation, the [first one](https://github.com/liferay-bpm/liferay-portal/pull/3978/files#diff-5e43287d614ea6b5789af4187f0a5c95f572ac6031d15f401549d9a44b61141dR431-R433) is responsible for aggregating the results by the process definition name that is unique, and the [second aggregation](https://github.com/liferay-bpm/liferay-portal/pull/3978/files#diff-5e43287d614ea6b5789af4187f0a5c95f572ac6031d15f401549d9a44b61141dR435-R444) that is the nested to the first one is responsible for sort descending all process definition versions by their version and then get only the first result.

## Test

[See](https://github.com/liferay/liferay-portal/blob/8db0beb67420773df8a6cc812fdbd5119110e4ce/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionVersionLocalServiceTest.java#L64), in my perspective we do not need a test covering this specific use case with PostgreSQL, the already existing test cover the functionality.
