### PR TITLE
LPD-47628 Implement isApplicable method in order to make the notification inactionable when viewed in a different publication

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandler.java
@@ -12,6 +12,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
@@ -92,6 +93,44 @@ public class WorkflowTaskUserNotificationHandler
 	}
 
 	@Override
+	public boolean isApplicable(
+		UserNotificationEvent userNotificationEvent,
+		ServiceContext serviceContext) {
+
+		JSONObject jsonObject = null;
+
+		try {
+			jsonObject = _jsonFactory.createJSONObject(
+				userNotificationEvent.getPayload());
+		}
+		catch (JSONException jsonException) {
+			_log.error(jsonException);
+		}
+
+		if (jsonObject == null) {
+			return false;
+		}
+
+		long ctCollectionId = jsonObject.getLong(
+			WorkflowConstants.CONTEXT_CT_COLLECTION_ID);
+
+		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
+			ctCollectionId);
+
+		if ((ctCollection != null) &&
+			(ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
+
+			ctCollectionId = CTConstants.CT_COLLECTION_ID_PRODUCTION;
+		}
+
+		if (ctCollectionId == CTCollectionThreadLocal.getCTCollectionId()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	protected String getBody(
 			UserNotificationEvent userNotificationEvent,
 			ServiceContext serviceContext)
@@ -113,19 +152,7 @@ public class WorkflowTaskUserNotificationHandler
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			userNotificationEvent.getPayload());
 
-		long ctCollectionId = jsonObject.getLong(
-			WorkflowConstants.CONTEXT_CT_COLLECTION_ID);
-
-		CTCollection ctCollection = _ctCollectionLocalService.fetchCTCollection(
-			ctCollectionId);
-
-		if ((ctCollection != null) &&
-			(ctCollection.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
-
-			ctCollectionId = CTConstants.CT_COLLECTION_ID_PRODUCTION;
-		}
-
-		if (ctCollectionId != CTCollectionThreadLocal.getCTCollectionId()) {
+		if (!isApplicable(userNotificationEvent, serviceContext)) {
 			return StringPool.BLANK;
 		}
 
@@ -136,7 +163,9 @@ public class WorkflowTaskUserNotificationHandler
 		long workflowTaskId = jsonObject.getLong("workflowTaskId");
 
 		if ((workflowHandler == null) ||
-			!_hasPermission(ctCollectionId, workflowTaskId, serviceContext)) {
+			!_hasPermission(
+				jsonObject.getLong(WorkflowConstants.CONTEXT_CT_COLLECTION_ID),
+				workflowTaskId, serviceContext)) {
 
 			return StringPool.BLANK;
 		}

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/notifications/WorkflowTaskUserNotificationHandlerTest.java
@@ -6,9 +6,11 @@
 package com.liferay.portal.workflow.task.web.internal.notifications;
 
 import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -141,6 +143,24 @@ public class WorkflowTaskUserNotificationHandlerTest {
 				mockUserNotificationEvent(
 					_VALID_ENTRY_CLASS_NAME, null, _INVALID_WORKFLOW_TASK_ID),
 				_serviceContext));
+	}
+
+	@Test
+	public void testIsApplicable() {
+		Assert.assertTrue(
+			_workflowTaskUserNotificationHandler.isApplicable(
+				mockUserNotificationEvent(null, "Sample Object", 0),
+				_serviceContext));
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					RandomTestUtil.randomInt())) {
+
+			Assert.assertFalse(
+				_workflowTaskUserNotificationHandler.isApplicable(
+					mockUserNotificationEvent(null, "Sample Object", 0),
+					_serviceContext));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Related ticket: [LPD-47628](https://liferay.atlassian.net/browse/LPD-47628)

[LPD-47628]: https://liferay.atlassian.net/browse/LPD-47628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ