### PR TITLE
LPD-50184 When the asset library is deleted, remove its groupId from the acceptedGroupIds setting

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionSettingLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionSettingLocalService.java
@@ -235,6 +235,11 @@ public interface ObjectDefinitionSettingLocalService
 			long objectDefinitionSettingId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectDefinitionSetting getObjectDefinitionSetting(
+			long objectDefinitionId, String name)
+		throws PortalException;
+
 	/**
 	 * Returns the object definition setting with the matching UUID and company.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionSettingLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionSettingLocalServiceUtil.java
@@ -272,6 +272,14 @@ public class ObjectDefinitionSettingLocalServiceUtil {
 			objectDefinitionSettingId);
 	}
 
+	public static ObjectDefinitionSetting getObjectDefinitionSetting(
+			long objectDefinitionId, String name)
+		throws PortalException {
+
+		return getService().getObjectDefinitionSetting(
+			objectDefinitionId, name);
+	}
+
 	/**
 	 * Returns the object definition setting with the matching UUID and company.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionSettingLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionSettingLocalServiceWrapper.java
@@ -308,6 +308,15 @@ public class ObjectDefinitionSettingLocalServiceWrapper
 			objectDefinitionSettingId);
 	}
 
+	@Override
+	public com.liferay.object.model.ObjectDefinitionSetting
+			getObjectDefinitionSetting(long objectDefinitionId, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectDefinitionSettingLocalService.getObjectDefinitionSetting(
+			objectDefinitionId, name);
+	}
+
 	/**
 	 * Returns the object definition setting with the matching UUID and company.
 	 *

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/GroupModelListener.java
@@ -5,10 +5,13 @@
 
 package com.liferay.object.internal.model.listener;
 
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
@@ -18,6 +21,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import org.osgi.service.component.annotations.Component;
@@ -51,6 +56,10 @@ public class GroupModelListener extends BaseModelListener<Group> {
 
 		try {
 			actionableDynamicQuery.performActions();
+
+			if (group.isDepot()) {
+				_updateObjectDefinitionSettings(group);
+			}
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
@@ -81,8 +90,52 @@ public class GroupModelListener extends BaseModelListener<Group> {
 		}
 	}
 
+	private void _updateObjectDefinitionSettings(Group group)
+		throws PortalException {
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_objectDefinitionSettingLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq("companyId", group.getCompanyId())
+			).add(
+				RestrictionsFactoryUtil.eq(
+					"name",
+					ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS)
+			));
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectDefinitionSetting objectDefinitionSetting) -> {
+				String oldAcceptedGroupIds = objectDefinitionSetting.getValue();
+
+				String[] newAcceptedGroupIds = ArrayUtil.filter(
+					oldAcceptedGroupIds.split("\\s*,\\s*"),
+					groupId -> !StringUtil.equals(
+						groupId, String.valueOf(group.getGroupId())));
+
+				if (newAcceptedGroupIds.length == 0) {
+					_objectDefinitionSettingLocalService.
+						deleteObjectDefinitionSetting(objectDefinitionSetting);
+
+					return;
+				}
+
+				objectDefinitionSetting.setValue(
+					StringUtil.merge(newAcceptedGroupIds));
+
+				_objectDefinitionSettingLocalService.
+					updateObjectDefinitionSetting(objectDefinitionSetting);
+			});
+
+		actionableDynamicQuery.performActions();
+	}
+
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionSettingLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionSettingLocalServiceImpl.java
@@ -54,6 +54,15 @@ public class ObjectDefinitionSettingLocalServiceImpl
 	}
 
 	@Override
+	public ObjectDefinitionSetting getObjectDefinitionSetting(
+			long objectDefinitionId, String name)
+		throws PortalException {
+
+		return objectDefinitionSettingPersistence.findByODI_N(
+			objectDefinitionId, name);
+	}
+
+	@Override
 	public List<ObjectDefinitionSetting> getObjectDefinitionSettings(
 		long objectDefinitionId) {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/model/listener/test/GroupModelListenerTest.java
@@ -12,9 +12,11 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.exception.NoSuchObjectDefinitionSettingException;
 import com.liferay.object.exception.RequiredObjectRelationshipException;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
@@ -104,13 +106,21 @@ public class GroupModelListenerTest {
 			_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
 				objectDefinition1.getUserId(),
 				objectDefinition1.getObjectDefinitionId(),
-				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
-				StringPool.TRUE);
+				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+				String.valueOf(group.getGroupId()));
+
+			DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomLocaleStringMap(),
+				ServiceContextTestUtil.getServiceContext());
+
 			_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
 				objectDefinition2.getUserId(),
 				objectDefinition2.getObjectDefinitionId(),
-				ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS,
-				StringPool.TRUE);
+				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+				StringBundler.concat(
+					group.getGroupId(), StringPool.COMMA,
+					depotEntry.getGroupId()));
 		}
 
 		ObjectRelationship objectRelationship =
@@ -162,6 +172,33 @@ public class GroupModelListenerTest {
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
 				objectEntry2.getObjectEntryId()));
+
+		if (scope.equals(ObjectDefinitionConstants.SCOPE_DEPOT)) {
+			AssertUtils.assertFailure(
+				NoSuchObjectDefinitionSettingException.class,
+				StringBundler.concat(
+					"No ObjectDefinitionSetting exists with the key ",
+					"{objectDefinitionId=",
+					objectDefinition1.getObjectDefinitionId(), ", name=",
+					ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+					"}"),
+				() ->
+					_objectDefinitionSettingLocalService.
+						getObjectDefinitionSetting(
+							objectDefinition1.getObjectDefinitionId(),
+							ObjectDefinitionSettingConstants.
+								NAME_ACCEPTED_GROUP_IDS));
+
+			ObjectDefinitionSetting objectDefinitionSetting =
+				_objectDefinitionSettingLocalService.getObjectDefinitionSetting(
+					objectDefinition2.getObjectDefinitionId(),
+					ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS);
+
+			String acceptedGroupIds = objectDefinitionSetting.getValue();
+
+			Assert.assertFalse(
+				acceptedGroupIds.contains(String.valueOf(group.getGroupId())));
+		}
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);


### PR DESCRIPTION
Related ticket: [LPD-50184](https://liferay.atlassian.net/browse/LPD-50184)

[LPD-50184]: https://liferay.atlassian.net/browse/LPD-50184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ