### PR TITLE
LPD-55285 Reducing the size of JSON returned by the server by removing availableLocales from each DDMFormField

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -51,6 +51,7 @@ export function useForm(): ({
 }) => void;
 
 export function useFormState<T extends {[key: string]: unknown}>(): T & {
+	availableLocales: AvailableLocale[];
 	defaultLanguageId: Liferay.Language.Locale;
 	editingLanguageId: Liferay.Language.Locale;
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRenderingContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRenderingContext.java
@@ -6,6 +6,7 @@
 package com.liferay.dynamic.data.mapping.form.renderer;
 
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -29,6 +30,10 @@ public class DDMFormRenderingContext {
 
 	public void addProperty(String key, Object value) {
 		_properties.put(key, value);
+	}
+
+	public JSONArray getAvailableLocalesJSONArray() {
+		return _availableLocalesJSONArray;
 	}
 
 	public String getCancelLabel() {
@@ -121,6 +126,12 @@ public class DDMFormRenderingContext {
 
 	public boolean isViewMode() {
 		return MapUtil.getBoolean(_properties, "viewMode");
+	}
+
+	public void setAvailableLocalesJSONArray(
+		JSONArray availableLocalesJSONArray) {
+
+		_availableLocalesJSONArray = availableLocalesJSONArray;
 	}
 
 	public void setCancelLabel(String cancelLabel) {
@@ -221,6 +232,7 @@ public class DDMFormRenderingContext {
 		return "ddmForm".concat(StringUtil.randomString());
 	}
 
+	private JSONArray _availableLocalesJSONArray;
 	private String _cancelLabel;
 	private String _containerId;
 	private long _ddmFormInstanceId;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldTemplateContextContributorUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldTemplateContextContributorUtil.java
@@ -12,9 +12,6 @@ import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -36,11 +33,6 @@ public class DDMFormFieldTemplateContextContributorUtil {
 		JSONObject localeJSONObject = _getLocaleJSONObject(defaultLocale);
 
 		return HashMapBuilder.<String, Object>put(
-			"availableLocales",
-			JSONUtil.toJSONArray(
-				LanguageUtil.getAvailableLocales(),
-				locale -> _getLocaleJSONObject(locale), _log)
-		).put(
 			"defaultLocale", localeJSONObject
 		).put(
 			"editingLocale", localeJSONObject
@@ -142,8 +134,5 @@ public class DDMFormFieldTemplateContextContributorUtil {
 			"localeId", languageId
 		);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		DDMFormFieldTemplateContextContributorUtil.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -19,7 +19,6 @@ import {useNumericInputValueMemo} from './hooks';
 import {getSymbols, maxLengthExceeded} from './numericUtil';
 
 import './Numeric.scss';
-import {AvailableLocale} from '../util/localizable/LocalesDropdown';
 
 import type {FieldChangeEventHandler, Locale, LocalizedValue} from '../types';
 
@@ -122,7 +121,6 @@ export default withConfirmationField(Main);
 export type NumericProps = {
 	append: string;
 	appendType: 'prefix' | 'suffix';
-	availableLocales: AvailableLocale[];
 	dataType: NumericDataType;
 	decimalPlaces: number;
 	defaultLanguageId: Locale;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/CheckboxLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/CheckboxLocalizedObjectField.tsx
@@ -8,15 +8,13 @@ import {useFormState} from 'data-engine-js-components-web';
 import React from 'react';
 
 import CheckboxBase, {ICheckboxBaseProps} from '../Checkbox/CheckboxBase';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import type {FieldChangeEventHandler, LocalizedValue} from '../types';
 
 export default function CheckboxLocalizedObjectField(props: IProps) {
-	const {editingLanguageId} = useFormState();
-	const {availableLocales, fieldName, onChange, value} = props;
+	const {availableLocales, editingLanguageId} = useFormState();
+	const {fieldName, onChange, value} = props;
 	const checked = !!value[editingLanguageId];
 
 	const handleCheckboxToggle: FieldChangeEventHandler<
@@ -55,7 +53,6 @@ export default function CheckboxLocalizedObjectField(props: IProps) {
 }
 
 export interface IProps extends ICheckboxBaseProps {
-	availableLocales: AvailableLocale[];
 	editOnlyInDefaultLanguage: boolean;
 	errorMessage: string;
 	fieldName: string;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/DatePickerLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/DatePickerLocalizedObjectField.tsx
@@ -13,9 +13,7 @@ import React, {useMemo} from 'react';
 import DatePickerBase, {
 	DatePickerBaseProps,
 } from '../DatePicker/DatePickerBase';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import './DatePickerLocalizedObjectField.scss';
 
@@ -30,7 +28,6 @@ export default function DatePickerLocalizedObjectField(
 	props: DatePickerLocalizedProps
 ) {
 	const {
-		availableLocales,
 		defaultLanguageId,
 		fieldName,
 		localizable,
@@ -41,7 +38,7 @@ export default function DatePickerLocalizedObjectField(
 		value,
 	} = props;
 
-	const {editingLanguageId} = useFormState();
+	const {availableLocales, editingLanguageId} = useFormState();
 
 	const dateMaskParams: DateMaskParams = useMemo(() => {
 		let parameters: DateMaskParams = {};
@@ -133,7 +130,6 @@ export interface DatePickerLocalizedProps extends DatePickerBaseProps {
 		'aria-describedby'?: string;
 		'aria-required': boolean;
 	};
-	availableLocales: AvailableLocale[];
 	fieldName: string;
 	onChange: any;
 	value: LocalizedValue<string>;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/MultipleSelectLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/MultipleSelectLocalizedObjectField.tsx
@@ -11,25 +11,21 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {MultipleSelectBase} from '../Select/MultipleSelectBase';
 import {MultipleSelectBaseProps} from '../Select/select.d';
 import {LocalizedValue} from '../types';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import type {Locale} from '../types';
 
 type valueTypes = string[] | LocalizedValue<string[]>;
 
-export interface MultipleSelectLocalizedObjectFieldProps
-	extends MultipleSelectBaseProps<string[] | LocalizedValue<string[]>> {
-	availableLocales: AvailableLocale[];
-}
+export type MultipleSelectLocalizedObjectFieldProps = MultipleSelectBaseProps<
+	string[] | LocalizedValue<string[]>
+>;
 
 function getDefaultValue(locale: Locale, value: valueTypes) {
 	return Array.isArray(value) ? {[locale]: value} : value;
 }
 
 export default function MultipleSelectLocalizedObjectField({
-	availableLocales,
 	errorMessage,
 	fieldName,
 	id,
@@ -42,7 +38,8 @@ export default function MultipleSelectLocalizedObjectField({
 	tip,
 	value,
 }: MultipleSelectLocalizedObjectFieldProps) {
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	const [localizedValues, setLocalizedValues] = useState(
 		getDefaultValue(editingLanguageId, value)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/NumericLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/NumericLocalizedObjectField.tsx
@@ -18,7 +18,6 @@ import {LocalizedValue} from '../types';
 import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 export default function NumericLocalizedObjectField({
-	availableLocales,
 	dataType,
 	decimalPlaces,
 	defaultLanguageId,
@@ -36,7 +35,7 @@ export default function NumericLocalizedObjectField({
 	value,
 	...otherProps
 }: NumericProps) {
-	const {editingLanguageId} = useFormState();
+	const {availableLocales, editingLanguageId} = useFormState();
 
 	const symbols = getSymbols({
 		editingLocale: editingLanguageId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/SelectLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/SelectLocalizedObjectField.tsx
@@ -14,9 +14,7 @@ import {useNormalizedOptionsMemo} from '../Select/hooks';
 import {SelectMainProps} from '../Select/select.d';
 import {LocalizedValue} from '../types';
 import {isEmptyObject} from '../util/basicJsUtils';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import './SelectLocalizedObjectField.scss';
 
@@ -26,7 +24,6 @@ type valueTypes = {} | LocalizedValue<string>;
 
 export interface SelectLocalizedObjectFieldProps
 	extends Omit<SelectMainProps, 'value'> {
-	availableLocales: AvailableLocale[];
 	value: valueTypes;
 }
 
@@ -63,7 +60,6 @@ function normalizeValues(
 }
 
 export default function SelectLocalizedObjectField({
-	availableLocales,
 	fieldName,
 	fixedOptions = [],
 	id,
@@ -78,7 +74,8 @@ export default function SelectLocalizedObjectField({
 	value,
 	...otherProps
 }: SelectLocalizedObjectFieldProps) {
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	const normalizedOptions = useNormalizedOptionsMemo({
 		editingLanguageId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
@@ -220,6 +220,10 @@ public class DDMFormTemplateContextFactoryImpl
 			ParamUtil.getInteger(
 				ddmFormRenderingContext.getHttpServletRequest(), "activePage"));
 
+		templateContext.put(
+			"availableLocales",
+			ddmFormRenderingContext.getAvailableLocalesJSONArray());
+
 		_setDDMFormFieldsEvaluableProperty(ddmForm, ddmFormLayout);
 
 		Locale locale = ddmFormRenderingContext.getLocale();

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.tsx
@@ -9,7 +9,6 @@ import {
 	FieldChangeEventHandler,
 	LocalizedValue,
 } from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/types';
-import {AvailableLocale} from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown';
 import {fetch} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -21,7 +20,6 @@ import AttachmentLocalizedObjectField from './AttachmentLocalizedObjectField';
 
 export interface AttachmentProps
 	extends AttachmentBaseProps<string | LocalizedValue<string>> {
-	availableLocales: AvailableLocale[];
 	contentURL?: string;
 	deleteURL?: string;
 	fieldName: string;

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentLocalizedObjectField.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentLocalizedObjectField.tsx
@@ -10,7 +10,6 @@ import {
 	FieldChangeEventHandler,
 	LocalizedValue,
 } from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/types';
-import {AvailableLocale} from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown';
 import React, {useEffect, useState} from 'react';
 
 import AttachmentBase, {
@@ -20,7 +19,6 @@ import AttachmentBase, {
 
 export interface AttachmentLocalizedObjectFieldProps
 	extends AttachmentBaseProps<string | LocalizedValue<string>> {
-	availableLocales: AvailableLocale[];
 	fieldName: string;
 	fileEntryProperties: LocalizedValue<AttachmentFile>;
 	onChange: FieldChangeEventHandler<LocalizedValue<string>>;
@@ -28,7 +26,6 @@ export interface AttachmentLocalizedObjectFieldProps
 }
 
 export default function AttachmentLocalizedObjectField({
-	availableLocales,
 	fieldName,
 	fileEntryProperties,
 	onChange,
@@ -38,7 +35,8 @@ export default function AttachmentLocalizedObjectField({
 	const [attachment, setAttachment] =
 		useState<LocalizedValue<AttachmentFile>>(fileEntryProperties);
 
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	const getAttachment = () => {
 		if (!attachment[editingLanguageId]) {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/MultiselectPicklist/MultiselectPicklist.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/MultiselectPicklist/MultiselectPicklist.tsx
@@ -4,7 +4,6 @@
  */
 
 import {
-	AvailableLocale,
 	LocalizedValue,
 	MultipleSelection,
 	ReactFieldBase as FieldBase,
@@ -20,7 +19,6 @@ interface MultiselectOption {
 type Values = string[] | LocalizedValue<string[]>;
 
 interface MultiselectPicklistProps {
-	availableLocales: AvailableLocale[];
 	defaultLanguageId: Liferay.Language.Locale;
 	errorMessage: string;
 	fieldName: string;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
@@ -674,6 +674,11 @@ public class ObjectEntryDisplayContextImpl
 		DDMFormRenderingContext ddmFormRenderingContext =
 			new DDMFormRenderingContext();
 
+		ddmFormRenderingContext.setAvailableLocalesJSONArray(
+			JSONUtil.toJSONArray(
+				LanguageUtil.getAvailableLocales(),
+				locale -> _getLocaleJSONObject(locale), _log));
+
 		ddmFormRenderingContext.setContainerId("editObjectEntry");
 
 		Locale locale = _themeDisplay.getSiteDefaultLocale();
@@ -1233,6 +1238,19 @@ public class ObjectEntryDisplayContextImpl
 
 			return 0L;
 		}
+	}
+
+	private JSONObject _getLocaleJSONObject(Locale locale) {
+		String languageId = LocaleUtil.toLanguageId(locale);
+
+		return JSONUtil.put(
+			"displayName", locale.getDisplayName(locale)
+		).put(
+			"icon",
+			StringUtil.toLowerCase(StringUtil.replace(languageId, '_', "-"))
+		).put(
+			"localeId", languageId
+		);
 	}
 
 	private List<DDMFormFieldValue> _getNestedDDMFormFieldValues(

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/env/portal-ext.properties
@@ -1,3 +1,3 @@
-com.liferay.portal.kernel.upload.FileItem.threshold.size=3145728
+com.liferay.portal.kernel.upload.FileItem.threshold.size=2097152
 
 database.partition.enabled=true


### PR DESCRIPTION
### References:
- Parent Task: [Slow Form Load After Importing LAR and Enabling All Locales](https://liferay.atlassian.net/browse/LPD-55285)
- Related Pull Request: https://github.com/brianchandotcom/liferay-portal/pull/157452

### What is the goal of this PR?

This pull request aims to remove the passing of the `availableLocales` parameter to all `DDMFormFields`. Instead of React components receiving this information via property, we are passing it through the `FormProvider`

### Evidence

Using Chrome DevTools to limit 4G speed to load a very heavy form that uses data providers and many rules activates in a 1.2 min load on the master.

![image](https://github.com/user-attachments/assets/9cd0a27b-a31d-4ebc-836a-d82e3a9397ad)

With the changes, executing the same action we obtained a result of 21 seconds. Additionally, in the size column we had a 77% reduction in the size of the content returned.

![image](https://github.com/user-attachments/assets/a61208d8-3bbc-4a67-b80b-0c25969d35f0)

Without internet speed limitation settings, this form can be opened in approximately 5 seconds. This is in line with the expected result reported in the ticket.

### Test Case

We have the '[can interact with a large list of fields on the form entries page](https://github.com/liferay-bpm/liferay-portal/blob/9320f13800aaf4317ace878f83d6a51468a14a18/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formEntries.spec.ts#L80)' test that failed after this performance issue. At the time, we did not relate the issues and treated it as a case where the test needed to be corrected.

So we increased the `com.liferay.portal.kernel.upload.FileItem.threshold.size` property, setting its value to 3MB. With this performance improvement, we can go back to using 2MB. If we have other performance issues similar to this one, this test will fail again.