### PR TITLE
LPD-51151 ObjectEntryLayoutDisplayPageProvider should consider site-scoped ERC lookups

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -116,7 +116,10 @@ public class ObjectEntryLayoutDisplayPageProvider
 
 			String scopeKey = null;
 
-			if (StringUtil.equals(_objectDefinition.getScope(), ObjectDefinitionConstants.SCOPE_SITE)) {
+			if (StringUtil.equals(
+					_objectDefinition.getScope(),
+					ObjectDefinitionConstants.SCOPE_SITE)) {
+
 				scopeKey = String.valueOf(serviceContext.getScopeGroupId());
 			}
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -12,6 +12,7 @@ import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.display.page.BaseLayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
@@ -113,6 +114,12 @@ public class ObjectEntryLayoutDisplayPageProvider
 				userId = PrincipalThreadLocal.getUserId();
 			}
 
+			String scopeKey = null;
+
+			if (StringUtil.equals(_objectDefinition.getScope(), ObjectDefinitionConstants.SCOPE_SITE)) {
+				scopeKey = String.valueOf(serviceContext.getScopeGroupId());
+			}
+
 			com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry =
 				_objectEntryManager.getObjectEntry(
 					serviceContext.getCompanyId(),
@@ -121,7 +128,7 @@ public class ObjectEntryLayoutDisplayPageProvider
 						serviceContext.getLocale(), null,
 						_userLocalService.fetchUser(userId)),
 					ercInfoItemIdentifier.getExternalReferenceCode(),
-					_objectDefinition, null);
+					_objectDefinition, scopeKey);
 
 			if (objectEntry != null) {
 				return new ObjectEntryLayoutDisplayPageObjectProvider(


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-51151

This PR addresses LPD-51151 and ensures that object display pages will handle site-scoped ERC lookups when the object definition indicates the object entry to display is site scoped.