### PR TITLE
LPD-52725 Follow up fluid layout on forms data-provider

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/navigation_bar.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/navigation_bar.jsp
@@ -8,7 +8,6 @@
 <%@ include file="/init.jsp" %>
 
 <clay:navigation-bar
-	cssClass="container-fluid-max-xxxl"
 	inverted="<%= true %>"
 	navigationItems="<%= ddmDataProviderDisplayContext.getNavigationItems(liferayPortletRequest, liferayPortletResponse) %>"
 />


### PR DESCRIPTION
Removing leftover excess styling already covered by Clay
See how it was:
![image](https://github.com/user-attachments/assets/58ac659a-ce1a-4fd6-874b-64c0e94352b1)
And after removing:
![image](https://github.com/user-attachments/assets/02d7b3cb-cf8d-452c-9711-190a2fed75ee)

