### PR TITLE
LPD-52595 Adding verification to prevent error in case of a className with null value

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v10_0_1/ObjectDefinitionPortletIdUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v10_0_1/ObjectDefinitionPortletIdUpgradeProcess.java
@@ -34,7 +34,9 @@ public class ObjectDefinitionPortletIdUpgradeProcess
 				long objectDefinitionId = resultSet.getLong(
 					"objectDefinitionId");
 
-				if (className.endsWith(StringPool.POUND + objectDefinitionId)) {
+				if ((className == null) ||
+					className.endsWith(StringPool.POUND + objectDefinitionId)) {
+
 					continue;
 				}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_0_1/test/ObjectDefinitionPortletIdUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v10_0_1/test/ObjectDefinitionPortletIdUpgradeProcessTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -93,6 +95,10 @@ public class ObjectDefinitionPortletIdUpgradeProcessTest {
 			).put(
 				"javax.portlet.name", _oldPortletId
 			).build());
+
+		_objectDefinitionLocalService.addObjectDefinition(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(), 0, true,
+			RandomTestUtil.randomString(), false);
 	}
 
 	@After
@@ -159,6 +165,9 @@ public class ObjectDefinitionPortletIdUpgradeProcessTest {
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	private String _oldPortletId;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52595

Adding verification to prevent error in case of a className with null value in ObjectDefinitionPortletIdUpgradeProcess.