### PR TITLE
LPD-54351 Add tests for unsupported translation alert on object fields

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/TranslationOptionsContainer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/TranslationOptionsContainer.spec.tsx
@@ -1,0 +1,173 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+import {render, screen} from '@testing-library/react';
+
+import {TranslationOptionsContainer} from '../../components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer';
+
+const mockLearnResources = {
+	'object-web': {
+		'localizing-object-definitions-and-entries': {
+			en_US: {
+				message: 'Learn more.',
+				url: 'https://learn.liferay.com',
+			},
+		},
+	},
+};
+
+const defaultProps = {
+	learnResources: mockLearnResources,
+	published: false,
+	setValues: jest.fn(),
+	values: {},
+};
+
+const alertIsRendered = () => {
+	expect(screen.getByText('info:')).toBeInTheDocument();
+
+	expect(
+		screen.getByText('this-field-type-does-not-support-translations')
+	).toBeInTheDocument();
+
+	expect(screen.getByText('Learn more.')).toBeInTheDocument();
+};
+
+const alertNotRendered = () => {
+	expect(
+		screen.queryByText('this-field-type-does-not-support-translations')
+	).toBeNull();
+};
+
+const renderComponent = (props = {}) => {
+	render(<TranslationOptionsContainer {...defaultProps} {...props} />);
+};
+
+describe('When the feature flag LPD-32050 is enabled', () => {
+	beforeAll(() => {
+		global.Liferay = {
+			...global.Liferay,
+			FeatureFlags: {
+				...global.Liferay?.FeatureFlags,
+				'LPD-32050': true,
+			},
+		};
+	});
+
+	test.each`
+		businessType             | system   | shouldRenderAlert
+		${'Aggregation'}         | ${false} | ${'render'}
+		${'Attachment'}          | ${false} | ${'not render'}
+		${'AutoIncrement'}       | ${false} | ${'render'}
+		${'Boolean'}             | ${false} | ${'not render'}
+		${'Date'}                | ${false} | ${'not render'}
+		${'DateTime'}            | ${false} | ${'not render'}
+		${'Decimal'}             | ${false} | ${'not render'}
+		${'Encrypted'}           | ${false} | ${'render'}
+		${'Formula'}             | ${false} | ${'render'}
+		${'Integer'}             | ${false} | ${'not render'}
+		${'LongInteger'}         | ${false} | ${'not render'}
+		${'LongText'}            | ${false} | ${'not render'}
+		${'MultiselectPicklist'} | ${false} | ${'not render'}
+		${'RichText'}            | ${false} | ${'not render'}
+		${'Picklist'}            | ${false} | ${'not render'}
+		${'PrecisionDecimal'}    | ${false} | ${'not render'}
+		${'Text'}                | ${false} | ${'not render'}
+		${'Aggregation'}         | ${true}  | ${'render'}
+		${'Attachment'}          | ${true}  | ${'render'}
+		${'AutoIncrement'}       | ${true}  | ${'render'}
+		${'Boolean'}             | ${true}  | ${'render'}
+		${'Date'}                | ${true}  | ${'render'}
+		${'DateTime'}            | ${true}  | ${'render'}
+		${'Decimal'}             | ${true}  | ${'render'}
+		${'Encrypted'}           | ${true}  | ${'render'}
+		${'Formula'}             | ${true}  | ${'render'}
+		${'Integer'}             | ${true}  | ${'render'}
+		${'LongInteger'}         | ${true}  | ${'render'}
+		${'LongText'}            | ${true}  | ${'render'}
+		${'MultiselectPicklist'} | ${true}  | ${'render'}
+		${'RichText'}            | ${true}  | ${'render'}
+		${'Picklist'}            | ${true}  | ${'render'}
+		${'PrecisionDecimal'}    | ${true}  | ${'render'}
+		${'Text'}                | ${true}  | ${'render'}
+	`(
+		'the object field $businessType system $system should $shouldRenderAlert the translation alert',
+		({businessType, shouldRenderAlert, system}) => {
+			renderComponent({values: {businessType, system}});
+
+			if (shouldRenderAlert === 'render') {
+				alertIsRendered();
+			}
+			else {
+				alertNotRendered();
+			}
+		}
+	);
+});
+
+describe('When the feature flag LPD-32050 is disabled', () => {
+	beforeAll(() => {
+		global.Liferay = {
+			...global.Liferay,
+			FeatureFlags: {
+				...global.Liferay?.FeatureFlags,
+				'LPD-32050': false,
+			},
+		};
+	});
+
+	test.each`
+		businessType             | system   | shouldRenderAlert
+		${'Aggregation'}         | ${false} | ${'render'}
+		${'Attachment'}          | ${false} | ${'render'}
+		${'AutoIncrement'}       | ${false} | ${'render'}
+		${'Boolean'}             | ${false} | ${'render'}
+		${'Date'}                | ${false} | ${'render'}
+		${'DateTime'}            | ${false} | ${'render'}
+		${'Decimal'}             | ${false} | ${'render'}
+		${'Encrypted'}           | ${false} | ${'render'}
+		${'Formula'}             | ${false} | ${'render'}
+		${'Integer'}             | ${false} | ${'render'}
+		${'LongInteger'}         | ${false} | ${'render'}
+		${'LongText'}            | ${false} | ${'not render'}
+		${'MultiselectPicklist'} | ${false} | ${'render'}
+		${'RichText'}            | ${false} | ${'not render'}
+		${'Picklist'}            | ${false} | ${'render'}
+		${'PrecisionDecimal'}    | ${false} | ${'render'}
+		${'Text'}                | ${false} | ${'not render'}
+		${'Aggregation'}         | ${true}  | ${'render'}
+		${'Attachment'}          | ${true}  | ${'render'}
+		${'AutoIncrement'}       | ${true}  | ${'render'}
+		${'Boolean'}             | ${true}  | ${'render'}
+		${'Date'}                | ${true}  | ${'render'}
+		${'DateTime'}            | ${true}  | ${'render'}
+		${'Decimal'}             | ${true}  | ${'render'}
+		${'Encrypted'}           | ${true}  | ${'render'}
+		${'Formula'}             | ${true}  | ${'render'}
+		${'Integer'}             | ${true}  | ${'render'}
+		${'LongInteger'}         | ${true}  | ${'render'}
+		${'LongText'}            | ${true}  | ${'render'}
+		${'MultiselectPicklist'} | ${true}  | ${'render'}
+		${'RichText'}            | ${true}  | ${'render'}
+		${'Picklist'}            | ${true}  | ${'render'}
+		${'PrecisionDecimal'}    | ${true}  | ${'render'}
+		${'Text'}                | ${true}  | ${'render'}
+	`(
+		'the object field $businessType system $system should $shouldRenderAlert the translation alert',
+		({businessType, shouldRenderAlert, system}) => {
+			renderComponent({values: {businessType, system}});
+
+			if (shouldRenderAlert === 'render') {
+				alertIsRendered();
+			}
+			else {
+				alertNotRendered();
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/object-web/main/objectFields.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectFields.spec.ts
@@ -754,6 +754,58 @@ test.describe('Manage object fields through Model Builder', () => {
 			)
 		).toBeVisible();
 	});
+
+	test('navigates to documentation from the "unsupported translations" alert link', async ({
+		apiHelpers,
+		modelBuilderDiagramPage,
+		modelBuilderLeftSidebarPage,
+		modelBuilderObjectDefinitionNodePage,
+		page,
+	}) => {
+		const {objectFields} = await mockObjectFields({
+			apiHelpers,
+			objectFieldBusinessTypes: ['encrypted'],
+		});
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFields,
+				objectFolderExternalReferenceCode: 'default',
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		await modelBuilderDiagramPage.goto({objectFolderName: 'Default'});
+
+		await modelBuilderLeftSidebarPage.sidebarItems
+			.filter({hasText: objectDefinition.label['en_US']})
+			.click();
+
+		await modelBuilderObjectDefinitionNodePage.clickShowAllFieldsButton(
+			objectDefinition.label['en_US'],
+			modelBuilderDiagramPage.objectDefinitionNodes
+		);
+
+		await page.getByText('Encrypted', {exact: true}).click();
+
+		const pagePromise = page.waitForEvent('popup');
+
+		await page
+			.getByRole('link', {name: 'Learn more. (Opens a new window)'})
+			.click();
+
+		const newPage = await pagePromise;
+
+		await expect(
+			newPage.getByRole('heading', {
+				name: 'Localizing Object Definitions',
+			})
+		).toBeVisible();
+	});
 });
 
 test.describe('Manage objectFields through Objects Admin UI', () => {
@@ -1088,5 +1140,47 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 		expect(objectFieldsPage.externalReferenceCodeField).toHaveValue(
 			ERCValue
 		);
+	});
+
+	test('navigates to documentation from the "unsupported translations" alert link', async ({
+		apiHelpers,
+		objectFieldsPage,
+		page,
+	}) => {
+		const {objectFields} = await mockObjectFields({
+			apiHelpers,
+			objectFieldBusinessTypes: ['encrypted'],
+		});
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFields,
+				objectFolderExternalReferenceCode: 'default',
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		await objectFieldsPage.goto(objectDefinition.label['en_US']);
+
+		await objectFieldsPage.openObjectField(objectFields[0].label['en_US']);
+
+		const pagePromise = page.waitForEvent('popup');
+
+		await page
+			.frameLocator('iframe')
+			.getByRole('link', {name: 'Learn more. (Opens a new window)'})
+			.click();
+
+		const newPage = await pagePromise;
+
+		await expect(
+			newPage.getByRole('heading', {
+				name: 'Localizing Object Definitions',
+			})
+		).toBeVisible();
 	});
 });


### PR DESCRIPTION
### References:
- Parent Task: [Add tests for unsupported translation alert on object fields](https://liferay.atlassian.net/browse/LPD-54351)
- Related Pull Request: https://github.com/liferay-bpm/liferay-portal/pull/4441

### What is the goal of this PR?

The unit tests aim to ensure the correct rendering of the alert message informing the user that a field does not support translation in its entries. This rendering is conditioned by various combinations of business rules. The strategy adopted was to use [test.each](https://jestjs.io/docs/api#describeeachtablename-fn-timeout) to duplicate test suites with different datasets. This approach allowed us to cover 68 scenarios, encompassing all object field types (business, system, and custom), with and without the feature flag. 

Within these unit tests, I chose to isolate the cases with the feature flag enabled and disabled into separate suites. This will facilitate the removal of tests with the feature flag disabled once that functionality is removed. I also decided to organize the table in a way that would make it easier to understand the expected result. But suggestions are welcome.

The functional tests are responsible for validating the correct redirection to the documentation.

Two functional tests are necessary because the learnResources parameter is passed through two different JSPs, and we need to ensure functionality in both cases.

### What does the unit test look like when it fails?

![image](https://github.com/user-attachments/assets/3d5c44e8-fb15-4cc3-9b48-3e0c15a26278)

Note that the terms "Text", "true" and "render" come from `$businessType`, `$system` and `$shouldRenderAlert`. 

For this reason I chose not to use Boolean values ​​for the `$shouldRenderAlert` column.