### PR TITLE
LPD-47585 Data too long for column 'body' at row 1 error on Notification template body

### DIFF
--- a/modules/apps/notification/notification-service/bnd.bnd
+++ b/modules/apps/notification/notification-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Notification Service
 Bundle-SymbolicName: com.liferay.notification.service
 Bundle-Version: 1.0.87
-Liferay-Require-SchemaVersion: 3.10.4
+Liferay-Require-SchemaVersion: 4.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/registry/NotificationUpgradeStepRegistrator.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/registry/NotificationUpgradeStepRegistrator.java
@@ -156,6 +156,11 @@ public class NotificationUpgradeStepRegistrator
 			new DeleteStaleNotificationQueueEntriesAndNotificationTemplatesUpgradeProcess(
 				_classNameLocalService, _groupLocalService,
 				_portletFileRepository, _resourcePermissionLocalService));
+
+		registry.register(
+			"3.10.4", "4.0.0",
+			UpgradeProcessFactory.alterColumnType(
+				"NotificationQueueEntry", "body", "TEXT null"));
 	}
 
 	@Reference


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPD-47585