### PR TITLE
LPD-35701 - Show the frontend tokens from the selected frontend token definition when editing a style book

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/bnd.bnd
+++ b/modules/apps/frontend-token/frontend-token-definition-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Frontend Token Definition API
 Bundle-SymbolicName: com.liferay.frontend.token.definition.api
-Bundle-Version: 6.0.1
+Bundle-Version: 7.0.0
 Export-Package: com.liferay.frontend.token.definition

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinitionRegistry.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinitionRegistry.java
@@ -17,6 +17,9 @@ public interface FrontendTokenDefinitionRegistry {
 	public FrontendTokenDefinition getFrontendTokenDefinition(
 		LayoutSet layoutSet);
 
+	public FrontendTokenDefinition getFrontendTokenDefinition(
+		long companyId, String themeId);
+
 	public List<FrontendTokenDefinition> getFrontendTokenDefinitions(
 		long companyId);
 

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -69,6 +70,21 @@ public class FrontendTokenDefinitionRegistryImpl
 			layoutSet.getCompanyId(),
 			_getCETExternalReferenceCode(layoutSet.getLayoutSetId()),
 			layoutSet.getThemeId());
+	}
+
+	@Override
+	public FrontendTokenDefinition getFrontendTokenDefinition(
+		long companyId, String themeId) {
+
+		for (FrontendTokenDefinition frontendTokenDefinition :
+				getFrontendTokenDefinitions(companyId)) {
+
+			if (Objects.equals(frontendTokenDefinition.getThemeId(), themeId)) {
+				return frontendTokenDefinition;
+			}
+		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -76,15 +75,19 @@ public class FrontendTokenDefinitionRegistryImpl
 	public FrontendTokenDefinition getFrontendTokenDefinition(
 		long companyId, String themeId) {
 
-		for (FrontendTokenDefinition frontendTokenDefinition :
-				getFrontendTokenDefinitions(companyId)) {
+		FrontendTokenDefinition frontendTokenDefinition =
+			_frontendTokenDefinitions.get(themeId);
 
-			if (Objects.equals(frontendTokenDefinition.getThemeId(), themeId)) {
-				return frontendTokenDefinition;
+		if (frontendTokenDefinition == null) {
+			Map<String, FrontendTokenDefinition> frontendTokenDefinitions =
+				_frontendTokenDefinitionsMap.get(companyId);
+
+			if (frontendTokenDefinitions != null) {
+				frontendTokenDefinition = frontendTokenDefinitions.get(themeId);
 			}
 		}
 
-		return null;
+		return frontendTokenDefinition;
 	}
 
 	@Override

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -8194,6 +8194,7 @@ frontend-js-lodash-description=Enabling Lodash will make the library available i
 frontend-theme-font-awesome-configuration-name=Font Awesome
 frontend-theme-font-awesome-description=Enabling Font Awesome will load the font file in all your pages making its icon fonts available out of the box.
 frontend-token-definition-json-file-upload=Frontend Token Definition JSON File Upload
+frontend-token-definition-provided-by=Frontend Token Definition Provided By
 frontpage=FrontPage
 ftl[stands-for]=FreeMarker
 ftp=FTP

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -5,7 +5,6 @@
 
 package com.liferay.style.book.web.internal.display.context;
 
-import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.fragment.collection.item.selector.FragmentCollectionItemSelectorReturnType;
 import com.liferay.fragment.collection.item.selector.criterion.FragmentCollectionItemSelectorCriterion;
@@ -33,7 +32,6 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -53,7 +51,6 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
-import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -70,6 +67,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalServiceUtil;
+import com.liferay.style.book.web.internal.util.StyleBookUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -587,26 +585,9 @@ public class EditStyleBookEntryDisplayContext {
 
 	private String _getThemeName() {
 		if (FeatureFlagManagerUtil.isEnabled("LPD-30204")) {
-			Theme theme = ThemeLocalServiceUtil.fetchTheme(
-				_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
-			String name = _styleBookEntry.getThemeId();
-
-			if (theme != null) {
-				name = LanguageUtil.format(
-					_httpServletRequest, "x-theme", theme.getName());
-			}
-			else {
-				CET cet = _cetManager.getCET(
-					_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
-
-				if (cet != null) {
-					name = LanguageUtil.format(
-						_httpServletRequest, "x-theme-css-client-extension",
-						cet.getName());
-				}
-			}
-
-			return name;
+			return StyleBookUtil.getThemeName(
+				_cetManager, _styleBookEntry.getCompanyId(),
+				_httpServletRequest, _styleBookEntry.getThemeId());
 		}
 
 		Group group = _themeDisplay.getScopeGroup();

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -302,9 +302,22 @@ public class EditStyleBookEntryDisplayContext {
 	private JSONObject _getFrontendTokenDefinitionJSONObject()
 		throws Exception {
 
-		FrontendTokenDefinition frontendTokenDefinition =
-			_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
-				_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
+		FrontendTokenDefinition frontendTokenDefinition;
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-30204")) {
+			frontendTokenDefinition =
+				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
+		}
+		else {
+			Group group = _themeDisplay.getScopeGroup();
+
+			frontendTokenDefinition =
+				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					LayoutSetLocalServiceUtil.fetchLayoutSet(
+						_themeDisplay.getSiteGroupId(),
+						group.isLayoutSetPrototype()));
+		}
 
 		if (frontendTokenDefinition != null) {
 			return frontendTokenDefinition.getJSONObject(

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -29,6 +29,7 @@ import com.liferay.layout.page.template.util.comparator.LayoutPageTemplateEntryM
 import com.liferay.layout.util.comparator.LayoutModifiedDateComparator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.Theme;
@@ -48,6 +50,7 @@ import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
@@ -572,26 +575,37 @@ public class EditStyleBookEntryDisplayContext {
 	}
 
 	private String _getThemeName() {
-		Theme theme = ThemeLocalServiceUtil.fetchTheme(
-			_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
-		String name = _styleBookEntry.getThemeId();
-
-		if (theme != null) {
-			name = LanguageUtil.format(
-				_httpServletRequest, "x-theme", theme.getName());
-		}
-		else {
-			CET cet = _cetManager.getCET(
+		if (FeatureFlagManagerUtil.isEnabled("LPD-30204")) {
+			Theme theme = ThemeLocalServiceUtil.fetchTheme(
 				_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
+			String name = _styleBookEntry.getThemeId();
 
-			if (cet != null) {
+			if (theme != null) {
 				name = LanguageUtil.format(
-					_httpServletRequest, "x-theme-css-client-extension",
-					cet.getName());
+					_httpServletRequest, "x-theme", theme.getName());
 			}
+			else {
+				CET cet = _cetManager.getCET(
+					_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
+
+				if (cet != null) {
+					name = LanguageUtil.format(
+						_httpServletRequest, "x-theme-css-client-extension",
+						cet.getName());
+				}
+			}
+
+			return name;
 		}
 
-		return name;
+		Group group = _themeDisplay.getScopeGroup();
+
+		LayoutSet layoutSet = LayoutSetLocalServiceUtil.fetchLayoutSet(
+			_themeDisplay.getSiteGroupId(), group.isLayoutSetPrototype());
+
+		Theme theme = layoutSet.getTheme();
+
+		return theme.getName();
 	}
 
 	private void _setViewAttributes() {

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -76,7 +76,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.portlet.PortletURL;
-import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import javax.servlet.http.HttpServletRequest;
@@ -92,7 +91,7 @@ public class EditStyleBookEntryDisplayContext {
 			fragmentCollectionContributorRegistry,
 		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
 		HttpServletRequest httpServletRequest, ItemSelector itemSelector,
-		RenderRequest renderRequest, RenderResponse renderResponse) {
+		RenderResponse renderResponse) {
 
 		_cetManager = cetManager;
 		_fragmentCollectionContributorRegistry =
@@ -100,7 +99,6 @@ public class EditStyleBookEntryDisplayContext {
 		_frontendTokenDefinitionRegistry = frontendTokenDefinitionRegistry;
 		_httpServletRequest = httpServletRequest;
 		_itemSelector = itemSelector;
-		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
@@ -629,7 +627,6 @@ public class EditStyleBookEntryDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private final ItemSelector _itemSelector;
 	private Long _previewItemsGroupId;
-	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private StyleBookEntry _styleBookEntry;
 	private Long _styleBookEntryId;

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -5,6 +5,8 @@
 
 package com.liferay.style.book.web.internal.display.context;
 
+import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.fragment.collection.item.selector.FragmentCollectionItemSelectorReturnType;
 import com.liferay.fragment.collection.item.selector.criterion.FragmentCollectionItemSelectorCriterion;
 import com.liferay.fragment.contributor.FragmentCollectionContributor;
@@ -30,12 +32,12 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.Theme;
@@ -46,9 +48,9 @@ import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -65,7 +67,6 @@ import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalServiceUtil;
-import com.liferay.style.book.web.internal.constants.StyleBookWebKeys;
 
 import java.util.Collections;
 import java.util.List;
@@ -83,21 +84,22 @@ import javax.servlet.http.HttpServletRequest;
 public class EditStyleBookEntryDisplayContext {
 
 	public EditStyleBookEntryDisplayContext(
-		HttpServletRequest httpServletRequest, RenderRequest renderRequest,
-		RenderResponse renderResponse) {
+		CETManager cetManager,
+		FragmentCollectionContributorRegistry
+			fragmentCollectionContributorRegistry,
+		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
+		HttpServletRequest httpServletRequest, ItemSelector itemSelector,
+		RenderRequest renderRequest, RenderResponse renderResponse) {
 
+		_cetManager = cetManager;
+		_fragmentCollectionContributorRegistry =
+			fragmentCollectionContributorRegistry;
+		_frontendTokenDefinitionRegistry = frontendTokenDefinitionRegistry;
 		_httpServletRequest = httpServletRequest;
+		_itemSelector = itemSelector;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 
-		_fragmentCollectionContributorRegistry =
-			(FragmentCollectionContributorRegistry)renderRequest.getAttribute(
-				StyleBookWebKeys.FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER);
-		_frontendTokenDefinitionRegistry =
-			(FrontendTokenDefinitionRegistry)renderRequest.getAttribute(
-				FrontendTokenDefinitionRegistry.class.getName());
-		_itemSelector = (ItemSelector)renderRequest.getAttribute(
-			ItemSelector.class.getName());
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -299,13 +301,9 @@ public class EditStyleBookEntryDisplayContext {
 	private JSONObject _getFrontendTokenDefinitionJSONObject()
 		throws Exception {
 
-		Group group = _themeDisplay.getScopeGroup();
-
 		FrontendTokenDefinition frontendTokenDefinition =
 			_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
-				LayoutSetLocalServiceUtil.fetchLayoutSet(
-					_themeDisplay.getSiteGroupId(),
-					group.isLayoutSetPrototype()));
+				_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
 
 		if (frontendTokenDefinition != null) {
 			return frontendTokenDefinition.getJSONObject(
@@ -574,14 +572,26 @@ public class EditStyleBookEntryDisplayContext {
 	}
 
 	private String _getThemeName() {
-		Group group = _themeDisplay.getScopeGroup();
+		Theme theme = ThemeLocalServiceUtil.fetchTheme(
+			_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
+		String name = _styleBookEntry.getThemeId();
 
-		LayoutSet layoutSet = LayoutSetLocalServiceUtil.fetchLayoutSet(
-			_themeDisplay.getSiteGroupId(), group.isLayoutSetPrototype());
+		if (theme != null) {
+			name = LanguageUtil.format(
+				_httpServletRequest, "x-theme", theme.getName());
+		}
+		else {
+			CET cet = _cetManager.getCET(
+				_themeDisplay.getCompanyId(), _styleBookEntry.getThemeId());
 
-		Theme theme = layoutSet.getTheme();
+			if (cet != null) {
+				name = LanguageUtil.format(
+					_httpServletRequest, "x-theme-css-client-extension",
+					cet.getName());
+			}
+		}
 
-		return theme.getName();
+		return name;
 	}
 
 	private void _setViewAttributes() {
@@ -597,6 +607,7 @@ public class EditStyleBookEntryDisplayContext {
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditStyleBookEntryDisplayContext.class.getName());
 
+	private final CETManager _cetManager;
 	private final FragmentCollectionContributorRegistry
 		_fragmentCollectionContributorRegistry;
 	private final FrontendTokenDefinitionRegistry

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -300,7 +300,7 @@ public class EditStyleBookEntryDisplayContext {
 	private JSONObject _getFrontendTokenDefinitionJSONObject()
 		throws Exception {
 
-		FrontendTokenDefinition frontendTokenDefinition;
+		FrontendTokenDefinition frontendTokenDefinition = null;
 
 		if (FeatureFlagManagerUtil.isEnabled("LPD-30204")) {
 			frontendTokenDefinition =

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/StyleBookManagementToolbarDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/StyleBookManagementToolbarDisplayContext.java
@@ -5,7 +5,6 @@
 
 package com.liferay.style.book.web.internal.display.context;
 
-import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.taglib.clay.servlet.taglib.display.context.SearchContainerManagementToolbarDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
@@ -17,17 +16,16 @@ import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.constants.StyleBookActionKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.web.internal.security.permissions.resource.StyleBookPermission;
+import com.liferay.style.book.web.internal.util.StyleBookUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -223,31 +221,13 @@ public class StyleBookManagementToolbarDisplayContext
 				_frontendTokenDefinitionRegistry.getFrontendTokenDefinitions(
 					_themeDisplay.getCompanyId())) {
 
-			String name = frontendTokenDefinition.getThemeId();
-
-			Theme theme = ThemeLocalServiceUtil.fetchTheme(
-				_themeDisplay.getCompanyId(),
-				frontendTokenDefinition.getThemeId());
-
-			if (theme != null) {
-				name = LanguageUtil.format(
-					httpServletRequest, "x-theme", theme.getName());
-			}
-			else {
-				CET cet = _cetManager.getCET(
-					_themeDisplay.getCompanyId(),
-					frontendTokenDefinition.getThemeId());
-
-				if (cet != null) {
-					name = LanguageUtil.format(
-						httpServletRequest, "x-theme-css-client-extension",
-						cet.getName());
-				}
-			}
-
 			frontendTokenDefinitionProviders.add(
 				HashMapBuilder.<String, Object>put(
-					"name", name
+					"name",
+					StyleBookUtil.getThemeName(
+						_cetManager, _themeDisplay.getCompanyId(),
+						httpServletRequest,
+						frontendTokenDefinition.getThemeId())
 				).put(
 					"themeId", frontendTokenDefinition.getThemeId()
 				).build());

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/EditStyleBookEntryMVCRenderCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/EditStyleBookEntryMVCRenderCommand.java
@@ -5,11 +5,16 @@
 
 package com.liferay.style.book.web.internal.portlet.action;
 
+import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.site.provider.GroupURLProvider;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
+import com.liferay.style.book.web.internal.constants.StyleBookWebKeys;
+import com.liferay.style.book.web.internal.display.context.EditStyleBookEntryDisplayContext;
 
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -34,14 +39,38 @@ public class EditStyleBookEntryMVCRenderCommand implements MVCRenderCommand {
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
 		renderRequest.setAttribute(
+			StyleBookWebKeys.FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER,
+			_fragmentCollectionContributorRegistry);
+		renderRequest.setAttribute(
+			StyleBookWebKeys.ITEM_SELECTOR, _itemSelector);
+
+		renderRequest.setAttribute(
 			FrontendTokenDefinitionRegistry.class.getName(),
 			_frontendTokenDefinitionRegistry);
 		renderRequest.setAttribute(ItemSelector.class.getName(), _itemSelector);
 		renderRequest.setAttribute(
 			GroupURLProvider.class.getName(), _groupURLProvider);
 
+		EditStyleBookEntryDisplayContext editStyleBookEntryDisplayContext =
+			new EditStyleBookEntryDisplayContext(
+				_cetManager, _fragmentCollectionContributorRegistry,
+				_frontendTokenDefinitionRegistry,
+				_portal.getHttpServletRequest(renderRequest), _itemSelector,
+				renderRequest, renderResponse);
+
+		renderRequest.setAttribute(
+			EditStyleBookEntryDisplayContext.class.getName(),
+			editStyleBookEntryDisplayContext);
+
 		return "/edit_style_book_entry.jsp";
 	}
+
+	@Reference
+	private CETManager _cetManager;
+
+	@Reference
+	private FragmentCollectionContributorRegistry
+		_fragmentCollectionContributorRegistry;
 
 	@Reference
 	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;
@@ -51,5 +80,8 @@ public class EditStyleBookEntryMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private ItemSelector _itemSelector;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/EditStyleBookEntryMVCRenderCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/EditStyleBookEntryMVCRenderCommand.java
@@ -36,16 +36,13 @@ public class EditStyleBookEntryMVCRenderCommand implements MVCRenderCommand {
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
-		EditStyleBookEntryDisplayContext editStyleBookEntryDisplayContext =
+		renderRequest.setAttribute(
+			EditStyleBookEntryDisplayContext.class.getName(),
 			new EditStyleBookEntryDisplayContext(
 				_cetManager, _fragmentCollectionContributorRegistry,
 				_frontendTokenDefinitionRegistry,
 				_portal.getHttpServletRequest(renderRequest), _itemSelector,
-				renderResponse);
-
-		renderRequest.setAttribute(
-			EditStyleBookEntryDisplayContext.class.getName(),
-			editStyleBookEntryDisplayContext);
+				renderResponse));
 
 		return "/edit_style_book_entry.jsp";
 	}

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/EditStyleBookEntryMVCRenderCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/EditStyleBookEntryMVCRenderCommand.java
@@ -11,9 +11,7 @@ import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.site.provider.GroupURLProvider;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
-import com.liferay.style.book.web.internal.constants.StyleBookWebKeys;
 import com.liferay.style.book.web.internal.display.context.EditStyleBookEntryDisplayContext;
 
 import javax.portlet.RenderRequest;
@@ -38,25 +36,12 @@ public class EditStyleBookEntryMVCRenderCommand implements MVCRenderCommand {
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
-		renderRequest.setAttribute(
-			StyleBookWebKeys.FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER,
-			_fragmentCollectionContributorRegistry);
-		renderRequest.setAttribute(
-			StyleBookWebKeys.ITEM_SELECTOR, _itemSelector);
-
-		renderRequest.setAttribute(
-			FrontendTokenDefinitionRegistry.class.getName(),
-			_frontendTokenDefinitionRegistry);
-		renderRequest.setAttribute(ItemSelector.class.getName(), _itemSelector);
-		renderRequest.setAttribute(
-			GroupURLProvider.class.getName(), _groupURLProvider);
-
 		EditStyleBookEntryDisplayContext editStyleBookEntryDisplayContext =
 			new EditStyleBookEntryDisplayContext(
 				_cetManager, _fragmentCollectionContributorRegistry,
 				_frontendTokenDefinitionRegistry,
 				_portal.getHttpServletRequest(renderRequest), _itemSelector,
-				renderRequest, renderResponse);
+				renderResponse);
 
 		renderRequest.setAttribute(
 			EditStyleBookEntryDisplayContext.class.getName(),
@@ -74,9 +59,6 @@ public class EditStyleBookEntryMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;
-
-	@Reference
-	private GroupURLProvider _groupURLProvider;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/util/StyleBookUtil.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/util/StyleBookUtil.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.web.internal.util;
+
+import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Theme;
+import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Evan Thibodeau
+ */
+public class StyleBookUtil {
+
+	public static String getThemeName(
+		CETManager cetManager, long companyId,
+		HttpServletRequest httpServletRequest, String themeId) {
+
+		String name = themeId;
+
+		Theme theme = ThemeLocalServiceUtil.fetchTheme(companyId, themeId);
+
+		if (theme != null) {
+			name = LanguageUtil.format(
+				httpServletRequest, "x-theme", theme.getName());
+		}
+		else {
+			CET cet = cetManager.getCET(companyId, themeId);
+
+			if (cet != null) {
+				name = LanguageUtil.format(
+					httpServletRequest, "x-theme-css-client-extension",
+					cet.getName());
+			}
+		}
+
+		return name;
+	}
+
+}

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/edit_style_book_entry.jsp
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/edit_style_book_entry.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-EditStyleBookEntryDisplayContext editStyleBookEntryDisplayContext = new EditStyleBookEntryDisplayContext(request, renderRequest, renderResponse);
+EditStyleBookEntryDisplayContext editStyleBookEntryDisplayContext = (EditStyleBookEntryDisplayContext)request.getAttribute(EditStyleBookEntryDisplayContext.class.getName());
 %>
 
 <div>

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/Sidebar.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/Sidebar.js
@@ -60,33 +60,25 @@ function UpdateStyle({sidebarRef}) {
 
 function ThemeInformation() {
 	return (
-		<div className="pb-3">
+		<div className="pb-1">
 			<p className="small text-secondary">
-				{IsValidFrontendTokenDefinition() ? (
-					config.isPrivateLayoutsEnabled ? (
-						Liferay.Language.get(
-							'this-token-definition-belongs-to-the-theme-set-for-public-pages'
-						)
-					) : (
-						Liferay.Language.get(
-							'this-token-definition-belongs-to-the-theme-set-for-pages'
-						)
-					)
-				) : (
+				{!IsValidFrontendTokenDefinition() ? (
 					<ClayAlert className="m-0" displayType="warning">
 						{Liferay.Language.get(
 							'the-current-theme-does-not-support-editing-style-book-values'
 						)}
 					</ClayAlert>
+				) : (
+					<p className="text-dark">
+						<p className="font-weight-bold mb-1">
+							{`${Liferay.Language.get(
+								'frontend-token-definition-provided-by'
+							)}`}
+						</p>
+
+						<p>{config.themeName}</p>
+					</p>
 				)}
-			</p>
-
-			<p className="mb-0 small">
-				<span className="font-weight-semi-bold">
-					{`${Liferay.Language.get('theme')}: `}
-				</span>
-
-				{config.themeName}
 			</p>
 		</div>
 	);

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/Sidebar.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/Sidebar.js
@@ -59,29 +59,64 @@ function UpdateStyle({sidebarRef}) {
 }
 
 function ThemeInformation() {
-	return (
-		<div className="pb-1">
-			<p className="small text-secondary">
-				{!IsValidFrontendTokenDefinition() ? (
-					<ClayAlert className="m-0" displayType="warning">
-						{Liferay.Language.get(
-							'the-current-theme-does-not-support-editing-style-book-values'
-						)}
-					</ClayAlert>
-				) : (
-					<p className="text-dark">
-						<p className="font-weight-bold mb-1">
-							{`${Liferay.Language.get(
-								'frontend-token-definition-provided-by'
-							)}`}
-						</p>
+	if (Liferay?.FeatureFlags?.['LPD-30204']) {
+		return (
+			<div className="pb-1">
+				<p className="small text-secondary">
+					{!IsValidFrontendTokenDefinition() ? (
+						<ClayAlert className="m-0" displayType="warning">
+							{Liferay.Language.get(
+								'the-current-theme-does-not-support-editing-style-book-values'
+							)}
+						</ClayAlert>
+					) : (
+						<p className="text-dark">
+							<p className="font-weight-bold mb-1">
+								{`${Liferay.Language.get(
+									'frontend-token-definition-provided-by'
+								)}`}
+							</p>
 
-						<p>{config.themeName}</p>
-					</p>
-				)}
-			</p>
-		</div>
-	);
+							<p>{config.themeName}</p>
+						</p>
+					)}
+				</p>
+			</div>
+		);
+	}
+	else {
+		return (
+			<div className="pb-1">
+				<p className="small text-secondary">
+					{IsValidFrontendTokenDefinition() ? (
+						config.isPrivateLayoutsEnabled ? (
+							Liferay.Language.get(
+								'this-token-definition-belongs-to-the-theme-set-for-public-pages'
+							)
+						) : (
+							Liferay.Language.get(
+								'this-token-definition-belongs-to-the-theme-set-for-pages'
+							)
+						)
+					) : (
+						<ClayAlert className="m-0" displayType="warning">
+							{Liferay.Language.get(
+								'the-current-theme-does-not-support-editing-style-book-values'
+							)}
+						</ClayAlert>
+					)}
+				</p>
+
+				<p className="mb-0 small">
+					<span className="font-weight-semi-bold">
+						{`${Liferay.Language.get('theme')}: `}
+					</span>
+
+					{config.themeName}
+				</p>
+			</div>
+		);
+	}
 }
 
 function IsValidFrontendTokenDefinition() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-35071

_Original Message_

## Goal
To provide show the frontend tokens from the selected frontend token definition when editing a style book.

## Approach
Use a new getFrontendTokenDefinition method to retrieve the frontend token definition from the companyId and themeId and. use this to display the token definitions for the selected theme/theme css cx. Also, display the correct theme name in the sidebar. 

![Screenshot 2025-01-15 at 12 52 41 PM](https://github.com/user-attachments/assets/77e26d6a-30c2-4850-8538-bf6127a85863)

