### PR TITLE
LPD-46477 - Remove moment.js

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/package.json
+++ b/modules/apps/data-engine/data-engine-js-components-web/package.json
@@ -18,7 +18,6 @@
 		"classnames": "2.3.1",
 		"dom-align": "1.12.2",
 		"frontend-js-web": "*",
-		"moment": "2.29.4",
 		"react": "18.2.0",
 		"react-dnd": "11.1.1",
 		"react-dnd-html5-backend": "11.1.1",

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/list/List.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/list/List.js
@@ -4,7 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import moment from 'moment/min/moment-with-locales';
+import {dateUtils} from 'frontend-js-web';
 import React, {useContext, useEffect} from 'react';
 
 import {removeEmptyValues} from '../../utils/data';
@@ -25,13 +25,14 @@ export default function List({data, field, summary, totalEntries, type}) {
 
 	const formatDate = (field, isDateTime) => {
 		const locale = themeDisplay.getLanguageId().split('_', 1).join('');
-		const date = moment(field).locale(locale).format('L');
+
+		const date = dateUtils.format(field, 'P', locale);
 
 		if (!isDateTime) {
 			return date;
 		}
 
-		const time = moment(field).locale(locale).format('LT');
+		const time = dateUtils.format(field, 'p', locale);
 
 		return `${date} ${time}`;
 	};

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/date.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/date.es.js
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import moment from 'moment/min/moment-with-locales';
+import {dateUtils} from 'frontend-js-web';
 
 export function formatDate(date, locale) {
-	const dateFormat = moment.localeData(locale).longDateFormat('L');
-
-	return moment(date).format(dateFormat);
+	return dateUtils.format(date, 'P', locale);
 }
 
 export function parseDate(locale, value) {
-	const dateFormat = moment.localeData(locale).longDateFormat('L');
-
-	return moment(value, dateFormat).toDate();
+	return dateUtils.parse(value, 'P', locale);
 }

--- a/modules/apps/digital-signature/digital-signature-web/package.json
+++ b/modules/apps/digital-signature/digital-signature-web/package.json
@@ -21,7 +21,6 @@
 		"frontend-js-web": "*",
 		"history": "4.9.0",
 		"image-promise": "^5.0.1",
-		"moment": "2.29.4",
 		"prop-types": "15.7.2",
 		"qs": "^6.9.6",
 		"react": "18.2.0",

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeList.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeList.js
@@ -13,7 +13,7 @@ import {Link} from 'react-router-dom';
 import {AppContext} from '../../AppContext';
 import ListView from '../../components/list-view/ListView';
 import {DOCUSIGN_STATUS} from '../../utils/contants';
-import {toDateFromNow} from '../../utils/moment';
+import {toDateFromNow} from '../../utils/date';
 
 const COLUMNS = [
 	{

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeView.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeView.js
@@ -19,7 +19,7 @@ import {AppContext} from '../../AppContext';
 import {BackButtonPortal} from '../../components/control-menu/ControlMenu';
 import DocumentPreviewerWrapper from '../../components/document-previewer/DocumentPreviewerWrapper';
 import {DOCUSIGN_STATUS} from '../../utils/contants';
-import {toLocalDateTimeFormatted} from '../../utils/moment';
+import {toLocalDateTimeFormatted} from '../../utils/date';
 import {concatValues} from '../../utils/utils';
 
 const QuestionLine = ({children, className, colon = true, question}) => (

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/utils/date.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/utils/date.js
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {dateUtils} from 'frontend-js-web';
+
+const getLanguage = () => {
+	const language = Liferay.ThemeDisplay.getBCP47LanguageId();
+
+	const languages = {
+		'zh-Hans-CN': 'zh-CN',
+	};
+
+	return languages[language] || language;
+};
+
+export function toDateFromNow(date) {
+	return dateUtils.fromNow(new Date(date));
+}
+
+export function toLocalDateTimeFormatted(date) {
+	return dateUtils.format(new Date(date), 'P p', getLanguage());
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -28,7 +28,6 @@
 		"frontend-editor-ckeditor-web": "*",
 		"frontend-js-web": "*",
 		"leaflet": "1.7.1",
-		"moment": "2.29.4",
 		"react": "18.2.0",
 		"react-dnd": "11.1.1",
 		"react-dnd-html5-backend": "11.1.1",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -6,7 +6,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import moment from 'moment';
+import {dateUtils} from 'frontend-js-web';
 import React from 'react';
 
 import DatePicker from '../../../src/main/resources/META-INF/resources/DatePicker/DatePicker.es';
@@ -72,7 +72,7 @@ describe('DatePicker', () => {
 		fireEvent.click(getByLabelText('select-current-date'));
 
 		expect(screen.getByRole('textbox', {hidden: true})).toHaveValue(
-			moment().format('MM/DD/YYYY')
+			dateUtils.format(new Date(), 'MM/dd/yyyy')
 		);
 	});
 
@@ -88,7 +88,7 @@ describe('DatePicker', () => {
 
 		expect(onChange).toHaveBeenCalledWith(
 			{},
-			moment().format('YYYY-MM-DD')
+			dateUtils.format(new Date(), 'yyyy-MM-dd')
 		);
 	});
 
@@ -101,7 +101,7 @@ describe('DatePicker', () => {
 		fireEvent.click(screen.getByLabelText('select-current-date'));
 
 		expect(screen.getByRole('textbox', {hidden: true})).toHaveValue(
-			moment().format('YYYY/MM/DD')
+			dateUtils.format(new Date(), 'yyyy/MM/dd')
 		);
 	});
 
@@ -162,8 +162,13 @@ describe('DatePicker', () => {
 		userEvent.type(hours, '23');
 		userEvent.type(minutes, '30');
 
+		const date = new Date();
+
+		date.setHours(23);
+		date.setMinutes(30);
+
 		expect(container.querySelector('[type=text]')).toHaveValue(
-			moment().format('DD/MM/YYYY [23:30]')
+			dateUtils.format(date, 'P p', 'pr_BR')
 		);
 	});
 
@@ -188,9 +193,14 @@ describe('DatePicker', () => {
 		userEvent.type(minutes, '30');
 		fireEvent.keyDown(sufix, {code: 'ArrowUp', key: 'ArrowUp'}); // PM
 
+		const date = new Date();
+
+		date.setHours(11);
+		date.setMinutes(30);
+
 		expect(onChange).toHaveBeenCalledWith(
 			{},
-			moment().format('YYYY-MM-DD [23:30]')
+			dateUtils.format(date, 'P p', 'pr_BR')
 		);
 	});
 });

--- a/modules/apps/object/object-js-components-web/package.json
+++ b/modules/apps/object/object-js-components-web/package.json
@@ -24,7 +24,6 @@
 		"frontend-editor-ckeditor-web": "*",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
-		"moment": "2.29.4",
 		"react": "18.2.0",
 		"react-dnd": "11.1.1",
 		"react-dnd-html5-backend": "11.1.1",

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/DatePicker.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/DatePicker.tsx
@@ -5,16 +5,13 @@
 
 import ClayDatePicker from '@clayui/date-picker';
 import {FieldBase} from 'frontend-js-components-web';
-
-// @ts-ignore
-
-import moment from 'moment/min/moment-with-locales';
+import {dateUtils} from 'frontend-js-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createTextMaskInputElement} from 'text-mask-core';
 
 import {createAutoCorrectedDatePipe} from '../utils/createAutoCorrectedDatePipe';
 import {
-	Date,
+	type DateData,
 	generateDate,
 	generateDateConfigurations,
 	generateInputMask,
@@ -53,8 +50,6 @@ type DateMaskParams = {
 	clayFormat?: string;
 	firstDayOfWeek?: FirstDayOfWeek;
 	isDateTime?: boolean;
-	momentFormat?: string;
-	months?: string[];
 	placeholder?: string;
 	serverFormat?: string;
 	use12Hours?: boolean;
@@ -88,9 +83,10 @@ export function DatePicker({
 }: DatePickerProps) {
 	const [expanded, setExpanded] = useState(false);
 
-	const momentLocale = moment().locale(locale ?? defaultLanguageId);
-	const months = momentLocale.localeData().months();
-	const weekdaysShort = momentLocale.localeData().weekdaysShort();
+	const months = dateUtils.getMonthsLong(locale ?? defaultLanguageId);
+	const weekdaysShort = dateUtils.getWeekdaysShort(
+		locale ?? defaultLanguageId
+	);
 
 	const inputRef = useRef(null);
 	const maskRef = useRef<null | MaskRef>(null);
@@ -98,7 +94,6 @@ export function DatePicker({
 		clayFormat,
 		firstDayOfWeek,
 		isDateTime = false,
-		momentFormat = '',
 		placeholder,
 		serverFormat = '',
 		use12Hours,
@@ -114,17 +109,33 @@ export function DatePicker({
 		return dateMaskParameters;
 	}, [defaultLanguageId, locale, type]);
 
-	const date: Date = useMemo(() => {
+	const date: DateData = useMemo(() => {
 		let formattedDate = '';
-		let year = moment().year();
+		let year = new Date().getFullYear();
 		const rawDate = value ?? '';
 
 		if (rawDate !== '') {
-			const date = moment(rawDate, serverFormat, true);
-			formattedDate = date
-				.locale(locale ?? defaultLanguageId)
-				.format(momentFormat);
-			year = date.year();
+			const parsedDate = new Date(rawDate);
+
+			if (!isNaN(parsedDate.getTime())) {
+				const options: Intl.DateTimeFormatOptions = isDateTime
+					? {
+							day: '2-digit',
+							hour: '2-digit',
+							hour12: use12Hours,
+							minute: '2-digit',
+							month: '2-digit',
+							year: 'numeric',
+						}
+					: {
+							day: '2-digit',
+							month: '2-digit',
+							year: 'numeric',
+						};
+
+				formattedDate = parsedDate.toLocaleDateString(locale, options);
+				year = parsedDate.getFullYear();
+			}
 		}
 
 		return {
@@ -135,7 +146,15 @@ export function DatePicker({
 			value,
 			years: {end: year + 5, start: year - 5},
 		};
-	}, [momentFormat, defaultLanguageId, locale, name, serverFormat, value]);
+	}, [
+		defaultLanguageId,
+		isDateTime,
+		locale,
+		name,
+		serverFormat,
+		use12Hours,
+		value,
+	]);
 
 	const [{formattedDate, rawDate, years}, setDate] = useState(date);
 
@@ -155,7 +174,7 @@ export function DatePicker({
 	 * Creates the input mask and update it whenever the format changes
 	 */
 	useEffect(() => {
-		const {mask, pipeFormat} = generateInputMask(momentFormat);
+		const {mask, pipeFormat} = generateInputMask(clayFormat as any);
 
 		maskRef.current = createTextMaskInputElement({
 			guide: true,
@@ -165,12 +184,11 @@ export function DatePicker({
 			pipe: createAutoCorrectedDatePipe(pipeFormat),
 			showMask: true,
 		});
-	}, [momentFormat]);
+	}, [clayFormat]);
 
 	const handleValueChange = (value: string) => {
 		const nextState = generateDate({
 			isDateTime,
-			momentFormat,
 			serverFormat,
 			value,
 		});

--- a/modules/apps/object/object-web/package.json
+++ b/modules/apps/object/object-web/package.json
@@ -23,7 +23,6 @@
 		"classnames": "2.3.1",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
-		"moment": "2.29.4",
 		"react": "18.2.0",
 		"react-flow-renderer": "9.7.0",
 		"text-mask-core": "^5.1.2"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/Validations.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/Validations.tsx
@@ -4,10 +4,7 @@
  */
 
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
-
-// @ts-ignore
-
-import moment from 'moment/min/moment-with-locales';
+import {dateUtils} from 'frontend-js-web';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {defaultFDSDataSetProps, formatActionURL} from '../../utils/fds';
@@ -27,8 +24,6 @@ function ObjectFieldActiveDataRenderer({itemData}: {itemData: ItemData}) {
 		? Liferay.Language.get('yes')
 		: Liferay.Language.get('no');
 }
-
-const language = Liferay.ThemeDisplay.getBCP47LanguageId();
 
 interface ValidationsProps extends IFDSTableProps {
 	allowScriptContentToBeExecutedOrIncluded: boolean;
@@ -74,9 +69,7 @@ export default function Validations({
 	}
 
 	function ObjectFieldModifiedDateDataRenderer() {
-		moment.locale(language);
-
-		return moment().format('MMMM D, YYYY, h:mm:ss A');
+		return dateUtils.format(new Date(), 'PP p');
 	}
 
 	const frontendDataSetProps = {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/package.json
@@ -18,7 +18,6 @@
 		"frontend-editor-ckeditor-web": "*",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
-		"moment": "2.29.4",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",
 		"react-flow-renderer": "9.7.0",


### PR DESCRIPTION
Hey, we are in the process of removing moment.js and date-fns from all of liferay-portal and replacement with our internal utilities. This significantly reduces total bytes sent to the client.

Please review this PR and make sure we didn't miss anything.

One note, we didn't update uses in
`dynamic-data-mapping-form-field-type`
`object-js-components-web`
`portal-workflow-metrics-web`

The complexity of the use cases of moment.js in these modules seemed like it was best for your team to tackle since you have the inner knowledge of the components. Please address those as soon as possible