### PR TITLE
LPD-41330 Modifications to truncate the nanoseconds into millisecond

### DIFF
--- a/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-storage-salesforce-test/src/testIntegration/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/test/SalesforceObjectEntryManagerImplTest.java
@@ -54,6 +54,7 @@ import java.text.DateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -327,6 +328,12 @@ public class SalesforceObjectEntryManagerImplTest
 			"queued", date, false, null, title1);
 
 		LocalDateTime localDateTime1 = LocalDateTime.now();
+
+		String localDateTime1String = localDateTime1.toString();
+
+		if(localDateTime1String.split("\\.")[1].length() > 3){
+			localDateTime1 = localDateTime1.truncatedTo(ChronoUnit.MILLIS);
+		}
 
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			"started", new Date(date.getTime() - Time.DAY), true,


### PR DESCRIPTION
Modifications to truncate the nanoseconds into millisecond avoiding the error on the SalesforceObjectEntryManagerImplTest.testGetObjectEntries test.