### PR TITLE
LPD-55455 Restrict freemarker template variables

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateManagerUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.workflow.kaleo.KaleoWorkflowModelConverter;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
@@ -112,7 +113,7 @@ public class TemplateNotificationMessageGenerator
 		return TemplateManagerUtil.getTemplate(
 			templateManagerName,
 			new StringTemplateResource(templateId, notificationTemplate),
-			false);
+			!PropsValues.NOTIFICATION_EMAIL_TEMPLATE_ENABLED);
 	}
 
 	private void _populateContextVariables(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
@@ -53,23 +53,10 @@ public class TemplateNotificationMessageGenerator
 			ExecutionContext executionContext)
 		throws NotificationMessageGenerationException {
 
-		String templateManagerName = _templateManagerNames.get(
-			notificationTemplateLanguage);
-
-		if (Validator.isNull(templateManagerName)) {
-			throw new NotificationMessageGenerationException(
-				"Unsupported notification template language " +
-					notificationTemplateLanguage);
-		}
-
 		try {
-			String templateId =
-				notificationName + kaleoClassName + kaleoClassPK;
-
-			Template template = TemplateManagerUtil.getTemplate(
-				templateManagerName,
-				new StringTemplateResource(templateId, notificationTemplate),
-				false);
+			Template template = _getTemplate(
+				kaleoClassName, kaleoClassPK, notificationName,
+				notificationTemplate, notificationTemplateLanguage);
 
 			_populateContextVariables(template, executionContext);
 
@@ -104,6 +91,28 @@ public class TemplateNotificationMessageGenerator
 			"freemarker", TemplateConstants.LANG_TYPE_FTL);
 		_templateManagerNames.put("soy", TemplateConstants.LANG_TYPE_SOY);
 		_templateManagerNames.put("velocity", TemplateConstants.LANG_TYPE_VM);
+	}
+
+	private Template _getTemplate(
+			String kaleoClassName, long kaleoClassPK, String notificationName,
+			String notificationTemplate, String notificationTemplateLanguage)
+		throws Exception {
+
+		String templateManagerName = _templateManagerNames.get(
+			notificationTemplateLanguage);
+
+		if (Validator.isNull(templateManagerName)) {
+			throw new NotificationMessageGenerationException(
+				"Unsupported notification template language " +
+					notificationTemplateLanguage);
+		}
+
+		String templateId = notificationName + kaleoClassName + kaleoClassPK;
+
+		return TemplateManagerUtil.getTemplate(
+			templateManagerName,
+			new StringTemplateResource(templateId, notificationTemplate),
+			false);
 	}
 
 	private void _populateContextVariables(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
@@ -43,7 +43,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marcellus Tavares
  * @author Michael C. Han
  */
-@Component(service = NotificationMessageGenerator.class)
+@Component(
+	property = "service.ranking:Integer=100",
+	service = NotificationMessageGenerator.class
+)
 public class TemplateNotificationMessageGenerator
 	implements NotificationMessageGenerator {
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java
@@ -172,8 +172,10 @@ public class TemplateNotificationMessageGenerator
 			KaleoInstanceToken kaleoInstanceToken =
 				executionContext.getKaleoInstanceToken();
 
-			template.put("userId", kaleoInstanceToken.getUserId());
-			template.put("userName", kaleoInstanceToken.getUserName());
+			if (kaleoInstanceToken != null) {
+				template.put("userId", kaleoInstanceToken.getUserId());
+				template.put("userName", kaleoInstanceToken.getUserName());
+			}
 		}
 
 		KaleoTimerInstanceToken kaleoTimerInstanceToken =

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/TemplateNotificationMessageGeneratorTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/TemplateNotificationMessageGeneratorTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.runtime.integration.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.workflow.kaleo.model.KaleoNode;
+import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
+import com.liferay.portal.workflow.kaleo.runtime.notification.NotificationMessageGenerationException;
+import com.liferay.portal.workflow.kaleo.runtime.notification.NotificationMessageGenerator;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Anderson Luiz
+ */
+@RunWith(Arquillian.class)
+public class TemplateNotificationMessageGeneratorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGenerateMessage()
+		throws NotificationMessageGenerationException {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"NOTIFICATION_EMAIL_TEMPLATE_ENABLED", true)) {
+
+			String message = _notificationMessageGenerator.generateMessage(
+				KaleoNode.class.getName(), RandomTestUtil.randomLong(),
+				RandomTestUtil.randomString(), "freemarker",
+				"Hello ${serviceLocator}!",
+				new ExecutionContext(null, new HashMap<>(), null));
+
+			Assert.assertTrue(message.contains("ServiceLocator"));
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"NOTIFICATION_EMAIL_TEMPLATE_ENABLED", false)) {
+
+			AssertUtils.assertFailure(
+				NotificationMessageGenerationException.class,
+				"Unable to generate notification message",
+				() -> _notificationMessageGenerator.generateMessage(
+					KaleoNode.class.getName(), RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), "freemarker",
+					"Hello ${serviceLocator}!",
+					new ExecutionContext(null, new HashMap<>(), null)));
+		}
+	}
+
+	@Inject
+	private NotificationMessageGenerator _notificationMessageGenerator;
+
+}


### PR DESCRIPTION
Bug reproduces due:
 * Template is using [unrestricted variables](https://github.com/liferay-bpm/liferay-portal/blob/master/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/notification/TemplateNotificationMessageGenerator.java#L72). The fix makes it driven by portal properties like the old service notification service, as [suggested](https://liferay.atlassian.net/browse/LPD-55455?focusedCommentId=2927633) in the ticket.
