### PR TITLE
LPD-51765 Do not set localized attribute based on enableLocalization

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -207,7 +207,7 @@ public class ObjectFieldUtil {
 	}
 
 	public static com.liferay.object.model.ObjectField toObjectField(
-		String defaultLanguageId, boolean enableLocalization,
+		String defaultLanguageId,
 		ListTypeDefinitionLocalService listTypeDefinitionLocalService,
 		ObjectField objectField,
 		ObjectFieldLocalService objectFieldLocalService,
@@ -262,8 +262,7 @@ public class ObjectFieldUtil {
 		serviceBuilderObjectField.setLabelMap(localizedLabelMap);
 
 		serviceBuilderObjectField.setLocalized(
-			GetterUtil.getBoolean(
-				objectField.getLocalized(), enableLocalization));
+			GetterUtil.getBoolean(objectField.getLocalized()));
 		serviceBuilderObjectField.setName(objectField.getName());
 		serviceBuilderObjectField.setObjectFieldSettings(
 			ObjectFieldSettingUtil.toObjectFieldSettings(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -283,10 +283,6 @@ public class ObjectDefinitionResourceImpl
 						objectDefinition.getObjectFields(),
 						objectField -> ObjectFieldUtil.toObjectField(
 							objectDefinition.getDefaultLanguageId(),
-							GetterUtil.getBoolean(
-								objectDefinition.getEnableLocalization(),
-								FeatureFlagManagerUtil.isEnabled(
-									contextUser.getCompanyId(), "LPD-32050")),
 							_listTypeDefinitionLocalService, objectField,
 							_objectFieldLocalService,
 							_objectFieldSettingLocalService,
@@ -342,10 +338,6 @@ public class ObjectDefinitionResourceImpl
 										BUSINESS_TYPE_RELATIONSHIP)),
 						objectField -> ObjectFieldUtil.toObjectField(
 							objectDefinition.getDefaultLanguageId(),
-							GetterUtil.getBoolean(
-								objectDefinition.getEnableLocalization(),
-								FeatureFlagManagerUtil.isEnabled(
-									contextUser.getCompanyId(), "LPD-32050")),
 							_listTypeDefinitionLocalService, objectField,
 							_objectFieldLocalService,
 							_objectFieldSettingLocalService,
@@ -414,7 +406,7 @@ public class ObjectDefinitionResourceImpl
 								ObjectFieldConstants.
 									BUSINESS_TYPE_AGGREGATION)),
 						objectField -> ObjectFieldUtil.toObjectField(
-							objectDefinition.getDefaultLanguageId(), false,
+							objectDefinition.getDefaultLanguageId(),
 							_listTypeDefinitionLocalService, objectField,
 							_objectFieldLocalService,
 							_objectFieldSettingLocalService,
@@ -1123,9 +1115,9 @@ public class ObjectDefinitionResourceImpl
 			serviceBuilderObjectDefinition1.getObjectDefinitionId(),
 			serviceBuilderObjectDefinition2.getObjectDefinitionId(),
 			ObjectFieldUtil.toObjectField(
-				defaultLanguageId, false, _listTypeDefinitionLocalService,
-				objectField, _objectFieldLocalService,
-				_objectFieldSettingLocalService, _objectFilterLocalService));
+				defaultLanguageId, _listTypeDefinitionLocalService, objectField,
+				_objectFieldLocalService, _objectFieldSettingLocalService,
+				_objectFilterLocalService));
 	}
 
 	private Set<String> _getAccountEntryRestrictedObjectRelationshipsNames(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
@@ -135,9 +135,7 @@ public class ObjectFieldResourceImpl extends BaseObjectFieldResourceImpl {
 				GetterUtil.getBoolean(objectField.getIndexedAsKeyword()),
 				objectField.getIndexedLanguageId(),
 				LocalizedMapUtil.populateLocalizedMap(objectField.getLabel()),
-				GetterUtil.getBoolean(
-					objectField.getLocalized(),
-					objectDefinition.isEnableLocalization()),
+				GetterUtil.getBoolean(objectField.getLocalized()),
 				objectField.getName(), objectField.getReadOnlyAsString(),
 				objectField.getReadOnlyConditionExpression(),
 				objectField.getRequired(),

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -221,7 +221,7 @@ public class ObjectRelationshipResourceImpl
 				GetterUtil.getBoolean(objectRelationship.getSystem()),
 				objectRelationship.getTypeAsString(),
 				ObjectFieldUtil.toObjectField(
-					LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()), false,
+					LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
 					_listTypeDefinitionLocalService,
 					objectRelationship.getObjectField(),
 					_objectFieldLocalService, _objectFieldSettingLocalService,
@@ -272,7 +272,7 @@ public class ObjectRelationshipResourceImpl
 				LocalizedMapUtil.populateLocalizedMap(
 					objectRelationship.getLabel()),
 				ObjectFieldUtil.toObjectField(
-					LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()), false,
+					LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()),
 					_listTypeDefinitionLocalService,
 					objectRelationship.getObjectField(),
 					_objectFieldLocalService, _objectFieldSettingLocalService,

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -751,6 +751,23 @@ public class ObjectDefinitionResourceTest
 						localized = true;
 						name = StringUtil.randomId();
 					}
+				},
+				new ObjectField() {
+					{
+						businessType = BusinessType.TEXT;
+						DBType = ObjectField.DBType.create("String");
+						label = Collections.singletonMap("en_US", "Column");
+						localized = false;
+						name = StringUtil.randomId();
+					}
+				},
+				new ObjectField() {
+					{
+						businessType = BusinessType.TEXT;
+						DBType = ObjectField.DBType.create("String");
+						label = Collections.singletonMap("en_US", "Column");
+						name = StringUtil.randomId();
+					}
 				}
 			});
 		randomObjectDefinition.setStatus(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -1119,7 +1119,7 @@ public class ObjectDefinitionResourceTest
 						indexed = true;
 						label = Collections.singletonMap(
 							"en_US", RandomTestUtil.randomString());
-						name = "relationshipObjectFieldName";
+						name = "r_relationshipName_c_objectDefinition1Id";
 						objectDefinitionExternalReferenceCode1 =
 							"TESTOBJECTDEFINITION1";
 						objectRelationshipExternalReferenceCode =
@@ -1134,7 +1134,8 @@ public class ObjectDefinitionResourceTest
 					objectLayoutColumns = new ObjectLayoutColumn[] {
 						new ObjectLayoutColumn() {
 							{
-								objectFieldName = "relationshipObjectFieldName";
+								objectFieldName =
+									"r_relationshipName_c_objectDefinition1Id";
 								priority = 0;
 								size = 6;
 							}
@@ -1187,7 +1188,7 @@ public class ObjectDefinitionResourceTest
 		ObjectField objectField = objectFields[0];
 
 		Assert.assertEquals(
-			"relationshipObjectFieldName", objectField.getName());
+			"r_relationshipName_c_objectDefinition1Id", objectField.getName());
 		Assert.assertEquals(
 			"TESTOBJECTDEFINITION1",
 			objectField.getObjectDefinitionExternalReferenceCode1());


### PR DESCRIPTION
Related: [LPD-51765](https://liferay.atlassian.net/browse/LPD-51765)

[LPD-51765]: https://liferay.atlassian.net/browse/LPD-51765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before the default value for localized attribute inside the object fields was being defined based on the flag enable translation if the localized property is not provided in the body, but this flag is not used anymore and for some reason it is always being defined as true, so for field like auto increment that does not accept translation if it does not provide localized as false it will no be inserted. 

In My POV we should not use this flag for business rules anymore because it officially does not exists.