### PR TITLE
LPD-55492 [Test Fix] KaleoForms

### DIFF
--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsManageFieldSets.testcase
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsManageFieldSets.testcase
@@ -151,18 +151,6 @@ definition {
 			rowNumber = 6);
 	}
 
-	@description = "Verify that the user can navigate to the next page."
-	@priority = 3
-	test NavigateToTheNextPage {
-		Pagination.changePagination(itemsPerPage = 4);
-
-		KaleoFormsAdmin.viewNextFieldSetPage();
-
-		Pagination.viewResults(results = "Showing 5 to 6 of 6 entries.");
-
-		KaleoFormsManageFieldSets.viewPageNumber(pageNumberList = 2);
-	}
-
 	@description = "Verify that when there are no results for the search, it displays the message -No Field Sets were found-."
 	@priority = 3
 	test NotViewResultTheSearch {

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsProcessListSubmissions.testcase
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsProcessListSubmissions.testcase
@@ -215,62 +215,6 @@ definition {
 		KaleoFormsNewSubmissions.viewOrderTable(fieldNameList = "Process B,Process A");
 	}
 
-	@description = "Verify that the user can modify the quantity of items view per page."
-	@priority = 3
-	test CanModifyQuantityOfItemsPerPage {
-		for (var kfProcessName : list "1,2,3,4") {
-			KaleoFormsAdmin.submitNewProcess(kfProcessName = "Kaleo Forms Process");
-
-			KaleoFormsNewSubmissions.addNewContacts(ddlCompany = "Liferay");
-
-			KaleoFormsAdmin.saveProcessRecord();
-
-			Navigator.gotoBack();
-		}
-
-		AssertElementNotPresent(locator1 = "Pagination#ITEMS_PER_PAGE_SELECT");
-
-		KaleoFormsAdmin.submitNewProcess(kfProcessName = "Kaleo Forms Process");
-
-		KaleoFormsNewSubmissions.addNewContacts(ddlCompany = "Liferay");
-
-		KaleoFormsAdmin.saveProcessRecord();
-
-		Pagination.changePagination(itemsPerPage = 4);
-
-		Pagination.viewResults(results = "Showing 1 to 4 of 5 entries.");
-	}
-
-	@description = "Verify that user can nagivate through pages."
-	@priority = 3
-	test CanNavigateThroughPages {
-		for (var kfProcessName : list "1,2,3,4") {
-			KaleoFormsAdmin.submitNewProcess(kfProcessName = "Kaleo Forms Process");
-
-			KaleoFormsNewSubmissions.addNewContacts(ddlCompany = "Liferay");
-
-			KaleoFormsAdmin.saveProcessRecord();
-
-			Navigator.gotoBack();
-		}
-
-		AssertElementNotPresent(locator1 = "Pagination#ITEMS_PER_PAGE_SELECT");
-
-		KaleoFormsAdmin.submitNewProcess(kfProcessName = "Kaleo Forms Process");
-
-		KaleoFormsNewSubmissions.addNewContacts(ddlCompany = "Liferay");
-
-		KaleoFormsAdmin.saveProcessRecord();
-
-		Pagination.changePagination(itemsPerPage = 4);
-
-		KaleoFormsAdmin.viewNextFieldSetPage();
-
-		Pagination.viewResults(results = "Showing 5 to 5 of 5 entries.");
-
-		KaleoFormsNewSubmissions.viewPaginationNumber(pageNumberList = 2);
-	}
-
 	@description = "Verify that the user can reverse the order of submissions."
 	@priority = 3
 	test CanOrderSubmissions {

--- a/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsProcessListView.testcase
+++ b/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-test/src/testFunctional/tests/KaleoFormsProcessListView.testcase
@@ -338,36 +338,6 @@ definition {
 		KaleoFormsAdmin.viewTableDisplaysColumns();
 	}
 
-	@description = "Verify that the page displays the pagination button."
-	@priority = 4
-	test DisplaysThePaginationButton {
-		for (var newProcess : list "1,2,3,4") {
-			KaleoFormsAdmin.addProcess();
-
-			KaleoFormsAdmin.createKaleoFormsProcess(
-				kfFieldSetName = "Contacts",
-				kfFormName = "Created Task Form ${newProcess}",
-				kfProcessDescription = "Kaleo Forms Process Description ${newProcess}",
-				kfProcessName = "Kaleo Forms Process ${newProcess}",
-				workflowDefinitionTitle = "Single Approver",
-				workflowTask = "created");
-		}
-
-		KaleoFormsAdmin.assertPaginationBarNotPresent();
-
-		KaleoFormsAdmin.addProcess();
-
-		KaleoFormsAdmin.createKaleoFormsProcess(
-			kfFieldSetName = "Contacts",
-			kfFormName = "Created Task Form 5",
-			kfProcessDescription = "Kaleo Forms Process Description 5",
-			kfProcessName = "Kaleo Forms Process 5",
-			workflowDefinitionTitle = "Single Approver",
-			workflowTask = "created");
-
-		KaleoFormsAdmin.assertPaginationBarPresent();
-	}
-
 	@description = "Verify that when there are no results for the search, it displays the message -No process were found-."
 	@priority = 3
 	test NoResultMessageInSearch {

--- a/modules/test/playwright/fixtures/kaleoFormsPagesTest.ts
+++ b/modules/test/playwright/fixtures/kaleoFormsPagesTest.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {KaleoFormModalPage} from '../pages/portal-workflow-kaleo-forms-web/KaleoFormModalPage';
+import {KaleoFormsAdminPage} from '../pages/portal-workflow-kaleo-forms-web/KaleoFormsAdminPage';
+
+const kaleoFormsPagesTest = test.extend<{
+	kaleoFormModalPage: KaleoFormModalPage;
+	kaleoFormsAdminPage: KaleoFormsAdminPage;
+}>({
+	kaleoFormModalPage: async ({page}, use) => {
+		await use(new KaleoFormModalPage(page));
+	},
+	kaleoFormsAdminPage: async ({page}, use) => {
+		await use(new KaleoFormsAdminPage(page));
+	},
+});
+
+export {kaleoFormsPagesTest};

--- a/modules/test/playwright/pages/portal-workflow-kaleo-forms-web/KaleoFormModalPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-forms-web/KaleoFormModalPage.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page} from '@playwright/test';
+
+export class KaleoFormModalPage {
+	readonly addNewFormButton: Locator;
+	readonly formNameField: Locator;
+	readonly iframe: FrameLocator;
+	readonly page: Page;
+	readonly saveFormButton: Locator;
+
+	constructor(page: Page) {
+		this.iframe = page.frameLocator('iframe[title="Form"]');
+
+		this.addNewFormButton = this.iframe.getByRole('link', {name: 'Add'});
+		this.formNameField = this.iframe.getByLabel('Name Required');
+		this.saveFormButton = this.iframe.getByRole('button', {
+			exact: true,
+			name: 'Save',
+		});
+	}
+
+	async chooseForm(formName: string) {
+		await this.iframe.getByRole('link', {name: formName}).click();
+	}
+}

--- a/modules/test/playwright/pages/portal-workflow-kaleo-forms-web/KaleoFormsAdminPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-forms-web/KaleoFormsAdminPage.ts
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {PORTLET_URLS} from '../../utils/portletUrls';
+
+export class KaleoFormsAdminPage {
+	readonly actionMenuChooseOption: Locator;
+	readonly addNewProcessButton: Locator;
+	readonly addNewProcessNextButton: Locator;
+	readonly assignFormButton: Locator;
+	readonly deleteButton: Locator;
+	readonly firstFieldSetActionMenu: Locator;
+	readonly firstFormsActionMenu: Locator;
+	readonly firstWorkflowActionMenu: Locator;
+	readonly newProcessNameField: Locator;
+	readonly page: Page;
+	readonly saveButton: Locator;
+	readonly selectAllItemsCheckbox: Locator;
+	readonly submitNewProcessEntryButton: Locator;
+
+	constructor(page: Page) {
+		this.actionMenuChooseOption = page.getByRole('link', {name: 'Choose'});
+		this.addNewProcessButton = page.getByRole('link', {name: 'Add'});
+		this.addNewProcessNextButton = page.getByRole('button', {name: 'Next'});
+		this.assignFormButton = page.getByRole('link', {name: 'Assign Form'});
+		this.deleteButton = page.getByRole('button', {name: 'Delete'});
+		this.firstFieldSetActionMenu = page.locator(
+			'[id="_com_liferay_portal_workflow_kaleo_forms_web_portlet_KaleoFormsAdminPortlet_ddmStructuresSearchContainer_1_menu"]'
+		);
+		this.firstFormsActionMenu = page.locator(
+			'[id="_com_liferay_portal_workflow_kaleo_forms_web_portlet_KaleoFormsAdminPortlet_kaleoTaskFormPairsSearchContainer_1_menu"]'
+		);
+		this.firstWorkflowActionMenu = page.locator(
+			'[id="_com_liferay_portal_workflow_kaleo_forms_web_portlet_KaleoFormsAdminPortlet_workflowDefinitionsSearchContainer_1_menu"]'
+		);
+		this.newProcessNameField = page.getByLabel('Name Required');
+		this.page = page;
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.selectAllItemsCheckbox = page.getByLabel(
+			'Select All Items on the Page'
+		);
+		this.submitNewProcessEntryButton = page.getByRole('link', {
+			name: 'Submit New',
+		});
+	}
+
+	async clickKaleoFormProcessLink(processName: string) {
+		await this.page.getByRole('link', {name: processName}).click();
+	}
+
+	async goto(siteUrl?: Site['friendlyUrlPath']) {
+		await this.page.goto(
+			`/group${siteUrl || '/guest'}${PORTLET_URLS.kaleoFormsAdmin}`
+		);
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -104,6 +104,7 @@ import {config as portalToolsRestBuilderTestImpl} from './tests/portal-tools-res
 import {config as portalUserLocaleOptionsConfig} from './tests/portal-user-locale-options-web/main/config';
 import {config as portalWebConfig} from './tests/portal-web/main/config';
 import {config as portalWorkflowKaleoDesignerWebConfig} from './tests/portal-workflow-kaleo-designer-web/main/config';
+import {config as portalWorkflowKaleoFormsWebConfig} from './tests/portal-workflow-kaleo-forms-web/main/config';
 import {config as portalWorkflowTaskWebConfig} from './tests/portal-workflow-task-web/main/config';
 import {config as portletConfigurationCssWebConfig} from './tests/portlet-configuration-css-web/main/config';
 import {config as productNavigationProductMenuWeb} from './tests/product-navigation-product-menu-web/main/config';
@@ -255,6 +256,7 @@ export default defineConfig({
 		portalUserLocaleOptionsConfig,
 		portalWebConfig,
 		portalWorkflowKaleoDesignerWebConfig,
+		portalWorkflowKaleoFormsWebConfig,
 		portalWorkflowTaskWebConfig,
 		portletConfigurationCssWebConfig,
 		productNavigationProductMenuWeb,

--- a/modules/test/playwright/tests/portal-workflow-kaleo-forms-web/main/config.ts
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-forms-web/main/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-workflow-kaleo-forms-web.main',
+	testDir: 'tests/portal-workflow-kaleo-forms-web/main',
+	use: {
+		viewport: {height: 1080, width: 1920},
+	},
+};

--- a/modules/test/playwright/tests/portal-workflow-kaleo-forms-web/main/pagination.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-forms-web/main/pagination.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {kaleoFormsPagesTest} from '../../../fixtures/kaleoFormsPagesTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import {waitForAlert} from '../../../utils/waitForAlert';
+
+export const test = mergeTests(loginTest(), kaleoFormsPagesTest);
+
+test.afterEach(async ({kaleoFormsAdminPage, page}) => {
+	await kaleoFormsAdminPage.goto();
+
+	await page.waitForLoadState('networkidle');
+
+	if (await kaleoFormsAdminPage.selectAllItemsCheckbox.isEnabled()) {
+		await kaleoFormsAdminPage.selectAllItemsCheckbox.check();
+
+		page.on('dialog', (dialog) => dialog.accept());
+
+		await kaleoFormsAdminPage.deleteButton.click();
+
+		await waitForAlert(page);
+	}
+});
+
+test('Can navigate through pages and modify the amount of items per page', async ({
+	kaleoFormModalPage,
+	kaleoFormsAdminPage,
+	page,
+}) => {
+	test.slow();
+
+	const kaleoFormsProcessName = 'kaleoFormsProcess' + getRandomInt();
+	const createdTaskFormName = 'createdTaskForm' + getRandomInt();
+
+	await test.step('Go to Kaleo Forms Admin and add new process', async () => {
+		await kaleoFormsAdminPage.goto();
+
+		await kaleoFormsAdminPage.addNewProcessButton.click();
+
+		// This waitForTimeout is needed so the event listener that copies the input value
+		// from newProcessNameField to the hidden field is attached before filling it.
+
+		await page.waitForTimeout(2000);
+
+		await kaleoFormsAdminPage.newProcessNameField.fill(
+			kaleoFormsProcessName
+		);
+
+		const newProcessNameFieldId =
+			await kaleoFormsAdminPage.newProcessNameField.getAttribute('id');
+
+		const newProcessNameHiddenField = page.locator(
+			`#${newProcessNameFieldId}_en_US`
+		);
+
+		// Check that the hidden field has the expected value, otherwise the process
+		// creation flow will fail.
+
+		await expect(newProcessNameHiddenField).toHaveValue(
+			kaleoFormsProcessName
+		);
+
+		await expect(kaleoFormsAdminPage.addNewProcessNextButton).toBeEnabled();
+
+		await kaleoFormsAdminPage.addNewProcessNextButton.click();
+
+		await kaleoFormsAdminPage.firstFieldSetActionMenu.click();
+
+		await kaleoFormsAdminPage.actionMenuChooseOption.click();
+
+		await kaleoFormsAdminPage.addNewProcessNextButton.click();
+
+		await kaleoFormsAdminPage.firstWorkflowActionMenu.click();
+
+		await kaleoFormsAdminPage.actionMenuChooseOption.click();
+
+		await kaleoFormsAdminPage.addNewProcessNextButton.click();
+
+		// This waitForTimeout is needed so the event listener that triggers the
+		// dropdown menu is attached to the action menu button before clicking it.
+
+		await page.waitForTimeout(2000);
+
+		await kaleoFormsAdminPage.firstFormsActionMenu.click();
+
+		await kaleoFormsAdminPage.assignFormButton.click();
+
+		await kaleoFormModalPage.addNewFormButton.click();
+
+		// This waitForTimeout is needed so the event listener that copies the input value
+		// from formNameField to the hidden field is attached before filling it.
+
+		await page.waitForTimeout(2000);
+
+		await kaleoFormModalPage.formNameField.fill(createdTaskFormName);
+
+		await kaleoFormModalPage.saveFormButton.click();
+
+		await kaleoFormModalPage.chooseForm(createdTaskFormName);
+
+		await kaleoFormsAdminPage.saveButton.click();
+	});
+
+	await test.step('Go to created process and add 21 entries', async () => {
+		await kaleoFormsAdminPage.clickKaleoFormProcessLink(
+			kaleoFormsProcessName
+		);
+
+		for (let index = 1; index <= 21; index++) {
+			await kaleoFormsAdminPage.submitNewProcessEntryButton.click();
+
+			// This waitForTimeout is needed so the event listener that copies the input value
+			// from companyField to the hidden field is attached before filling it.
+
+			await page.waitForTimeout(2000);
+
+			const companyField = page.getByRole('textbox').first();
+
+			await companyField.fill('Liferay' + index);
+
+			await companyField.press('Enter');
+		}
+	});
+
+	await test.step('Assert that the user can navigate to page 2', async () => {
+		await expect(page.getByLabel('Page 2')).toBeVisible();
+
+		await page.getByLabel('Page 2').click();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: 'Liferay1'})
+		).not.toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: 'Liferay21'})
+		).toBeVisible();
+	});
+
+	await test.step('Assert that the user can modify the amount of items per page', async () => {
+		await page.getByLabel('Items per Page').click();
+
+		await page.getByRole('option', {name: '40 Entries per Page'}).click();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: 'Liferay1'})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: 'Liferay21'})
+		).toBeVisible();
+	});
+});

--- a/modules/test/playwright/tests/portal-workflow-kaleo-forms-web/main/test.properties
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-forms-web/main/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Kaleo Forms Admin

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -43,6 +43,8 @@ export const PORTLET_URLS = {
 		'/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_structures.jsp',
 	journalTemplates:
 		'/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_templates.jsp',
+	kaleoFormsAdmin:
+		'/~/control_panel/manage?p_p_id=com_liferay_portal_workflow_kaleo_forms_web_portlet_KaleoFormsAdminPortlet',
 	knowledgeBase:
 		'/~/control_panel/manage?p_p_id=com_liferay_knowledge_base_web_portlet_AdminPortlet',
 	languageOverride:

--- a/test.properties
+++ b/test.properties
@@ -2675,6 +2675,7 @@
         notification-web.main,\
         object-web.main,\
         portal-workflow-kaleo-designer-web.main,\
+        portal-workflow-kaleo-forms-web.main,\
         portal-workflow-task-web.main
 
     test.batch.class.names.excludes[bpm]=\
@@ -7207,6 +7208,7 @@
 
     playwright.test.project[playwright-js-tomcat90-postgresql163][workflow]=\
         portal-workflow-kaleo-designer-web.main,\
+        portal-workflow-kaleo-forms-web.main,\
         portal-workflow-task-web.main
 
     test.batch.class.names.includes[workflow]=\


### PR DESCRIPTION
Jira ticket: https://liferay.atlassian.net/browse/LPD-55492

Hello, reviewer! This PR Replaces two pagination Poshi tests with a Playwright-equivalent and delete two other pagination tests that are not necessary because the pagination is not handled on the Kaleo Forms side.

The following two tests...

LocalFile.KaleoFormsProcessListSubmissions#CanModifyQuantityOfItemsPerPage
LocalFile.KaleoFormsProcessListSubmissions#CanNavigateThroughPages

assert pagination features rendered by [this line](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view_kaleo_process.jsp#L173), which is dependent on `kaleoFormsViewRecordsDisplayContext.getSearch` method, so I decided to be extra cautious and migrate the tests to Playwright.

But the following two tests...

LocalFile.KaleoFormsManageFieldSets#NavigateToTheNextPage
LocalFile.KaleoFormsProcessListView#DisplaysThePaginationButton

assert pagination features rendered, respectively, by the following two files:

https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/view.jsp

https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow-kaleo-forms/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/view.jsp

And in these cases, we don't even call the paginator taglib. Pagination is entirely handled on the search container taglib side, so we should not be testing this.