### PR TITLE
LPD-53712 Wrap inline style with <@liferay_ui.csp> in separator.ftl

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/separator.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/separator.ftl
@@ -9,7 +9,9 @@
 	label=escape(label)
 >
 	<div class="form-group">
-		<hr class="separator" style="${escapeAttribute(style)}" />
+		<@liferay_ui.csp>
+			<hr class="separator" style="${escapeAttribute(style)}" />
+		</@liferay_ui.csp>
 	</div>
 
 	${fieldStructure.children}


### PR DESCRIPTION
Parent issue: [LPD-52980](https://liferay.atlassian.net/browse/LPD-52980)

Note to reviewer: We were not able to render this file. This might be a dead file. We tried in master, 7.3, 7.2 and 7.0. But because we are not 100% sure, we need to deal with the occurrence of an inline style. And because we are not able to render it, we need to change this blindly, without knowing what `fieldStructure.style` returns and the actual DOM result. In this case, where we have a dynamic value in a Freemarker file that we cannot render, I think that using `<@liferay_ui.csp>` is necessary to prevent a possible breakup of the Portal if a security content policy is enabled. An analysis to check if these possibly dead files could be deleted should follow after.

[LPD-52980]: https://liferay.atlassian.net/browse/LPD-52980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ