### PR TITLE
LPD-55309 Show object permissions in the correct group

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -866,6 +866,47 @@ public class ObjectEntry implements Serializable {
 	private Supplier<Date> _reviewDateSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getScopeId() {
+		if (_scopeIdSupplier != null) {
+			scopeId = _scopeIdSupplier.get();
+
+			_scopeIdSupplier = null;
+		}
+
+		return scopeId;
+	}
+
+	public void setScopeId(Long scopeId) {
+		this.scopeId = scopeId;
+
+		_scopeIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setScopeId(
+		UnsafeSupplier<Long, Exception> scopeIdUnsafeSupplier) {
+
+		_scopeIdSupplier = () -> {
+			try {
+				return scopeIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long scopeId;
+
+	@JsonIgnore
+	private Supplier<Long> _scopeIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getScopeKey() {
 		if (_scopeKeySupplier != null) {
 			scopeKey = _scopeKeySupplier.get();
@@ -1153,6 +1194,9 @@ public class ObjectEntry implements Serializable {
 		}
 		else if (Objects.equals(propertyName, "reviewDate")) {
 			return getReviewDate();
+		}
+		else if (Objects.equals(propertyName, "scopeId")) {
+			return getScopeId();
 		}
 		else if (Objects.equals(propertyName, "scopeKey")) {
 			return getScopeKey();
@@ -1520,6 +1564,18 @@ public class ObjectEntry implements Serializable {
 			sb.append(liferayToJSONDateFormat.format(reviewDate));
 
 			sb.append("\"");
+		}
+
+		Long scopeId = getScopeId();
+
+		if (scopeId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"scopeId\": ");
+
+			sb.append(scopeId);
 		}
 
 		String scopeKey = getScopeKey();

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -165,6 +165,10 @@ components:
                 reviewDate:
                     format: date
                     type: string
+                scopeId:
+                    format: int64
+                    readOnly: true
+                    type: integer
                 scopeKey:
                     readOnly: true
                     type: string

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -380,6 +380,7 @@ public class ObjectEntryDTOConverter
 						ObjectEntryVersionModel::getReviewDate,
 						serviceBuilderObjectEntry,
 						ObjectEntryModel::getReviewDate));
+				setScopeId(serviceBuilderObjectEntry::getGroupId);
 				setScopeKey(
 					() -> _getScopeKey(
 						objectDefinition, serviceBuilderObjectEntry));

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/dto/v1_0/converter/test/ObjectEntryDTOConverterTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/dto/v1_0/converter/test/ObjectEntryDTOConverterTest.java
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.dto.v1_0.converter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Adolfo Pérez
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryDTOConverterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testToDTO() throws Exception {
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"name"
+				).build()),
+			ObjectDefinitionConstants.SCOPE_SITE);
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.addObjectEntry(
+				TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				null,
+				HashMapBuilder.<String, Serializable>put(
+					"name", StringUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getGroupId()));
+
+		Group group = _groupLocalService.getGroup(
+			serviceBuilderObjectEntry.getGroupId());
+
+		ObjectEntry objectEntry = _toDTO(serviceBuilderObjectEntry);
+
+		Assert.assertEquals(
+			group.getGroupId(), GetterUtil.getLong(objectEntry.getScopeId()));
+		Assert.assertEquals(group.getGroupKey(), objectEntry.getScopeKey());
+	}
+
+	private ObjectEntry _toDTO(
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry)
+		throws Exception {
+
+		DTOConverter<com.liferay.object.model.ObjectEntry, ObjectEntry>
+			dtoConverter =
+				(DTOConverter
+					<com.liferay.object.model.ObjectEntry, ObjectEntry>)
+						_dtoConverterRegistry.getDTOConverter(
+							com.liferay.object.model.ObjectEntry.class.
+								getName());
+
+		DefaultDTOConverterContext dtoConverterContext =
+			new DefaultDTOConverterContext(
+				_dtoConverterRegistry,
+				serviceBuilderObjectEntry.getObjectEntryId(),
+				LocaleUtil.getDefault(), null, null);
+
+		dtoConverterContext.setAttribute("objectDefinition", _objectDefinition);
+
+		return dtoConverter.toDTO(
+			dtoConverterContext, serviceBuilderObjectEntry);
+	}
+
+	@Inject
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSpacesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/AllSpacesSectionDisplayContext.java
@@ -143,6 +143,8 @@ public class AllSpacesSectionDisplayContext {
 				).setParameter(
 					"modelResourceDescription", "{name}"
 				).setParameter(
+					"resourceGroupId", "{embedded.scopeId}"
+				).setParameter(
 					"resourcePrimKey", "{id}"
 				).setWindowState(
 					LiferayWindowState.POP_UP

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseSectionDisplayContext.java
@@ -223,6 +223,8 @@ public abstract class BaseSectionDisplayContext {
 				).setParameter(
 					"modelResourceDescription", "{embedded.name}"
 				).setParameter(
+					"resourceGroupId", "{embedded.scopeId}"
+				).setParameter(
 					"resourcePrimKey", "{embedded.id}"
 				).setWindowState(
 					LiferayWindowState.POP_UP


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-55309

In the CMS, we need to set/get the permissions from the correct group -- the space -- but currently they're get/set in the CMS group.

# How am I fixing it?

By exposing the group ID (scope ID) in the Objects headless API and providing that value to the permissions modal.