### PR TITLE
LPD-53895

### DIFF
--- a/modules/apps/object/object-admin-rest-api/bnd.bnd
+++ b/modules/apps/object/object-admin-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object Admin REST API
 Bundle-SymbolicName: com.liferay.object.admin.rest.api
-Bundle-Version: 21.1.1
+Bundle-Version: 21.2.0
 Export-Package:\
 	com.liferay.object.admin.rest.dto.v1_0,\
 	com.liferay.object.admin.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/util/ObjectDefinitionUtil.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.object.web.internal.object.definitions.portlet.action.util;
+package com.liferay.object.admin.rest.dto.v1_0.util;
 
 import com.liferay.object.admin.rest.dto.v1_0.ObjectAction;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
@@ -17,7 +17,7 @@ import java.util.Map;
 /**
  * @author Gabriel Albuquerque
  */
-public class ExportImportObjectDefinitionUtil {
+public class ObjectDefinitionUtil {
 
 	public static void prepareObjectDefinitionForExport(
 		JSONFactory jsonFactory, ObjectDefinition objectDefinition) {

--- a/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/util/packageinfo
+++ b/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ExportBoundObjectDefinitionsMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ExportBoundObjectDefinitionsMVCResourceCommand.java
@@ -6,9 +6,9 @@
 package com.liferay.object.web.internal.object.definitions.portlet.action;
 
 import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.dto.v1_0.util.ObjectDefinitionUtil;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.object.constants.ObjectPortletKeys;
-import com.liferay.object.web.internal.object.definitions.portlet.action.util.ExportImportObjectDefinitionUtil;
 import com.liferay.object.web.internal.util.JSONObjectSanitizerUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -86,7 +86,7 @@ public class ExportBoundObjectDefinitionsMVCResourceCommand
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
 
 		for (ObjectDefinition objectDefinition : objectDefinitions) {
-			ExportImportObjectDefinitionUtil.prepareObjectDefinitionForExport(
+			ObjectDefinitionUtil.prepareObjectDefinitionForExport(
 				_jsonFactory, objectDefinition);
 
 			JSONObject jsonObject = _jsonFactory.createJSONObject(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ExportObjectDefinitionMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ExportObjectDefinitionMVCResourceCommand.java
@@ -6,9 +6,9 @@
 package com.liferay.object.web.internal.object.definitions.portlet.action;
 
 import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.dto.v1_0.util.ObjectDefinitionUtil;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.object.constants.ObjectPortletKeys;
-import com.liferay.object.web.internal.object.definitions.portlet.action.util.ExportImportObjectDefinitionUtil;
 import com.liferay.object.web.internal.util.JSONObjectSanitizerUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -65,7 +65,7 @@ public class ExportObjectDefinitionMVCResourceCommand
 		ObjectDefinition objectDefinition =
 			objectDefinitionResource.getObjectDefinition(objectDefinitionId);
 
-		ExportImportObjectDefinitionUtil.prepareObjectDefinitionForExport(
+		ObjectDefinitionUtil.prepareObjectDefinitionForExport(
 			_jsonFactory, objectDefinition);
 
 		JSONObject objectDefinitionJSONObject = _jsonFactory.createJSONObject(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ExportObjectFolderMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ExportObjectFolderMVCResourceCommand.java
@@ -7,9 +7,9 @@ package com.liferay.object.web.internal.object.definitions.portlet.action;
 
 import com.liferay.object.admin.rest.dto.v1_0.ObjectFolder;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectFolderItem;
+import com.liferay.object.admin.rest.dto.v1_0.util.ObjectDefinitionUtil;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectFolderResource;
 import com.liferay.object.constants.ObjectPortletKeys;
-import com.liferay.object.web.internal.object.definitions.portlet.action.util.ExportImportObjectDefinitionUtil;
 import com.liferay.object.web.internal.util.JSONObjectSanitizerUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -68,7 +68,7 @@ public class ExportObjectFolderMVCResourceCommand
 		for (ObjectFolderItem objectFolderItem :
 				objectFolder.getObjectFolderItems()) {
 
-			ExportImportObjectDefinitionUtil.prepareObjectDefinitionForExport(
+			ObjectDefinitionUtil.prepareObjectDefinitionForExport(
 				_jsonFactory, objectFolderItem.getObjectDefinition());
 		}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureBuilderDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/StructureBuilderDisplayContext.java
@@ -5,8 +5,8 @@
 
 package com.liferay.site.cms.site.initializer.internal.display.context;
 
-import com.liferay.object.admin.rest.dto.v1_0.ObjectAction;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.dto.v1_0.util.ObjectDefinitionUtil;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -15,13 +15,10 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -94,22 +91,8 @@ public class StructureBuilderDisplayContext {
 			return null;
 		}
 
-		for (ObjectAction objectAction : objectDefinition.getObjectActions()) {
-			Map<String, Object> parameters =
-				(Map<String, Object>)objectAction.getParameters();
-
-			Object object = parameters.get("predefinedValues");
-
-			if (object == null) {
-				continue;
-			}
-
-			parameters.put(
-				"predefinedValues",
-				ListUtil.toList(
-					(ArrayList<LinkedHashMap>)object,
-					_jsonFactory::createJSONObject));
-		}
+		ObjectDefinitionUtil.prepareObjectDefinitionForExport(
+			_jsonFactory, objectDefinition);
 
 		try {
 			return _jsonFactory.createJSONObject(objectDefinition.toString());


### PR DESCRIPTION
Motivation
----
Moves **ExportImportObjectDefinitionUtil** to reuse it in other modules, in this case in Structure Builder.

[Link to the issue](https://liferay.atlassian.net/browse/LPD-53894)

Proposed Solution
----

Moves **ExportImportObjectDefinitionUtil** to **object-admin-rest-api**, also rename it to **ObjectDefinitionUtil** to match with other classes in the same packaged.

Please let me know if you have any question.