### PR TITLE
LPD-52535 Announce richText label and help message via screen reader

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -58,7 +58,7 @@ const RichText = ({
 	evaluable,
 	fieldName,
 	id,
-	label,
+	label = '',
 	locale,
 	name,
 	localizedObjectField,
@@ -67,6 +67,7 @@ const RichText = ({
 	onFocus,
 	predefinedValue = '',
 	readOnly,
+	tip = '',
 	value,
 	visible,
 	...otherProps
@@ -336,6 +337,7 @@ const RichText = ({
 			name={name}
 			readOnly={readOnly}
 			style={readOnly ? {pointerEvents: 'none'} : null}
+			tip={tip}
 			visible={visible}
 		>
 			<ClayInput.Group>
@@ -362,7 +364,11 @@ const RichText = ({
 										]
 									: ''
 							}
-							editorConfig={editorConfig}
+							editorConfig={{
+								...editorConfig,
+								applicationTitle:
+									(label || tip) && `${label}, ${tip}`,
+							}}
 							name={name}
 							onBlur={onBlur}
 							onChange={(content) => handleContentChange(content)}

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderPage.ts
@@ -16,6 +16,7 @@ export class FormBuilderPage {
 	readonly formSettingsDoneButton: Locator;
 	readonly formTab: Locator;
 	readonly formTitle: Locator;
+	readonly helpText: Locator;
 	readonly newFormHeading: Locator;
 	readonly newPageButton: Locator;
 	readonly openFormButton: Locator;
@@ -36,6 +37,7 @@ export class FormBuilderPage {
 		this.formSettingsDoneButton = page.getByRole('button', {name: 'Done'});
 		this.formTab = page.getByRole('button', {name: 'Form'});
 		this.formTitle = page.getByPlaceholder('Untitled Form');
+		this.helpText = page.getByLabel('Help Text');
 		this.newFormHeading = page.getByRole('heading', {name: 'New Form'});
 		this.newPageButton = page.getByRole('button', {name: 'New Page'});
 		this.openFormButton = page.getByRole('button', {

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/richText.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/richText.spec.ts
@@ -78,6 +78,8 @@ const assertRichTextContent = async (
 
 	await formBuilderSidePanelPage.addFieldByDoubleClick('Rich Text');
 
+	await formBuilderPage.helpText.fill('help text');
+
 	const newTabPagePromise = new Promise<Page>((resolve) =>
 		formBuilderPage.page.once('popup', resolve)
 	);
@@ -99,9 +101,7 @@ const assertRichTextContent = async (
 	await codeMirror.click();
 
 	const textArea = newTabPage
-		.getByLabel(
-			'Rich Text Editor'
-		)
+		.getByLabel('Rich Text, help text')
 		.getByRole('textbox');
 
 	await textArea.fill(content);


### PR DESCRIPTION
### References:
- Parent Task: [LPP-58469 Accessibility - Some Form fields' helptext are not connected to the field](https://liferay.atlassian.net/browse/LPP-58469)
- Recent pull request related: https://github.com/liferay-frontend/liferay-portal/pull/4864
- Follow up of: https://github.com/liferay-platform-experience/liferay-portal/pull/1164#issuecomment-2825310403

### What is the goal of this PR?
The goal of these changes is to make the screen reader read relevant information about the rich text field when we focus on the CKEditor input.

### What did it look like before the changes?

https://github.com/user-attachments/assets/516d2901-eb47-4996-8b32-1b2f248e4a2b

### What does it look like after the changes?

https://github.com/user-attachments/assets/4fc0ed70-aeb7-461c-9a41-87776c82a72e