### PR TITLE
LPD-52241 Standardizing  of object API filter in case of different database types

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -382,10 +382,11 @@ public class PredicateExpressionVisitorImpl
 	}
 
 	private Predicate _contains(Column<?, ?> column, Object value) {
-		return DSLFunctionFactoryUtil.castText(
-			column
+		return DSLFunctionFactoryUtil.lower(
+			DSLFunctionFactoryUtil.castText(column)
 		).like(
-			StringPool.PERCENT + value + StringPool.PERCENT
+			StringPool.PERCENT + StringUtil.toLowerCase(String.valueOf(value)) +
+				StringPool.PERCENT
 		);
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -3030,6 +3030,13 @@ public class DefaultObjectEntryManagerImplTest
 				_buildContainsExpressionFilterString("textObjectFieldName", "b")
 			).build(),
 			childObjectEntry2);
+		testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				_buildContainsExpressionFilterString(
+					"textObjectFieldName", "Aab")
+			).build(),
+			childObjectEntry2);
 
 		// Equals expression
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2900,6 +2900,8 @@ public class DefaultObjectEntryManagerImplTest
 							"localizedLongTextObjectFieldName",
 							"en_US localizedLongTextObjectFieldValue"
 						).put(
+							"longIntegerObjectFieldName", 200L
+						).put(
 							"picklistObjectFieldName", picklistObjectFieldValue2
 						).put(
 							"textObjectFieldName", "aab"


### PR DESCRIPTION
Standardizing  of object API filter in case of different database types, to assure the expected behavior of Objects API across the DB vendors

https://liferay.atlassian.net/browse/LPD-52241