### PR TITLE
LPD-54208 | LPD-54166 Workflow modals are empty 

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/js/WorkFlowTaskActionDropdownPropsTransformer.js
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/js/WorkFlowTaskActionDropdownPropsTransformer.js
@@ -7,35 +7,25 @@ import {openSimpleInputModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	taskAssign({assignURL, namespace, title}) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				height: 430,
-				resizable: false,
-				width: 896,
-			},
-			dialogIframe: {
-				bodyCssClass: 'task-dialog',
-			},
+		Liferay.Util.openModal({
+			containerProps: {},
+			height: 360,
 			id: namespace + 'assignToDialog',
+			iframeBodyCssClass: 'task-dialog',
+			size: 'md',
 			title,
-			uri: assignURL,
+			url: assignURL,
 		});
 	},
 	taskAssignToMe({assignToMeURL, namespace, title}) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				height: 340,
-				resizable: false,
-				width: 896,
-			},
-			dialogIframe: {
-				bodyCssClass: 'task-dialog',
-			},
+		Liferay.Util.openModal({
+			containerProps: {},
+			height: 280,
 			id: namespace + 'assignToDialog',
+			iframeBodyCssClass: 'task-dialog',
+			size: 'md',
 			title,
-			uri: assignToMeURL,
+			url: assignToMeURL,
 		});
 	},
 	taskEditWorkflowTask({formSubmitURL, namespace, title}) {
@@ -55,19 +45,14 @@ const ACTIONS = {
 		});
 	},
 	updateDueDate({namespace, title, updateDueDateURL}) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				height: 430,
-				resizable: false,
-				width: 896,
-			},
-			dialogIframe: {
-				bodyCssClass: 'task-dialog',
-			},
+		Liferay.Util.openModal({
+			containerProps: {},
+			height: 360,
 			id: namespace + 'updateDialog',
+			iframeBodyCssClass: 'task-dialog',
+			size: 'md',
 			title,
-			uri: updateDueDateURL,
+			url: updateDueDateURL,
 		});
 	},
 };


### PR DESCRIPTION
1. https://liferay.atlassian.net/browse/LPD-54208
2. https://liferay.atlassian.net/browse/LPD-54166

**This PR does not need test as it fixes many currently failing tests such as:**

1. [object-web/objectEntries.spec.ts > Manage object entries through Workflow › can edit object entry through workflow task page
](https://testray.liferay.com/#/project/35392/routines/189378256/build/201183082/case-result/201194341/history?filter=%7B%22testrayRoutineIds%22%3A%5B189378256%5D%7D&filterSchema=buildResultsHistory)
4. [portal-workflow-task-web/assignments.spec.ts > approve or reject modal appear even after doing a comment on the comments section](https://testray.liferay.com/#/project/35392/routines/189378256/build/201183082/case-result/201200092/history?filter=%7B%22testrayRoutineIds%22%3A%5B189378256%5D%7D&filterSchema=buildResultsHistory)

Fix based on https://github.com/liferay/liferay-portal/commit/3cf55c7f4cbdfe3252a4579836a6a41aa9c42752