### PR TITLE
LPD-55493 Use modules.includes to restrict the execution of front-end unit tests

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -2798,6 +2798,9 @@
     # Calendar
     #
 
+    modules.includes[js-unit][calendar]=\
+        apps/calendar/**
+
     playwright.test.project[playwright-js-tomcat90-*][calendar]=\
         calendar-web.main
 
@@ -3284,6 +3287,9 @@
     # Data Engine
     #
 
+    modules.includes[js-unit][data-engine]=\
+        apps/data-engine/**
+
     test.batch.class.names.includes[data-engine]=\
         **/data-engine/**/*Test.java,\
         **/dynamic-data-lists/**/*Test.java,\
@@ -3603,6 +3609,9 @@
     #
     # Forms
     #
+
+    modules.includes[js-unit][forms]=\
+        apps/dynamic-data-mapping/**,
 
     playwright.projects.includes[playwright-js-tomcat90-postgresql163][forms]=\
         dynamic-data-mapping-form-web.main
@@ -4438,6 +4447,8 @@
     #
     # Object
     #
+    modules.includes[js-unit][object]=\
+        apps/object/**
 
     playwright.projects.includes[playwright-js-tomcat90-postgresql163][object]=\
         notification-web.main,\
@@ -7243,6 +7254,9 @@
     #
     # Workflow
     #
+
+    modules.includes[js-unit][workflow]=\
+        portal-workflow/**
 
     playwright.test.project[playwright-js-tomcat90-postgresql163][workflow]=\
         portal-workflow-kaleo-designer-web.main,\


### PR DESCRIPTION
### References:
Parent Task: [Filter the execution of javascript unit tests in BPM product testing routines](https://liferay.atlassian.net/browse/LPD-55493)

### What is the goal of this PR?
To prevent BPM product testing routines from running all portal unit tests, we are using modules.includes to restrict unit test execution based on the product module path.