### PR TITLE
LPD-47175 Draft status is not used in KaleoDefinition and KaleoDefinitionVersion table

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionVersionLocalServiceImpl.java
@@ -495,9 +495,11 @@ public class KaleoDefinitionVersionLocalServiceImpl
 			booleanQuery.addMustQueryClauses(keywordsBooleanQuery);
 		}
 
-		if (status != WorkflowConstants.STATUS_ANY) {
-			booleanQuery.addMustQueryClauses(
-				_queries.term(Field.STATUS, status));
+		if (status == WorkflowConstants.STATUS_APPROVED) {
+			booleanQuery.addMustQueryClauses(_queries.term("active", 1));
+		}
+		else if (status == WorkflowConstants.STATUS_DRAFT) {
+			booleanQuery.addMustQueryClauses(_queries.term("active", 0));
 		}
 
 		searchSearchRequest.setQuery(booleanQuery);


### PR DESCRIPTION
Related: [LPD-47175](https://liferay.atlassian.net/browse/LPD-47175)

[LPD-47175]: https://liferay.atlassian.net/browse/LPD-47175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test fix: ProcessBuilderListView#CanFilterByNonPublishedProcesses