### PR TITLE
LPD-50998 Move Script Management to BPM on Testray

### DIFF
--- a/modules/apps/portal-security/portal-security-script-management-api/test.properties
+++ b/modules/apps/portal-security/portal-security-script-management-api/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Object

--- a/modules/apps/portal-security/portal-security-script-management-test-util/test.properties
+++ b/modules/apps/portal-security/portal-security-script-management-test-util/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Object

--- a/modules/apps/portal-security/portal-security-script-management-test/test.properties
+++ b/modules/apps/portal-security/portal-security-script-management-test/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Object

--- a/modules/apps/portal-security/portal-security-script-management-web/test.properties
+++ b/modules/apps/portal-security/portal-security-script-management-web/test.properties
@@ -14,3 +14,9 @@
 
     playwright.projects.includes[playwright-js-tomcat90-mysql57][relevant][portal-security-script-management-web-playwright-rule]=\
         portal-security-script-management-web
+
+##
+## Testray
+##
+
+    testray.main.component.name=Object

--- a/test.properties
+++ b/test.properties
@@ -4394,7 +4394,8 @@
     test.batch.class.names.includes[modules-integration-*][object]=\
         **/list-type/**/src/testIntegration/**/*Test.java,\
         **/notification/**/src/testIntegration/**/*Test.java,\
-        **/object/**/src/testIntegration/**/*Test.java
+        **/object/**/src/testIntegration/**/*Test.java,\
+        **/portal-security-script-management-test/**/*Test.java
 
     test.batch.class.names.includes[modules-unit][object]=\
         **/list-type/**/src/test/**/*Test.java,\


### PR DESCRIPTION
Related issue: [LPD-50998](https://liferay.atlassian.net/browse/LPD-50998)

Hello team!

I'm sending this PR for you to review since it is related to the Object component. These modules were assigned to the "Security" component on Testray but they're actually not owned by AppSec. 

I've talked with @MarinhoFeliphe about this being owned by BPM and he agreed on the change. I've also added the tests to the object test suite, but we can drop this commit if it's unnecessary to you

Please let me know if you have any questions :)

The main PR is being worked here: https://github.com/liferay-appsec/liferay-portal/pull/2268

[LPD-50998]: https://liferay.atlassian.net/browse/LPD-50998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ