### PR TITLE
LPD-43203 Remove resource reference during unbinding

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1993,6 +1993,8 @@ public class ObjectDefinitionLocalServiceImpl
 
 		deployObjectDefinition(objectDefinition1);
 
+		objectDefinition1.setPreviousRESTContextPath(null);
+
 		boolean containsDraftDescendantNodeObjectDefinitions = false;
 		ObjectDefinitionTreeFactory objectDefinitionTreeFactory =
 			new ObjectDefinitionTreeFactory(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -79,6 +79,7 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.security.RandomUtil;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -1729,6 +1730,10 @@ public class ObjectRelationshipLocalServiceImpl
 		_updateObjectDefinitionTree(
 			objectDefinition2, oldRootObjectDefinitionId2,
 			newRootObjectDefinitionId2);
+
+		if (objectDefinition2.isRootNode()) {
+			_deployObjectDefinition(objectDefinition2);
+		}
 	}
 
 	private void _updateObjectDefinitionTree(
@@ -1841,6 +1846,18 @@ public class ObjectRelationshipLocalServiceImpl
 			_deployObjectDefinition(objectDefinition);
 
 			return;
+		}
+
+		if (objectDefinition.isApproved() &&
+			objectDefinition.isRootDescendantNode()) {
+
+			ObjectDefinition oldRootObjectDefinition =
+				_objectDefinitionPersistence.findByPrimaryKey(
+					oldRootObjectDefinitionId);
+
+			_resourceActions.removeModelResourceReference(
+				objectDefinition.getClassName(),
+				oldRootObjectDefinition.getPortletId());
 		}
 
 		String previousRESTContextPath = objectDefinition.getRESTContextPath();
@@ -2337,6 +2354,9 @@ public class ObjectRelationshipLocalServiceImpl
 
 	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourceActions _resourceActions;
 
 	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -2121,6 +2121,13 @@ public class ObjectDefinitionLocalServiceTest {
 				objectDefinitionA.getObjectDefinitionId()),
 			_objectDefinitionLocalService);
 
+		TreeTestUtil.unbind(
+			objectDefinitionA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_assertModelResourceNames(ListUtil.fromArray("C_A"));
+		_assertModelResourceNames(ListUtil.fromArray("C_AA", "C_AAAAA"));
+
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,
 			new String[] {"C_A", "C_AA", "C_AAA", "C_AAAA", "C_AAAAA"},

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -619,6 +619,17 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	@Override
+	public void removeModelResourceReference(
+		String modelName, String portletName) {
+
+		Set<String> resources = _resourceReferences.get(portletName);
+
+		if (resources != null) {
+			resources.remove(modelName);
+		}
+	}
+
+	@Override
 	public void removeModelResources(Document document) {
 		Element rootElement = document.getRootElement();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -123,6 +123,9 @@ public interface ResourceActions {
 
 	public void removeModelResource(String name, String action);
 
+	public void removeModelResourceReference(
+		String modelName, String portletName);
+
 	public void removeModelResources(Document document);
 
 	public void removePortletResources(Document document);

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
@@ -1,1 +1,1 @@
-version 9.5.0
+version 9.6.0


### PR DESCRIPTION
**Related ticket:** https://liferay.atlassian.net/browse/LPD-43203

---
Hi team,

I would like your help reviewing this PR.

Basically, I'm adding a new method `removeModelResourceReference` to the `ResourceActions` class (https://github.com/carolmariaabb/liferay-portal/commit/fd0f08967f7423038afd858fc824e5fcc0997844 and https://github.com/carolmariaabb/liferay-portal/commit/38dc3c00a4b35dd9ab7db5b70fae9dde856c9e28).

This was necessary because we have a feature in our product called **Root Model**.

This feature allows the user to `bind` more than one Object Definition, thus forming a "tree" structure:

**For example**: Object A -> Object B.

- This means that, as shown in the following image, the permissions for Object B are listed in the Object A "Define Permissions" page:
- <img src="https://github.com/user-attachments/assets/c49f76ca-6a77-4796-8a41-a921065f3c22" width="250">

We also allow the user to `unbind` these object definitions. 

- In this case, the "Define Permissions" page should return to its normal state. In other words, we need to remove Object B from the Object A "Define Permissions" page.

For both cases (`bind` and `unbind`) we dynamically populate the Resource Actions ([here](https://github.com/carolmariaabb/liferay-portal/blob/61b58512ab7f586f7ca6824d9a013acf90aafc3f/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java#L40C29-L40C44)).

During the binding process, we dynamically create **only one** XML for the root node (Object A) which also includes the Object B:

```
...
	<model-resource>
		<model-name>ObjectA_ModelName</model-name>
		<portlet-ref>
			<portlet-name>ObjectA_PortletId</portlet-name>
		</portlet-ref>
		<weight>2</weight>
		<permissions>
			....
		</permissions>
	</model-resource>
	<model-resource>
		<model-name>ObjectB_ModelName</model-name>
		<portlet-ref>
			<portlet-name>ObjectA_PortletId</portlet-name>
		</portlet-ref>
		<weight>3</weight>
		<permissions>
			....
		</permissions>
	</model-resource>
...
```

When unbinding, we dynamically generate two XMLs for each object definition:

**Object A:**

```
<model-resource>
	<model-name>ObjectA_ModelName</model-name>
	<portlet-ref>
		<portlet-name>ObjectA_PortletId</portlet-name>
	</portlet-ref>
	<weight>2</weight>
	<permissions>
		....
	</permissions>
</model-resource>
```

**Object B:**

```
<model-resource>
	<model-name>ObjectB_ModelName</model-name>
	<portlet-ref>
		<portlet-name>ObjectB_PortletId</portlet-name>
	</portlet-ref>
	<weight>2</weight>
	<permissions>
		....
	</permissions>
</model-resource>
```

However, even after removing `ObjectB_ModelName` from Object A's XML, Object B continues to be displayed on Object A "Define Permissions" page.

- Even after [populating resources](https://github.com/carolmariaabb/liferay-portal/blob/fff2eae7cd56690384f2d41f06826f84b52898c5/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java#L478) with the new XMLs, the `_resourceReferences` for Object A portlet still includes Object B, because this [code](https://github.com/carolmariaabb/liferay-portal/blob/fff2eae7cd56690384f2d41f06826f84b52898c5/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java#L1143-L1147) is not overriding.

So the idea of this PR is to create a new method to remove obsolete references in the `_resourceReferences` map.

Please let me know if this is a valid way to achieve the expected behavior.





