### PR TITLE
LPD-55285 Reducing the size of JSON returned by the server by removing availableLocales from each DDMFormField

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -51,6 +51,7 @@ export function useForm(): ({
 }) => void;
 
 export function useFormState<T extends {[key: string]: unknown}>(): T & {
+	availableLocales: AvailableLocale[];
 	defaultLanguageId: Liferay.Language.Locale;
 	editingLanguageId: Liferay.Language.Locale;
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldTemplateContextContributorUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldTemplateContextContributorUtil.java
@@ -12,9 +12,6 @@ import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -36,11 +33,6 @@ public class DDMFormFieldTemplateContextContributorUtil {
 		JSONObject localeJSONObject = _getLocaleJSONObject(defaultLocale);
 
 		return HashMapBuilder.<String, Object>put(
-			"availableLocales",
-			JSONUtil.toJSONArray(
-				LanguageUtil.getAvailableLocales(),
-				locale -> _getLocaleJSONObject(locale), _log)
-		).put(
 			"defaultLocale", localeJSONObject
 		).put(
 			"editingLocale", localeJSONObject
@@ -142,8 +134,5 @@ public class DDMFormFieldTemplateContextContributorUtil {
 			"localeId", languageId
 		);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		DDMFormFieldTemplateContextContributorUtil.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LocalizableText/LocalizableText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LocalizableText/LocalizableText.es.js
@@ -206,7 +206,6 @@ const LocalizableText = ({
 };
 
 const Main = ({
-	availableLocales,
 	defaultLocale,
 	displayStyle,
 	editingLocale,
@@ -225,7 +224,8 @@ const Main = ({
 	value = {},
 	...otherProps
 }) => {
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	return (
 		<FieldBase

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -19,7 +19,6 @@ import {useNumericInputValueMemo} from './hooks';
 import {getSymbols, maxLengthExceeded} from './numericUtil';
 
 import './Numeric.scss';
-import {AvailableLocale} from '../util/localizable/LocalesDropdown';
 
 import type {FieldChangeEventHandler, Locale, LocalizedValue} from '../types';
 
@@ -122,7 +121,6 @@ export default withConfirmationField(Main);
 export type NumericProps = {
 	append: string;
 	appendType: 'prefix' | 'suffix';
-	availableLocales: AvailableLocale[];
 	dataType: NumericDataType;
 	decimalPlaces: number;
 	defaultLanguageId: Locale;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -50,7 +50,6 @@ const skipsChangeValidation = (fieldName) => {
 };
 
 const RichText = ({
-	availableLocales,
 	defaultLocale = INITIAL_DEFAULT_LOCALE,
 	editable,
 	editingLocale = INITIAL_EDITING_LOCALE,
@@ -72,7 +71,7 @@ const RichText = ({
 	visible,
 	...otherProps
 }) => {
-	const {editingLanguageId} = useFormState();
+	const {availableLocales, editingLanguageId} = useFormState();
 
 	const editorRef = useRef();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/CheckboxLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/CheckboxLocalizedObjectField.tsx
@@ -8,15 +8,13 @@ import {useFormState} from 'data-engine-js-components-web';
 import React from 'react';
 
 import CheckboxBase, {ICheckboxBaseProps} from '../Checkbox/CheckboxBase';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import type {FieldChangeEventHandler, LocalizedValue} from '../types';
 
 export default function CheckboxLocalizedObjectField(props: IProps) {
-	const {editingLanguageId} = useFormState();
-	const {availableLocales, fieldName, onChange, value} = props;
+	const {availableLocales, editingLanguageId} = useFormState();
+	const {fieldName, onChange, value} = props;
 	const checked = !!value[editingLanguageId];
 
 	const handleCheckboxToggle: FieldChangeEventHandler<
@@ -55,7 +53,6 @@ export default function CheckboxLocalizedObjectField(props: IProps) {
 }
 
 export interface IProps extends ICheckboxBaseProps {
-	availableLocales: AvailableLocale[];
 	editOnlyInDefaultLanguage: boolean;
 	errorMessage: string;
 	fieldName: string;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/DatePickerLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/DatePickerLocalizedObjectField.tsx
@@ -13,9 +13,7 @@ import React, {useMemo} from 'react';
 import DatePickerBase, {
 	DatePickerBaseProps,
 } from '../DatePicker/DatePickerBase';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import './DatePickerLocalizedObjectField.scss';
 
@@ -30,7 +28,6 @@ export default function DatePickerLocalizedObjectField(
 	props: DatePickerLocalizedProps
 ) {
 	const {
-		availableLocales,
 		defaultLanguageId,
 		fieldName,
 		localizable,
@@ -41,7 +38,7 @@ export default function DatePickerLocalizedObjectField(
 		value,
 	} = props;
 
-	const {editingLanguageId} = useFormState();
+	const {availableLocales, editingLanguageId} = useFormState();
 
 	const dateMaskParams: DateMaskParams = useMemo(() => {
 		let parameters: DateMaskParams = {};
@@ -133,7 +130,6 @@ export interface DatePickerLocalizedProps extends DatePickerBaseProps {
 		'aria-describedby'?: string;
 		'aria-required': boolean;
 	};
-	availableLocales: AvailableLocale[];
 	fieldName: string;
 	onChange: any;
 	value: LocalizedValue<string>;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/MultipleSelectLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/MultipleSelectLocalizedObjectField.tsx
@@ -11,25 +11,21 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {MultipleSelectBase} from '../Select/MultipleSelectBase';
 import {MultipleSelectBaseProps} from '../Select/select.d';
 import {LocalizedValue} from '../types';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import type {Locale} from '../types';
 
 type valueTypes = string[] | LocalizedValue<string[]>;
 
-export interface MultipleSelectLocalizedObjectFieldProps
-	extends MultipleSelectBaseProps<string[] | LocalizedValue<string[]>> {
-	availableLocales: AvailableLocale[];
-}
+export type MultipleSelectLocalizedObjectFieldProps = MultipleSelectBaseProps<
+	string[] | LocalizedValue<string[]>
+>;
 
 function getDefaultValue(locale: Locale, value: valueTypes) {
 	return Array.isArray(value) ? {[locale]: value} : value;
 }
 
 export default function MultipleSelectLocalizedObjectField({
-	availableLocales,
 	errorMessage,
 	fieldName,
 	id,
@@ -42,7 +38,8 @@ export default function MultipleSelectLocalizedObjectField({
 	tip,
 	value,
 }: MultipleSelectLocalizedObjectFieldProps) {
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	const [localizedValues, setLocalizedValues] = useState(
 		getDefaultValue(editingLanguageId, value)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/NumericLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/NumericLocalizedObjectField.tsx
@@ -18,7 +18,6 @@ import {LocalizedValue} from '../types';
 import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 export default function NumericLocalizedObjectField({
-	availableLocales,
 	dataType,
 	decimalPlaces,
 	defaultLanguageId,
@@ -36,7 +35,7 @@ export default function NumericLocalizedObjectField({
 	value,
 	...otherProps
 }: NumericProps) {
-	const {editingLanguageId} = useFormState();
+	const {availableLocales, editingLanguageId} = useFormState();
 
 	const symbols = getSymbols({
 		editingLocale: editingLanguageId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/SelectLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/localizedObjectFields/SelectLocalizedObjectField.tsx
@@ -14,9 +14,7 @@ import {useNormalizedOptionsMemo} from '../Select/hooks';
 import {SelectMainProps} from '../Select/select.d';
 import {LocalizedValue} from '../types';
 import {isEmptyObject} from '../util/basicJsUtils';
-import LocalesDropdown, {
-	AvailableLocale,
-} from '../util/localizable/LocalesDropdown';
+import LocalesDropdown from '../util/localizable/LocalesDropdown';
 
 import './SelectLocalizedObjectField.scss';
 
@@ -26,7 +24,6 @@ type valueTypes = {} | LocalizedValue<string>;
 
 export interface SelectLocalizedObjectFieldProps
 	extends Omit<SelectMainProps, 'value'> {
-	availableLocales: AvailableLocale[];
 	value: valueTypes;
 }
 
@@ -63,7 +60,6 @@ function normalizeValues(
 }
 
 export default function SelectLocalizedObjectField({
-	availableLocales,
 	fieldName,
 	fixedOptions = [],
 	id,
@@ -78,7 +74,8 @@ export default function SelectLocalizedObjectField({
 	value,
 	...otherProps
 }: SelectLocalizedObjectFieldProps) {
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	const normalizedOptions = useNormalizedOptionsMemo({
 		editingLanguageId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/localizable/text/LocalizableTextDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/localizable/text/LocalizableTextDDMFormFieldTemplateContextContributorTest.java
@@ -55,17 +55,6 @@ public class LocalizableTextDDMFormFieldTemplateContextContributorTest
 	}
 
 	@Test
-	public void testGetAvailableLocales() {
-		Map<String, Object> parameters = _getParameters();
-
-		JSONArray availableLocalesJSONArray = (JSONArray)parameters.get(
-			"availableLocales");
-
-		Assert.assertEquals(
-			_availableLocales.length, availableLocalesJSONArray.length());
-	}
-
-	@Test
 	public void testGetNotDefinedPredefinedValue() {
 		Map<String, Object> parameters = _getParameters();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/LocalizableText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/LocalizableText.es.js
@@ -77,7 +77,11 @@ const LocalizableTextWithProvider = (props) => (
 		<FormProvider
 			initialState={state}
 			reducers={[languageReducer]}
-			value={{defaultLanguageId: 'en_US', editingLanguageId: 'en_US'}}
+			value={{
+				availableLocales,
+				defaultLanguageId: 'en_US',
+				editingLanguageId: 'en_US',
+			}}
 		>
 			<LocalizableText {...props} />
 		</FormProvider>
@@ -97,7 +101,6 @@ afterAll(() => {
 afterEach(cleanup);
 
 const defaultLocalizableTextConfig = {
-	availableLocales,
 	defaultLocale: {
 		displayName: 'English (United States)',
 		icon: 'en-us',
@@ -587,8 +590,6 @@ describe('Field LocalizableText', () => {
 
 			expect(queryAllByText('default')).toHaveLength(1);
 
-			const {availableLocales} = defaultLocalizableTextConfig;
-
 			expect(queryAllByText('not-translated')).toHaveLength(
 				availableLocales.length - 3
 			);
@@ -631,8 +632,6 @@ describe('Field LocalizableText', () => {
 			);
 
 			expect(queryAllByText('customized')).toHaveLength(2);
-
-			const {availableLocales} = defaultLocalizableTextConfig;
 
 			expect(queryAllByText('not-customized')).toHaveLength(
 				availableLocales.length - 2

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormTemplateContextFactoryImpl.java
@@ -27,7 +27,12 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -220,6 +225,12 @@ public class DDMFormTemplateContextFactoryImpl
 			ParamUtil.getInteger(
 				ddmFormRenderingContext.getHttpServletRequest(), "activePage"));
 
+		templateContext.put(
+			"availableLocales",
+			JSONUtil.toJSONArray(
+				LanguageUtil.getAvailableLocales(),
+				locale -> _getLocaleJSONObject(locale), _log));
+
 		_setDDMFormFieldsEvaluableProperty(ddmForm, ddmFormLayout);
 
 		Locale locale = ddmFormRenderingContext.getLocale();
@@ -366,6 +377,19 @@ public class DDMFormTemplateContextFactoryImpl
 		).build();
 	}
 
+	private JSONObject _getLocaleJSONObject(Locale locale) {
+		String languageId = LocaleUtil.toLanguageId(locale);
+
+		return JSONUtil.put(
+			"displayName", locale.getDisplayName(locale)
+		).put(
+			"icon",
+			StringUtil.toLowerCase(StringUtil.replace(languageId, '_', "-"))
+		).put(
+			"localeId", languageId
+		);
+	}
+
 	private List<Object> _getPages(
 		DDMForm ddmForm, DDMFormLayout ddmFormLayout,
 		DDMFormRenderingContext ddmFormRenderingContext) {
@@ -453,6 +477,9 @@ public class DDMFormTemplateContextFactoryImpl
 
 		return TransformUtil.transform(ddmFormRules, this::_toMap);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFormTemplateContextFactoryImpl.class);
 
 	@Reference
 	private DDM _ddm;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -82,6 +82,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -282,6 +283,12 @@ public class DDMFormAdminDisplayContext {
 		}
 
 		return new Locale[] {getDefaultLocale()};
+	}
+
+	public JSONArray getAvailableLocalesJSONArray() {
+		return JSONUtil.toJSONArray(
+			LanguageUtil.getAvailableLocales(),
+			locale -> _getLocaleJSONObject(locale), _log);
 	}
 
 	public String getClearResultsURL() throws PortletException {
@@ -1678,6 +1685,19 @@ public class DDMFormAdminDisplayContext {
 
 			return null;
 		}
+	}
+
+	private JSONObject _getLocaleJSONObject(Locale locale) {
+		String languageId = LocaleUtil.toLanguageId(locale);
+
+		return JSONUtil.put(
+			"displayName", locale.getDisplayName(locale)
+		).put(
+			"icon",
+			StringUtil.toLowerCase(StringUtil.replace(languageId, '_', "-"))
+		).put(
+			"localeId", languageId
+		);
 	}
 
 	private void _populateDDMDataProviderNavigationItem(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -90,6 +90,8 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 					HashMapBuilder.<String, Object>put(
 						"availableLanguageIds", ddmFormAdminDisplayContext.getAvailableLanguageIdsJSONArray()
 					).put(
+						"availableLocales", ddmFormAdminDisplayContext.getAvailableLocalesJSONArray()
+					).put(
 						"context", formBuilderContextJSONObject
 					).put(
 						"dataProviderInstanceParameterSettingsURL", dataProviderInstanceParameterSettingsURL

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -148,6 +148,8 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 					).put(
 						"availableLanguageIds", ddmFormAdminDisplayContext.getAvailableLanguageIdsJSONArray()
 					).put(
+						"availableLocales", ddmFormAdminDisplayContext.getAvailableLocalesJSONArray()
+					).put(
 						"context", formBuilderContextJSONObject
 					).put(
 						"dataEngineModule", ddmFormAdminDisplayContext.getDataEngineModule()

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldTemplateContextContributorUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldTemplateContextContributorUtilTest.java
@@ -8,7 +8,6 @@ package com.liferay.dynamic.data.mapping.util;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.checkbox.CheckboxDDMFormFieldTemplateContextContributor;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.test.util.BaseDDMFormFieldTemplateContextContributorTestCase;
-import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -54,15 +53,11 @@ public class DDMFormFieldTemplateContextContributorUtilTest
 			checkboxDDMFormFieldTemplateContextContributor.getParameters(
 				ddmFormField, createDDMFormFieldRenderingContext());
 
-		JSONArray availableLocalesJSONArray = (JSONArray)parameters.get(
-			"availableLocales");
 		JSONObject defaultLocaleJSONObject = (JSONObject)parameters.get(
 			"defaultLocale");
 		JSONObject editingLocaleJSONObject = (JSONObject)parameters.get(
 			"editingLocale");
 
-		Assert.assertEquals(
-			availableLocales.size(), availableLocalesJSONArray.length());
 		Assert.assertEquals(
 			LocaleUtil.US.toString(), defaultLocaleJSONObject.get("localeId"));
 		Assert.assertEquals(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/test/DDMFormTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/test/DDMFormTemplateContextFactoryTest.java
@@ -11,6 +11,11 @@ import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTemplateContext;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -36,6 +41,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -92,6 +99,15 @@ public class DDMFormTemplateContextFactoryTest {
 			).build();
 
 		Assert.assertEquals(0, ddmFormTemplateContext.get("activePage"));
+		JSONAssert.assertEquals(
+			JSONUtil.toJSONArray(
+				LanguageUtil.getAvailableLocales(),
+				locale -> _getLocaleJSONObject(locale), _log
+			).toString(),
+			ddmFormTemplateContext.get(
+				"availableLocales"
+			).toString(),
+			true);
 		Assert.assertEquals(
 			containerId, ddmFormTemplateContext.get("containerId"));
 		Assert.assertFalse((boolean)ddmFormTemplateContext.get("readOnly"));
@@ -479,6 +495,19 @@ public class DDMFormTemplateContextFactoryTest {
 		}
 	}
 
+	private JSONObject _getLocaleJSONObject(Locale locale) {
+		String languageId = LocaleUtil.toLanguageId(locale);
+
+		return JSONUtil.put(
+			"displayName", locale.getDisplayName(locale)
+		).put(
+			"icon",
+			StringUtil.toLowerCase(StringUtil.replace(languageId, '_', "-"))
+		).put(
+			"localeId", languageId
+		);
+	}
+
 	private MockHttpServletRequest _getMockHttpServletRequest()
 		throws Exception {
 
@@ -496,6 +525,9 @@ public class DDMFormTemplateContextFactoryTest {
 
 		return mockHttpServletRequest;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFormTemplateContextFactoryTest.class);
 
 	@Inject
 	private static DDMFormTemplateContextFactory _ddmFormTemplateContextFactory;

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.tsx
@@ -9,7 +9,6 @@ import {
 	FieldChangeEventHandler,
 	LocalizedValue,
 } from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/types';
-import {AvailableLocale} from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown';
 import {fetch} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
@@ -21,7 +20,6 @@ import AttachmentLocalizedObjectField from './AttachmentLocalizedObjectField';
 
 export interface AttachmentProps
 	extends AttachmentBaseProps<string | LocalizedValue<string>> {
-	availableLocales: AvailableLocale[];
 	contentURL?: string;
 	deleteURL?: string;
 	fieldName: string;

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentLocalizedObjectField.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentLocalizedObjectField.tsx
@@ -10,7 +10,6 @@ import {
 	FieldChangeEventHandler,
 	LocalizedValue,
 } from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/types';
-import {AvailableLocale} from 'dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown';
 import React, {useEffect, useState} from 'react';
 
 import AttachmentBase, {
@@ -20,7 +19,6 @@ import AttachmentBase, {
 
 export interface AttachmentLocalizedObjectFieldProps
 	extends AttachmentBaseProps<string | LocalizedValue<string>> {
-	availableLocales: AvailableLocale[];
 	fieldName: string;
 	fileEntryProperties: LocalizedValue<AttachmentFile>;
 	onChange: FieldChangeEventHandler<LocalizedValue<string>>;
@@ -28,7 +26,6 @@ export interface AttachmentLocalizedObjectFieldProps
 }
 
 export default function AttachmentLocalizedObjectField({
-	availableLocales,
 	fieldName,
 	fileEntryProperties,
 	onChange,
@@ -38,7 +35,8 @@ export default function AttachmentLocalizedObjectField({
 	const [attachment, setAttachment] =
 		useState<LocalizedValue<AttachmentFile>>(fileEntryProperties);
 
-	const {defaultLanguageId, editingLanguageId} = useFormState();
+	const {availableLocales, defaultLanguageId, editingLanguageId} =
+		useFormState();
 
 	const getAttachment = () => {
 		if (!attachment[editingLanguageId]) {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/MultiselectPicklist/MultiselectPicklist.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/MultiselectPicklist/MultiselectPicklist.tsx
@@ -4,7 +4,6 @@
  */
 
 import {
-	AvailableLocale,
 	LocalizedValue,
 	MultipleSelection,
 	ReactFieldBase as FieldBase,
@@ -20,7 +19,6 @@ interface MultiselectOption {
 type Values = string[] | LocalizedValue<string[]>;
 
 interface MultiselectPicklistProps {
-	availableLocales: AvailableLocale[];
 	defaultLanguageId: Liferay.Language.Locale;
 	errorMessage: string;
 	fieldName: string;

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/env/portal-ext.properties
@@ -1,3 +1,3 @@
-com.liferay.portal.kernel.upload.FileItem.threshold.size=3145728
+com.liferay.portal.kernel.upload.FileItem.threshold.size=2097152
 
 database.partition.enabled=true


### PR DESCRIPTION
### References:
- Parent Task: [Slow Form Load After Importing LAR and Enabling All Locales](https://liferay.atlassian.net/browse/LPD-55285)
- Related Pull Request: https://github.com/brianchandotcom/liferay-portal/pull/157452

### What is the goal of this PR?

This pull request aims to remove the passing of the `availableLocales` parameter to all `DDMFormFields`. Instead of React components receiving this information via property, we are passing it through the `FormProvider`

### Evidence

Using Chrome DevTools to limit 4G speed to load a very heavy form that uses data providers and many rules activates in a 1.2 min load on the master.

![image](https://github.com/user-attachments/assets/9cd0a27b-a31d-4ebc-836a-d82e3a9397ad)

With the changes, executing the same action we obtained a result of 21 seconds. Additionally, in the size column we had a 77% reduction in the size of the content returned.

![image](https://github.com/user-attachments/assets/a61208d8-3bbc-4a67-b80b-0c25969d35f0)

Without internet speed limitation settings, this form can be opened in approximately 5 seconds. This is in line with the expected result reported in the ticket.

### Test Case

We have the '[can interact with a large list of fields on the form entries page](https://github.com/liferay-bpm/liferay-portal/blob/9320f13800aaf4317ace878f83d6a51468a14a18/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formEntries.spec.ts#L80)' test that failed after this performance issue. At the time, we did not relate the issues and treated it as a case where the test needed to be corrected.

So we increased the `com.liferay.portal.kernel.upload.FileItem.threshold.size` property, setting its value to 3MB. With this performance improvement, we can go back to using 2MB. If we have other performance issues similar to this one, this test will fail again.