### PR TITLE
LPD-51785 In-lined radio buttons of Single Selection Form Field cannot be correctly selected using tab and arrow keys

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
@@ -64,6 +64,7 @@ const Radio = ({
 			<div className="ddm__radio" onBlur={onBlur} onFocus={onFocus}>
 				<ClayRadioGroup
 					inline={inline}
+					name={name}
 					onChange={(value) => {
 						setCurrentValue(value);
 						onChange({target: {value}});
@@ -78,7 +79,7 @@ const Radio = ({
 					}}
 					value={currentValue}
 				>
-					{options.map((option, index) => (
+					{options.map((option) => (
 						<ClayRadio
 							aria-required={otherProps.required}
 							containerProps={{
@@ -88,7 +89,6 @@ const Radio = ({
 							disabled={disabled}
 							key={option.value}
 							label={option.label}
-							name={`${name}_${index}`}
 							value={option.value}
 						/>
 					))}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
@@ -20,6 +20,7 @@ exports[`Field Radio has a helptext 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -42,6 +43,7 @@ exports[`Field Radio has a helptext 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -119,6 +121,7 @@ exports[`Field Radio has a label 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -141,6 +144,7 @@ exports[`Field Radio has a label 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -208,6 +212,7 @@ exports[`Field Radio has a placeholder 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -230,6 +235,7 @@ exports[`Field Radio has a placeholder 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -291,6 +297,7 @@ exports[`Field Radio has a value 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -313,6 +320,7 @@ exports[`Field Radio has a value 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -374,6 +382,7 @@ exports[`Field Radio has an id 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -396,6 +405,7 @@ exports[`Field Radio has an id 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -458,6 +468,7 @@ exports[`Field Radio is not editable 1`] = `
             <input
               class="custom-control-input"
               disabled=""
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -481,6 +492,7 @@ exports[`Field Radio is not editable 1`] = `
             <input
               class="custom-control-input"
               disabled=""
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -543,6 +555,7 @@ exports[`Field Radio is not required 1`] = `
             <input
               aria-required="false"
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -566,6 +579,7 @@ exports[`Field Radio is not required 1`] = `
             <input
               aria-required="false"
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -632,6 +646,7 @@ exports[`Field Radio renders Label if showLabel is true 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option1"
@@ -654,6 +669,7 @@ exports[`Field Radio renders Label if showLabel is true 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="option2"
@@ -759,6 +775,7 @@ exports[`Field Radio renders options 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="item"
@@ -781,6 +798,7 @@ exports[`Field Radio renders options 1`] = `
           <label>
             <input
               class="custom-control-input"
+              name="radioField"
               role="radio"
               type="radio"
               value="item2"

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderFieldSettingsSidePanelPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderFieldSettingsSidePanelPage.ts
@@ -10,6 +10,7 @@ export class FormBuilderFieldSettingsSidePanelPage {
 	readonly advancedTabButton: Locator;
 	readonly allowMultipleSelectionsSettingToggle: Locator;
 	readonly createListSettingSelect: Locator;
+	readonly inlineToggle: Locator;
 	readonly optionDisplayNameInputField: Locator;
 	readonly page: Page;
 
@@ -22,6 +23,7 @@ export class FormBuilderFieldSettingsSidePanelPage {
 			'Allow Multiple Selections'
 		);
 		this.createListSettingSelect = page.getByLabel('Create List');
+		this.inlineToggle = page.getByText('Inline');
 		this.optionDisplayNameInputField = page.getByPlaceholder('Option');
 		this.page = page;
 	}

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderFieldSettingsSidePanelPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderFieldSettingsSidePanelPage.ts
@@ -38,7 +38,7 @@ export class FormBuilderFieldSettingsSidePanelPage {
 
 			await this.page.waitForTimeout(2000);
 
-			if (index < numberOfOptions) {
+			if (index < numberOfOptions - 1) {
 				await this.addOptionButton.click();
 			}
 		}

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/formEntries.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/formEntries.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Page, expect, mergeTests} from '@playwright/test';
 
 import {formsPagesTest} from '../../fixtures/formsPagesTest';
 import {loginTest} from '../../fixtures/loginTest';
@@ -12,7 +12,15 @@ import {deleteItems} from './utils/deleteItems';
 
 export const test = mergeTests(loginTest(), formsPagesTest);
 
+let formPreviewPage: Page;
+
 test.afterEach(async ({formsPage}) => {
+	if (formPreviewPage) {
+		await formPreviewPage.close();
+
+		formPreviewPage = null;
+	}
+
 	await formsPage.goTo();
 
 	await deleteItems(formsPage);
@@ -65,4 +73,80 @@ test('can interact with a large list of fields on the form entries page', async 
 	await page.locator('a').filter({hasText: 'Text 29'}).click();
 
 	await expect(page.getByText(formEntry)).toBeVisible();
+});
+
+test('can interact with Single Selection options using only keys', async ({
+	formBuilderFieldSettingsSidePanelPage,
+	formBuilderPage,
+	formBuilderSidePanelPage,
+	formsPage,
+	page,
+}) => {
+	await formsPage.goTo();
+
+	await formsPage.clickManagementToolbarNewButton();
+
+	for (let index = 0; index < 2; index++) {
+		await formBuilderSidePanelPage.addSingleSelectionButton.dblclick();
+
+		await formBuilderFieldSettingsSidePanelPage.addOptions(3);
+
+		await formBuilderFieldSettingsSidePanelPage.advancedTabButton.click();
+
+		await formBuilderFieldSettingsSidePanelPage.inlineToggle.click();
+
+		await formBuilderSidePanelPage.backButton.click();
+	}
+
+	const formPreviewPagePromise = page.waitForEvent('popup');
+
+	await formBuilderPage.previewButton.click();
+
+	formPreviewPage = await formPreviewPagePromise;
+
+	// We need to ensure option elements are enabled before tabbing through them.
+
+	await expect(formPreviewPage.getByLabel('Option0').first()).toBeEnabled();
+
+	for (let index = 0; index < 2; index++) {
+
+		// On the second loop iteration, pressing Tab should focus the second group.
+
+		await formPreviewPage.keyboard.press('Tab');
+
+		await expect(
+			formPreviewPage.getByLabel('Option0').nth(index)
+		).toBeChecked();
+
+		await formPreviewPage.keyboard.press('ArrowDown');
+
+		await expect(
+			formPreviewPage.getByLabel('Option1').nth(index)
+		).toBeChecked();
+
+		await formPreviewPage.keyboard.press('ArrowDown');
+
+		await expect(
+			formPreviewPage.getByLabel('Option2').nth(index)
+		).toBeChecked();
+
+		await formPreviewPage.keyboard.press('ArrowDown');
+
+		// After pressing Arrow Down while being in the last option,
+		// we should have the first option selected again.
+
+		await expect(
+			formPreviewPage.getByLabel('Option0').nth(index)
+		).toBeChecked();
+
+		// Then, pressing Arrow Up twice should select the middle option.
+
+		await formPreviewPage.keyboard.press('ArrowUp');
+
+		await formPreviewPage.keyboard.press('ArrowUp');
+
+		await expect(
+			formPreviewPage.getByLabel('Option1').nth(index)
+		).toBeChecked();
+	}
 });


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-51785

This is the bug found on master from [LPP-58131](https://liferay.atlassian.net/browse/LPP-58131).

[LPP-58131]: https://liferay.atlassian.net/browse/LPP-58131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ