### PR TITLE
LPD-54428 Using the ProviderType annotation on WorkflowMetricsReindexerRegistry to fix Workflow Metrics

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/InstanceWorkflowMetricsReindexer.java
@@ -27,12 +27,14 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=instance",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class InstanceWorkflowMetricsReindexer
 	implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "instance";
+	}
 
 	@Override
 	public void reindex(long companyId) throws PortalException {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/NodeWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/NodeWorkflowMetricsReindexer.java
@@ -30,11 +30,13 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=node",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class NodeWorkflowMetricsReindexer implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "node";
+	}
 
 	@Override
 	public void reindex(long companyId) throws PortalException {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/ProcessWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/ProcessWorkflowMetricsReindexer.java
@@ -24,12 +24,14 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=process",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class ProcessWorkflowMetricsReindexer
 	implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "process";
+	}
 
 	@Override
 	public void reindex(long companyId) throws PortalException {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TaskWorkflowMetricsReindexer.java
@@ -29,11 +29,13 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=task",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class TaskWorkflowMetricsReindexer implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "task";
+	}
 
 	@Override
 	public void reindex(long companyId) throws PortalException {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TransitionWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/search/index/reindexer/TransitionWorkflowMetricsReindexer.java
@@ -26,12 +26,14 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=transition",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class TransitionWorkflowMetricsReindexer
 	implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "transition";
+	}
 
 	@Override
 	public void reindex(long companyId) throws PortalException {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/bnd.bnd
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Metrics API
 Bundle-SymbolicName: com.liferay.portal.workflow.metrics.api
-Bundle-Version: 15.0.6
+Bundle-Version: 16.0.0
 Export-Package:\
 	com.liferay.portal.workflow.metrics.exception,\
 	com.liferay.portal.workflow.metrics.model,\

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/src/main/java/com/liferay/portal/workflow/metrics/search/index/reindexer/WorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/src/main/java/com/liferay/portal/workflow/metrics/search/index/reindexer/WorkflowMetricsReindexer.java
@@ -12,6 +12,8 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public interface WorkflowMetricsReindexer {
 
+	public String getKey();
+
 	public void reindex(long companyId) throws PortalException;
 
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/src/main/java/com/liferay/portal/workflow/metrics/search/index/reindexer/WorkflowMetricsReindexerRegistry.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/src/main/java/com/liferay/portal/workflow/metrics/search/index/reindexer/WorkflowMetricsReindexerRegistry.java
@@ -7,9 +7,12 @@ package com.liferay.portal.workflow.metrics.search.index.reindexer;
 
 import java.util.Set;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Jiaxu Wei
  */
+@ProviderType
 public interface WorkflowMetricsReindexerRegistry {
 
 	public boolean containsKey(String indexEntityName);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/src/main/resources/com/liferay/portal/workflow/metrics/search/index/reindexer/packageinfo
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-api/src/main/resources/com/liferay/portal/workflow/metrics/search/index/reindexer/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/search/index/reindexer/WorkflowMetricsReindexerRegistryImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/search/index/reindexer/WorkflowMetricsReindexerRegistryImpl.java
@@ -44,8 +44,13 @@ public class WorkflowMetricsReindexerRegistryImpl
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
-			bundleContext, WorkflowMetricsReindexer.class,
-			"workflow.metrics.index.entity.name");
+			bundleContext, WorkflowMetricsReindexer.class, null,
+			(serviceReference, emitter) -> {
+				WorkflowMetricsReindexer workflowMetricsReindexer =
+					bundleContext.getService(serviceReference);
+
+				emitter.emit(workflowMetricsReindexer.getKey());
+			});
 	}
 
 	@Deactivate

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsReindexBackgroundTaskExecutor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsReindexBackgroundTaskExecutor.java
@@ -17,8 +17,6 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
 import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -144,22 +142,8 @@ public class WorkflowMetricsReindexBackgroundTaskExecutor
 				(String[])taskContextMap.get(
 					"workflow.metrics.index.entity.names"),
 				name -> {
-					try {
-						WorkflowMetricsIndex workflowMetricsIndex =
-							WorkflowMetricsIndex.toWorkflowMetricsIndex(name);
-
-						if (_workflowMetricsReindexerRegistry.containsKey(
-								workflowMetricsIndex.name())) {
-
-							return name;
-						}
-
-						return null;
-					}
-					catch (IllegalArgumentException illegalArgumentException) {
-						_log.error(
-							"Unknown workflow metrics index: " + name,
-							illegalArgumentException);
+					if (_workflowMetricsReindexerRegistry.containsKey(name)) {
+						return name;
 					}
 
 					return null;
@@ -198,9 +182,6 @@ public class WorkflowMetricsReindexBackgroundTaskExecutor
 		_backgroundTaskStatusMessageSender.sendBackgroundTaskStatusMessage(
 			message);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		WorkflowMetricsReindexBackgroundTaskExecutor.class);
 
 	@Reference
 	private BackgroundTaskStatusMessageSender

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLAInstanceResultWorkflowMetricsReindexer.java
@@ -34,12 +34,14 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=sla-instance-result",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class SLAInstanceResultWorkflowMetricsReindexer
 	implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "sla-instance-result";
+	}
 
 	@Override
 	public void reindex(long companyId) throws PortalException {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/reindexer/SLATaskResultWorkflowMetricsReindexer.java
@@ -34,12 +34,14 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Rafael Praxedes
  */
-@Component(
-	property = "workflow.metrics.index.entity.name=sla-task-result",
-	service = WorkflowMetricsReindexer.class
-)
+@Component(service = WorkflowMetricsReindexer.class)
 public class SLATaskResultWorkflowMetricsReindexer
 	implements WorkflowMetricsReindexer {
+
+	@Override
+	public String getKey() {
+		return "sla-task-result";
+	}
 
 	@Override
 	public void reindex(long companyId) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/util/BaseWorkflowMetricsIndexerTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/service/util/BaseWorkflowMetricsIndexerTestCase.java
@@ -39,6 +39,7 @@ import com.liferay.portal.workflow.kaleo.service.KaleoNodeLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskInstanceTokenLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoTaskLocalService;
 import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexer;
+import com.liferay.portal.workflow.metrics.search.index.reindexer.WorkflowMetricsReindexerRegistry;
 
 import java.io.Serializable;
 
@@ -465,17 +466,24 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 		}
 	}
 
+	private void _reindex(long companyId, String key) throws Exception {
+		WorkflowMetricsReindexer reindexer =
+			_workflowMetricsReindexerRegistry.getWorkflowMetricsReindexer(key);
+
+		reindexer.reindex(companyId);
+	}
+
 	private void _reindexMetricIndexes(long companyId) throws Exception {
-		_instanceWorkflowMetricsReindexer.reindex(companyId);
-		_nodeWorkflowMetricsReindexer.reindex(companyId);
-		_processWorkflowMetricsReindexer.reindex(companyId);
-		_taskWorkflowMetricsReindexer.reindex(companyId);
-		_transitionWorkflowMetricsReindexer.reindex(companyId);
+		_reindex(companyId, "instance");
+		_reindex(companyId, "node");
+		_reindex(companyId, "process");
+		_reindex(companyId, "task");
+		_reindex(companyId, "transition");
 	}
 
 	private void _reindexSLAIndexes(long companyId) throws Exception {
-		_slaInstanceResultWorkflowMetricsReindexer.reindex(companyId);
-		_slaTaskResultWorkflowMetricsReindexer.reindex(companyId);
+		_reindex(companyId, "sla-instance-result");
+		_reindex(companyId, "sla-task-result");
 	}
 
 	private final List<BlogsEntry> _blogsEntries = new ArrayList<>();
@@ -485,9 +493,6 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 
 	@Inject
 	private DocumentBuilderFactory _documentBuilderFactory;
-
-	@Inject(filter = "workflow.metrics.index.entity.name=instance")
-	private WorkflowMetricsReindexer _instanceWorkflowMetricsReindexer;
 
 	private KaleoDefinition _kaleoDefinition;
 
@@ -519,29 +524,14 @@ public abstract class BaseWorkflowMetricsIndexerTestCase
 
 	private final List<KaleoTask> _kaleoTasks = new ArrayList<>();
 
-	@Inject(filter = "workflow.metrics.index.entity.name=node")
-	private WorkflowMetricsReindexer _nodeWorkflowMetricsReindexer;
-
-	@Inject(filter = "workflow.metrics.index.entity.name=process")
-	private WorkflowMetricsReindexer _processWorkflowMetricsReindexer;
-
-	@Inject(filter = "workflow.metrics.index.entity.name=sla-instance-result")
-	private WorkflowMetricsReindexer _slaInstanceResultWorkflowMetricsReindexer;
-
-	@Inject(filter = "workflow.metrics.index.entity.name=sla-task-result")
-	private WorkflowMetricsReindexer _slaTaskResultWorkflowMetricsReindexer;
-
-	@Inject(filter = "workflow.metrics.index.entity.name=task")
-	private WorkflowMetricsReindexer _taskWorkflowMetricsReindexer;
-
-	@Inject(filter = "workflow.metrics.index.entity.name=transition")
-	private WorkflowMetricsReindexer _transitionWorkflowMetricsReindexer;
-
 	@Inject
 	private WorkflowDefinitionLinkLocalService
 		_workflowDefinitionLinkLocalService;
 
 	@Inject
 	private WorkflowInstanceLinkLocalService _workflowInstanceLinkLocalService;
+
+	@Inject
+	private WorkflowMetricsReindexerRegistry _workflowMetricsReindexerRegistry;
 
 }


### PR DESCRIPTION
Using the ProviderType annotation on WorkflowMetricsReindexerRegistry to to fix the problem on getting the serviceTrackerMap, fixing the problem with reindexing on Workflow Metrics.