### PR TITLE
LPD-52455 Update external reference code in ObjectFolderItem data structure

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolder.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolder.tsx
@@ -472,6 +472,36 @@ export default function EditObjectFolder({
 								return element;
 							}) as Elements<ObjectDefinitionNodeData>;
 
+							const updatedSelectedObjectFolderItems =
+								selectedObjectFolder.objectFolderItems.map(
+									(objectFolderItem) => {
+										if (
+											objectFolderItem.objectDefinitionExternalReferenceCode ===
+											selectedObjectDefinitionNode.data
+												?.externalReferenceCode
+										) {
+											return {
+												...objectFolderItem,
+												objectDefinitionExternalReferenceCode:
+													externalReferenceCode,
+											};
+										}
+
+										return objectFolderItem;
+									}
+								);
+
+							dispatch({
+								payload: {
+									updatedSelectedObjectFolder: {
+										...selectedObjectFolder,
+										objectFolderItems:
+											updatedSelectedObjectFolderItems,
+									},
+								},
+								type: TYPES.SET_SELECTED_OBJECT_FOLDER_DETAILS,
+							});
+
 							dispatch({
 								payload: {
 									newElements: updatedElements,

--- a/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
+++ b/modules/test/playwright/pages/object-web/model-builder/ModelBuilderObjectDefinitionNodePage.ts
@@ -16,8 +16,10 @@ export class ModelBuilderObjectDefinitionNodePage {
 	readonly addObjectFieldOrRelationshipButton: Locator;
 	readonly addObjectRelationshipButton: Locator;
 	readonly deleteObjectDefinitionOption: Locator;
+	readonly editObjectDefinitionExternalReferenceCodeButton: Locator;
 	readonly newObjectFieldSaveButton: Locator;
 	readonly newObjectRelationshipSaveButton: Locator;
+	readonly modalEditObjectDefinitionExternalReferenceCodeInput: Locator;
 	readonly modalDeleteObjectDefinitionTextField: Locator;
 	readonly modalDeleteObjectDefinitionConfirmationButton: Locator;
 	readonly objectFieldBusinessTypeSelect: Locator;
@@ -47,9 +49,14 @@ export class ModelBuilderObjectDefinitionNodePage {
 		this.deleteObjectDefinitionOption = page.getByRole('menuitem', {
 			name: 'Delete Object',
 		});
+		this.editObjectDefinitionExternalReferenceCodeButton = page
+			.getByText('Edit ERC')
+			.last();
 		this.modalDeleteObjectDefinitionConfirmationButton = page
 			.getByRole('dialog')
 			.getByRole('button', {exact: true, name: 'Delete'});
+		this.modalEditObjectDefinitionExternalReferenceCodeInput =
+			page.getByLabel('External Reference Code' + 'Mandatory');
 		this.modalDeleteObjectDefinitionTextField = page.getByPlaceholder(
 			'Confirm Object Definition Name'
 		);

--- a/modules/test/playwright/tests/object-web/objectDefinitions.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectDefinitions.spec.ts
@@ -446,6 +446,79 @@ test.describe('Manage object definitions through Model Builder', () => {
 		).toBeVisible();
 	});
 
+	test('object definition remains in its folder after external reference code edit and new object definition creation', async ({
+		apiHelpers,
+		modalAddObjectDefinitionPage,
+		modelBuilderDiagramPage,
+		modelBuilderLeftSidebarPage,
+		modelBuilderObjectDefinitionNodePage,
+		page,
+	}) => {
+		const objectFolder =
+			await apiHelpers.objectAdmin.postRandomObjectFolder();
+
+		apiHelpers.data.push({id: objectFolder.id, type: 'objectFolder'});
+
+		const objectDefinition1 =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFolderExternalReferenceCode:
+					objectFolder.externalReferenceCode,
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition1.id,
+			type: 'objectDefinition',
+		});
+
+		await modelBuilderDiagramPage.goto({
+			objectFolderName: objectFolder.name,
+		});
+
+		await modelBuilderObjectDefinitionNodePage.clickObjectDefinitionActionsButton(
+			objectDefinition1.label['en-us'],
+			modelBuilderDiagramPage.objectDefinitionNodes
+		);
+
+		await modelBuilderObjectDefinitionNodePage.editObjectDefinitionExternalReferenceCodeButton.click();
+
+		const objectDefinitionExternalReferenceCode =
+			'ObjectDefinition' + getRandomInt();
+
+		await modelBuilderObjectDefinitionNodePage.modalEditObjectDefinitionExternalReferenceCodeInput.fill(
+			objectDefinitionExternalReferenceCode
+		);
+
+		await page.getByRole('button', {name: 'save'}).click();
+
+		const objectDefinitionLabel = 'ObjectDefinitionLabel' + getRandomInt();
+
+		await modelBuilderLeftSidebarPage.createNewObjectDefinitionButton.click();
+
+		const objectDefinition2 =
+			await modalAddObjectDefinitionPage.createObjectDefinition(
+				objectDefinitionLabel
+			);
+
+		apiHelpers.data.push({
+			id: objectDefinition2.id,
+			type: 'objectDefinition',
+		});
+
+		await waitForAlert(
+			page,
+			`Success:${objectDefinitionLabel} was created successfully.`
+		);
+
+		await page.reload();
+
+		await expect(
+			modelBuilderDiagramPage.objectDefinitionNodes.filter({
+				hasText: objectDefinition1.label['en_US'],
+			})
+		).toBeVisible();
+	});
+
 	test('see object definition details', async ({
 		apiHelpers,
 		modelBuilderDiagramPage,


### PR DESCRIPTION
### References:

- Parent Task: [LPD-52455  - Object moves folders when creating second object](https://liferay.atlassian.net/browse/LPD-52455)

The purpose of this PR is to update the `externalReferenceCode` property in the `ObjectFolderItem`, to prevent that, when we create a new object and send a **PUT** to `object-folders/by-external-reference-code`, the non-existence of the external reference code triggers a flow of moving the edited object to the default folder.
