### PR TITLE
LPD-47149 Column type mismatch after upgrade in DDMTemplate

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -40,6 +40,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.7.0
+Liferay-Require-SchemaVersion: 7.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -653,8 +653,12 @@ public class DDMServiceUpgradeStepRegistrator
 					_fileEntryFriendlyURLResolver, _groupLocalService,
 					_userLocalService));
 
+		registry.register("5.6.1", "5.7.0", new DummyUpgradeStep());
+
+		registry.register("5.7.0", "6.0.0", new DummyUpgradeStep());
+
 		registry.register(
-			"5.6.1", "5.7.0",
+			"6.0.0", "6.1.0",
 			new BaseExternalReferenceCodeUpgradeProcess() {
 
 				@Override
@@ -663,6 +667,11 @@ public class DDMServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"6.1.0", "7.0.0",
+			UpgradeProcessFactory.alterColumnType(
+				"DDMTemplate", "name", "TEXT null"));
 	}
 
 	@Activate


### PR DESCRIPTION
[LPD-47149](https://liferay.atlassian.net/browse/LPD-47149)

I had to create a dummy upgrade because I need to send it to [release-2024.q4](https://github.com/liferay/liferay-portal-ee/blob/release-2024.q4/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java#L593)

[LPD-47149]: https://liferay.atlassian.net/browse/LPD-47149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ