### PR TITLE
LPD-53553 [Test Fix] portal-workflow-kaleo-designer-web/actions.spec.ts > can save a workflow definition that has a customer extension action after changing from an Update

### DIFF
--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/NodePropertiesSidebarPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/NodePropertiesSidebarPage.ts
@@ -19,6 +19,7 @@ export class NodePropertiesSidebarPage {
 	readonly deleteNotificationsButton: Locator;
 	readonly diagramViewPage: DiagramViewPage;
 	readonly editAssignmentButton: Locator;
+	readonly editActionButton: Locator;
 	readonly nodeLabelInput: Locator;
 	readonly notificationPage: NotificationSectionPage;
 	readonly page: Page;
@@ -50,6 +51,10 @@ export class NodePropertiesSidebarPage {
 		this.editAssignmentButton = page
 			.getByRole('tablist')
 			.filter({hasText: 'Assignments'})
+			.locator('a');
+		this.editActionButton = page
+			.getByRole('tablist')
+			.filter({hasText: 'Actions'})
 			.locator('a');
 		this.nodeLabelInput = page.locator('#workflowDefinitionBaseNodeLabel');
 		this.notificationPage = new NotificationSectionPage(page);

--- a/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/actions.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/actions.spec.ts
@@ -159,6 +159,7 @@ test('cannot save a workflow definition that has a java action when the script m
 test('can save a workflow definition that has a customer extension action after changing from an UpdateStatus to a customer extension action', async ({
 	apiHelpers,
 	diagramViewPage,
+	nodePropertiesSidebarPage,
 	page,
 	processBuilderPage,
 }) => {
@@ -177,6 +178,8 @@ test('can save a workflow definition that has a customer extension action after 
 	);
 
 	await diagramViewPage.clickNode('Review');
+
+	await nodePropertiesSidebarPage.editActionButton.click();
 
 	await page
 		.locator('#type')


### PR DESCRIPTION
Issue was happening because the Workflow action type detail was being checked before Action be clicked first.

![image](https://github.com/user-attachments/assets/d0a05376-c94b-4bdc-bc60-0dd99619731b)

![image](https://github.com/user-attachments/assets/73c803d3-8fbf-4a9e-894d-b0ef637697fb)

I've added a locator in _NodePropertiesSidebarPage_ to track the Actions section and used it.
