### PR TITLE
LPD-52908 Use the learn resource to reference the documentation

### DIFF
--- a/learn-resources/data/object-web.json
+++ b/learn-resources/data/object-web.json
@@ -11,6 +11,12 @@
 			"url": "https://learn.liferay.com/en/w/dxp/liferay-development/objects/creating-and-managing-objects/validations/expression-builder-validations-reference"
 		}
 	},
+	"localizing-object-definitions-and-entries": {
+		"en_US": {
+			"message": "Click here for documentation.",
+			"url": "https://learn.liferay.com/w/dxp/liferay-development/objects/creating-and-managing-objects/localizing-object-definitions-and-entries"
+		}
+	},
 	"managing-data-from-external-systems": {
 		"en_US": {
 			"message": "Learn more.",

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectFieldContent.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectFieldContent.tsx
@@ -175,6 +175,7 @@ export function EditObjectFieldContent({
 								errors={errors}
 								filterOperators={filterOperators}
 								handleChange={handleChange}
+								learnResources={learnResources}
 								modelBuilder={modelBuilder}
 								objectDefinition={objectDefinition}
 								objectFieldBusinessTypes={
@@ -226,6 +227,7 @@ export function EditObjectFieldContent({
 					errors={errors}
 					filterOperators={filterOperators}
 					handleChange={handleChange}
+					learnResources={learnResources}
 					modelBuilder={modelBuilder}
 					objectDefinition={objectDefinition}
 					objectFieldBusinessTypes={objectFieldBusinessTypes}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfoTab.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfoTab.tsx
@@ -5,6 +5,7 @@
 
 import {Input, SidebarCategory} from '@liferay/object-js-components-web';
 import classNames from 'classnames';
+import {ILearnResourceContext} from 'frontend-js-components-web';
 import React, {ElementType, useState} from 'react';
 
 import {AutoIncrementFormBase} from '../../AutoIncrementFormBase';
@@ -37,6 +38,7 @@ interface BasicInfoTabProps {
 	errors: ObjectFieldErrors;
 	filterOperators: TFilterOperators;
 	handleChange: React.ChangeEventHandler<HTMLInputElement>;
+	learnResources: ILearnResourceContext;
 	modelBuilder?: boolean;
 	objectDefinition?: ObjectDefinition;
 	objectFieldBusinessTypes: ObjectFieldBusinessType[];
@@ -57,6 +59,7 @@ export function BasicInfoTab({
 	errors,
 	filterOperators,
 	handleChange,
+	learnResources,
 	modelBuilder = false,
 	objectDefinition,
 	objectFieldBusinessTypes,
@@ -205,6 +208,7 @@ export function BasicInfoTab({
 				title={Liferay.Language.get('translation-options')}
 			>
 				<TranslationOptionsContainer
+					learnResources={learnResources}
 					modelBuilder={modelBuilder}
 					objectDefinition={objectDefinition}
 					onSubmit={onSubmit}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.tsx
@@ -5,15 +5,20 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {Toggle} from '@liferay/object-js-components-web';
 import classNames from 'classnames';
+import {
+	ILearnResourceContext,
+	LearnMessage,
+	LearnResourcesContext,
+} from 'frontend-js-components-web';
 import React from 'react';
 
 import './TranslationOptionsContainer.scss';
 
 interface TranslationOptionsContainerProps {
+	learnResources: ILearnResourceContext;
 	modelBuilder?: boolean;
 	objectDefinition?: ObjectDefinition;
 	onSubmit?: () => void;
@@ -23,6 +28,7 @@ interface TranslationOptionsContainerProps {
 }
 
 export function TranslationOptionsContainer({
+	learnResources,
 	modelBuilder,
 	objectDefinition,
 	onSubmit,
@@ -64,10 +70,14 @@ export function TranslationOptionsContainer({
 					{`${Liferay.Language.get(
 						'this-field-type-does-not-support-translations'
 					)} `}
-
-					<ClayLink href="#" target="_blank" weight="semi-bold">
-						{Liferay.Language.get('click-here-for-documentation')}
-					</ClayLink>
+					&nbsp;
+					<LearnResourcesContext.Provider value={learnResources}>
+						<LearnMessage
+							className="alert-link"
+							resource="object-web"
+							resourceKey="localizing-object-definitions-and-entries"
+						/>
+					</LearnResourcesContext.Provider>
 				</ClayAlert>
 			)}
 


### PR DESCRIPTION
**References:**

- Parent Task: [LPD-52908 - Fields that do not support translations do not link correctly to documentation](https://liferay.atlassian.net/browse/LPD-52908)

The goal of this PR is to remove the use of the unreferenced anchor and start using the correct link to documentation which is being improved to provide more information about translations in the context of entries in the object.

A [task](https://liferay.atlassian.net/browse/LPD-54351) to create a test that covers the operation of this flow has been created. When the CDN is updated and the link is fully functional, I will be submitting this test case.