### PR TITLE
LPD-48539 Configure Object Version Retention

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
@@ -72,6 +72,9 @@ public interface ObjectEntryVersionLocalService
 	public ObjectEntryVersion addObjectEntryVersion(
 		ObjectEntryVersion objectEntryVersion);
 
+	public void checkObjectEntryRetention(long companyId)
+		throws PortalException;
+
 	/**
 	 * Creates a new object entry version with the primary key. Does not add the object entry version to the database.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
@@ -59,6 +59,12 @@ public class ObjectEntryVersionLocalServiceUtil {
 		return getService().addObjectEntryVersion(objectEntryVersion);
 	}
 
+	public static void checkObjectEntryRetention(long companyId)
+		throws PortalException {
+
+		getService().checkObjectEntryRetention(companyId);
+	}
+
 	/**
 	 * Creates a new object entry version with the primary key. Does not add the object entry version to the database.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
@@ -56,6 +56,13 @@ public class ObjectEntryVersionLocalServiceWrapper
 			objectEntryVersion);
 	}
 
+	@Override
+	public void checkObjectEntryRetention(long companyId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_objectEntryVersionLocalService.checkObjectEntryRetention(companyId);
+	}
+
 	/**
 	 * Creates a new object entry version with the primary key. Does not add the object entry version to the database.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryVersionPersistence.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryVersionPersistence.java
@@ -9,6 +9,8 @@ import com.liferay.object.exception.NoSuchObjectEntryVersionException;
 import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 
+import java.util.Date;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -617,6 +619,161 @@ public interface ObjectEntryVersionPersistence
 	 * @return the number of matching object entry versions
 	 */
 	public int countByObjectEntryId(long objectEntryId);
+
+	/**
+	 * Returns all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @return the matching object entry versions
+	 */
+	public java.util.List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate);
+
+	/**
+	 * Returns a range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @return the range of matching object entry versions
+	 */
+	public java.util.List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entry versions
+	 */
+	public java.util.List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entry versions
+	 */
+	public java.util.List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry version
+	 * @throws NoSuchObjectEntryVersionException if a matching object entry version could not be found
+	 */
+	public ObjectEntryVersion findByC_LtCD_First(
+			long companyId, Date createDate,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+				orderByComparator)
+		throws NoSuchObjectEntryVersionException;
+
+	/**
+	 * Returns the first object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry version, or <code>null</code> if a matching object entry version could not be found
+	 */
+	public ObjectEntryVersion fetchByC_LtCD_First(
+		long companyId, Date createDate,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns the last object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object entry version
+	 * @throws NoSuchObjectEntryVersionException if a matching object entry version could not be found
+	 */
+	public ObjectEntryVersion findByC_LtCD_Last(
+			long companyId, Date createDate,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+				orderByComparator)
+		throws NoSuchObjectEntryVersionException;
+
+	/**
+	 * Returns the last object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object entry version, or <code>null</code> if a matching object entry version could not be found
+	 */
+	public ObjectEntryVersion fetchByC_LtCD_Last(
+		long companyId, Date createDate,
+		com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns the object entry versions before and after the current object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param objectEntryVersionId the primary key of the current object entry version
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object entry version
+	 * @throws NoSuchObjectEntryVersionException if a object entry version with the primary key could not be found
+	 */
+	public ObjectEntryVersion[] findByC_LtCD_PrevAndNext(
+			long objectEntryVersionId, long companyId, Date createDate,
+			com.liferay.portal.kernel.util.OrderByComparator<ObjectEntryVersion>
+				orderByComparator)
+		throws NoSuchObjectEntryVersionException;
+
+	/**
+	 * Removes all the object entry versions where companyId = &#63; and createDate &lt; &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 */
+	public void removeByC_LtCD(long companyId, Date createDate);
+
+	/**
+	 * Returns the number of object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @return the number of matching object entry versions
+	 */
+	public int countByC_LtCD(long companyId, Date createDate);
 
 	/**
 	 * Returns the object entry version where objectEntryId = &#63; and version = &#63; or throws a <code>NoSuchObjectEntryVersionException</code> if it could not be found.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryVersionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/persistence/ObjectEntryVersionUtil.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.io.Serializable;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -813,6 +814,193 @@ public class ObjectEntryVersionUtil {
 	 */
 	public static int countByObjectEntryId(long objectEntryId) {
 		return getPersistence().countByObjectEntryId(objectEntryId);
+	}
+
+	/**
+	 * Returns all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @return the matching object entry versions
+	 */
+	public static List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate) {
+
+		return getPersistence().findByC_LtCD(companyId, createDate);
+	}
+
+	/**
+	 * Returns a range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @return the range of matching object entry versions
+	 */
+	public static List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end) {
+
+		return getPersistence().findByC_LtCD(companyId, createDate, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entry versions
+	 */
+	public static List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end,
+		OrderByComparator<ObjectEntryVersion> orderByComparator) {
+
+		return getPersistence().findByC_LtCD(
+			companyId, createDate, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entry versions
+	 */
+	public static List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end,
+		OrderByComparator<ObjectEntryVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_LtCD(
+			companyId, createDate, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry version
+	 * @throws NoSuchObjectEntryVersionException if a matching object entry version could not be found
+	 */
+	public static ObjectEntryVersion findByC_LtCD_First(
+			long companyId, Date createDate,
+			OrderByComparator<ObjectEntryVersion> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectEntryVersionException {
+
+		return getPersistence().findByC_LtCD_First(
+			companyId, createDate, orderByComparator);
+	}
+
+	/**
+	 * Returns the first object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry version, or <code>null</code> if a matching object entry version could not be found
+	 */
+	public static ObjectEntryVersion fetchByC_LtCD_First(
+		long companyId, Date createDate,
+		OrderByComparator<ObjectEntryVersion> orderByComparator) {
+
+		return getPersistence().fetchByC_LtCD_First(
+			companyId, createDate, orderByComparator);
+	}
+
+	/**
+	 * Returns the last object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object entry version
+	 * @throws NoSuchObjectEntryVersionException if a matching object entry version could not be found
+	 */
+	public static ObjectEntryVersion findByC_LtCD_Last(
+			long companyId, Date createDate,
+			OrderByComparator<ObjectEntryVersion> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectEntryVersionException {
+
+		return getPersistence().findByC_LtCD_Last(
+			companyId, createDate, orderByComparator);
+	}
+
+	/**
+	 * Returns the last object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object entry version, or <code>null</code> if a matching object entry version could not be found
+	 */
+	public static ObjectEntryVersion fetchByC_LtCD_Last(
+		long companyId, Date createDate,
+		OrderByComparator<ObjectEntryVersion> orderByComparator) {
+
+		return getPersistence().fetchByC_LtCD_Last(
+			companyId, createDate, orderByComparator);
+	}
+
+	/**
+	 * Returns the object entry versions before and after the current object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param objectEntryVersionId the primary key of the current object entry version
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object entry version
+	 * @throws NoSuchObjectEntryVersionException if a object entry version with the primary key could not be found
+	 */
+	public static ObjectEntryVersion[] findByC_LtCD_PrevAndNext(
+			long objectEntryVersionId, long companyId, Date createDate,
+			OrderByComparator<ObjectEntryVersion> orderByComparator)
+		throws com.liferay.object.exception.NoSuchObjectEntryVersionException {
+
+		return getPersistence().findByC_LtCD_PrevAndNext(
+			objectEntryVersionId, companyId, createDate, orderByComparator);
+	}
+
+	/**
+	 * Removes all the object entry versions where companyId = &#63; and createDate &lt; &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 */
+	public static void removeByC_LtCD(long companyId, Date createDate) {
+		getPersistence().removeByC_LtCD(companyId, createDate);
+	}
+
+	/**
+	 * Returns the number of object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @return the number of matching object entry versions
+	 */
+	public static int countByC_LtCD(long companyId, Date createDate) {
+		return getPersistence().countByC_LtCD(companyId, createDate);
 	}
 
 	/**

--- a/modules/apps/object/object-service/service.xml
+++ b/modules/apps/object/object-service/service.xml
@@ -396,6 +396,10 @@
 		<finder name="ObjectEntryId" return-type="Collection">
 			<finder-column name="objectEntryId" />
 		</finder>
+		<finder name="C_LtCD" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column comparator="&lt;" name="createDate" />
+		</finder>
 		<finder name="OEI_V" return-type="ObjectEntryVersion" unique="true">
 			<finder-column name="objectEntryId" />
 			<finder-column name="version" />

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryVersionModelImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryVersionModelImpl.java
@@ -130,32 +130,38 @@ public class ObjectEntryVersionModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long OBJECTDEFINITIONID_COLUMN_BITMASK = 2L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long OBJECTENTRYID_COLUMN_BITMASK = 4L;
+	public static final long OBJECTDEFINITIONID_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
+	public static final long OBJECTENTRYID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 16L;
+	public static final long UUID_COLUMN_BITMASK = 16L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long VERSION_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long OBJECTENTRYVERSIONID_COLUMN_BITMASK = 32L;
+	public static final long OBJECTENTRYVERSIONID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -555,6 +561,15 @@ public class ObjectEntryVersionModelImpl
 		}
 
 		_createDate = createDate;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public Date getOriginalCreateDate() {
+		return getColumnOriginalValue("createDate");
 	}
 
 	@JSON

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -25,6 +25,9 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 import java.util.Date;
 import java.util.List;
 
@@ -65,6 +68,37 @@ public class ObjectEntryVersionLocalServiceImpl
 		}
 
 		return objectEntryVersion;
+	}
+
+	public void checkObjectEntryRetention(long companyId)
+		throws PortalException {
+
+		ObjectEntryVersionConfiguration objectEntryVersionConfiguration =
+			_configurationProvider.getCompanyConfiguration(
+				ObjectEntryVersionConfiguration.class,
+				CompanyThreadLocal.getCompanyId());
+
+		int retentionPeriod =
+			objectEntryVersionConfiguration.maximumRetentionPeriod();
+
+		LocalDate localDate = LocalDate.now(
+		).minusMonths(
+			retentionPeriod
+		);
+
+		Date retentionDate = Date.from(
+			localDate.atStartOfDay(
+				ZoneId.systemDefault()
+			).toInstant());
+
+		List<ObjectEntryVersion> versions =
+			objectEntryVersionPersistence.findByC_LtCD(
+				companyId, retentionDate);
+
+		for (ObjectEntryVersion version : versions) {
+			deleteObjectEntryVersion(
+				version.getObjectEntryId(), version.getVersion());
+		}
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectEntryVersionPersistenceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/persistence/impl/ObjectEntryVersionPersistenceImpl.java
@@ -42,6 +42,8 @@ import java.io.Serializable;
 
 import java.lang.reflect.InvocationHandler;
 
+import java.sql.Timestamp;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -2234,6 +2236,577 @@ public class ObjectEntryVersionPersistenceImpl
 	private static final String _FINDER_COLUMN_OBJECTENTRYID_OBJECTENTRYID_2 =
 		"objectEntryVersion.objectEntryId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByC_LtCD;
+	private FinderPath _finderPathWithPaginationCountByC_LtCD;
+
+	/**
+	 * Returns all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @return the matching object entry versions
+	 */
+	@Override
+	public List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate) {
+
+		return findByC_LtCD(
+			companyId, createDate, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @return the range of matching object entry versions
+	 */
+	@Override
+	public List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end) {
+
+		return findByC_LtCD(companyId, createDate, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching object entry versions
+	 */
+	@Override
+	public List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end,
+		OrderByComparator<ObjectEntryVersion> orderByComparator) {
+
+		return findByC_LtCD(
+			companyId, createDate, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>ObjectEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param start the lower bound of the range of object entry versions
+	 * @param end the upper bound of the range of object entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching object entry versions
+	 */
+	@Override
+	public List<ObjectEntryVersion> findByC_LtCD(
+		long companyId, Date createDate, int start, int end,
+		OrderByComparator<ObjectEntryVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		finderPath = _finderPathWithPaginationFindByC_LtCD;
+		finderArgs = new Object[] {
+			companyId, _getTime(createDate), start, end, orderByComparator
+		};
+
+		List<ObjectEntryVersion> list = null;
+
+		if (useFinderCache) {
+			list = (List<ObjectEntryVersion>)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (ObjectEntryVersion objectEntryVersion : list) {
+					if ((companyId != objectEntryVersion.getCompanyId()) ||
+						(createDate.getTime() <=
+							objectEntryVersion.getCreateDate(
+							).getTime())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
+
+			sb.append(_SQL_SELECT_OBJECTENTRYVERSION_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_LTCD_COMPANYID_2);
+
+			boolean bindCreateDate = false;
+
+			if (createDate == null) {
+				sb.append(_FINDER_COLUMN_C_LTCD_CREATEDATE_1);
+			}
+			else {
+				bindCreateDate = true;
+
+				sb.append(_FINDER_COLUMN_C_LTCD_CREATEDATE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(ObjectEntryVersionModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				if (bindCreateDate) {
+					queryPos.add(new Timestamp(createDate.getTime()));
+				}
+
+				list = (List<ObjectEntryVersion>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry version
+	 * @throws NoSuchObjectEntryVersionException if a matching object entry version could not be found
+	 */
+	@Override
+	public ObjectEntryVersion findByC_LtCD_First(
+			long companyId, Date createDate,
+			OrderByComparator<ObjectEntryVersion> orderByComparator)
+		throws NoSuchObjectEntryVersionException {
+
+		ObjectEntryVersion objectEntryVersion = fetchByC_LtCD_First(
+			companyId, createDate, orderByComparator);
+
+		if (objectEntryVersion != null) {
+			return objectEntryVersion;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", createDate<");
+		sb.append(createDate);
+
+		sb.append("}");
+
+		throw new NoSuchObjectEntryVersionException(sb.toString());
+	}
+
+	/**
+	 * Returns the first object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching object entry version, or <code>null</code> if a matching object entry version could not be found
+	 */
+	@Override
+	public ObjectEntryVersion fetchByC_LtCD_First(
+		long companyId, Date createDate,
+		OrderByComparator<ObjectEntryVersion> orderByComparator) {
+
+		List<ObjectEntryVersion> list = findByC_LtCD(
+			companyId, createDate, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object entry version
+	 * @throws NoSuchObjectEntryVersionException if a matching object entry version could not be found
+	 */
+	@Override
+	public ObjectEntryVersion findByC_LtCD_Last(
+			long companyId, Date createDate,
+			OrderByComparator<ObjectEntryVersion> orderByComparator)
+		throws NoSuchObjectEntryVersionException {
+
+		ObjectEntryVersion objectEntryVersion = fetchByC_LtCD_Last(
+			companyId, createDate, orderByComparator);
+
+		if (objectEntryVersion != null) {
+			return objectEntryVersion;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("companyId=");
+		sb.append(companyId);
+
+		sb.append(", createDate<");
+		sb.append(createDate);
+
+		sb.append("}");
+
+		throw new NoSuchObjectEntryVersionException(sb.toString());
+	}
+
+	/**
+	 * Returns the last object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching object entry version, or <code>null</code> if a matching object entry version could not be found
+	 */
+	@Override
+	public ObjectEntryVersion fetchByC_LtCD_Last(
+		long companyId, Date createDate,
+		OrderByComparator<ObjectEntryVersion> orderByComparator) {
+
+		int count = countByC_LtCD(companyId, createDate);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<ObjectEntryVersion> list = findByC_LtCD(
+			companyId, createDate, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the object entry versions before and after the current object entry version in the ordered set where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param objectEntryVersionId the primary key of the current object entry version
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next object entry version
+	 * @throws NoSuchObjectEntryVersionException if a object entry version with the primary key could not be found
+	 */
+	@Override
+	public ObjectEntryVersion[] findByC_LtCD_PrevAndNext(
+			long objectEntryVersionId, long companyId, Date createDate,
+			OrderByComparator<ObjectEntryVersion> orderByComparator)
+		throws NoSuchObjectEntryVersionException {
+
+		ObjectEntryVersion objectEntryVersion = findByPrimaryKey(
+			objectEntryVersionId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			ObjectEntryVersion[] array = new ObjectEntryVersionImpl[3];
+
+			array[0] = getByC_LtCD_PrevAndNext(
+				session, objectEntryVersion, companyId, createDate,
+				orderByComparator, true);
+
+			array[1] = objectEntryVersion;
+
+			array[2] = getByC_LtCD_PrevAndNext(
+				session, objectEntryVersion, companyId, createDate,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected ObjectEntryVersion getByC_LtCD_PrevAndNext(
+		Session session, ObjectEntryVersion objectEntryVersion, long companyId,
+		Date createDate,
+		OrderByComparator<ObjectEntryVersion> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_OBJECTENTRYVERSION_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_LTCD_COMPANYID_2);
+
+		boolean bindCreateDate = false;
+
+		if (createDate == null) {
+			sb.append(_FINDER_COLUMN_C_LTCD_CREATEDATE_1);
+		}
+		else {
+			bindCreateDate = true;
+
+			sb.append(_FINDER_COLUMN_C_LTCD_CREATEDATE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(ObjectEntryVersionModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(companyId);
+
+		if (bindCreateDate) {
+			queryPos.add(new Timestamp(createDate.getTime()));
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						objectEntryVersion)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<ObjectEntryVersion> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the object entry versions where companyId = &#63; and createDate &lt; &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 */
+	@Override
+	public void removeByC_LtCD(long companyId, Date createDate) {
+		for (ObjectEntryVersion objectEntryVersion :
+				findByC_LtCD(
+					companyId, createDate, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(objectEntryVersion);
+		}
+	}
+
+	/**
+	 * Returns the number of object entry versions where companyId = &#63; and createDate &lt; &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param createDate the create date
+	 * @return the number of matching object entry versions
+	 */
+	@Override
+	public int countByC_LtCD(long companyId, Date createDate) {
+		FinderPath finderPath = _finderPathWithPaginationCountByC_LtCD;
+
+		Object[] finderArgs = new Object[] {companyId, _getTime(createDate)};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_OBJECTENTRYVERSION_WHERE);
+
+			sb.append(_FINDER_COLUMN_C_LTCD_COMPANYID_2);
+
+			boolean bindCreateDate = false;
+
+			if (createDate == null) {
+				sb.append(_FINDER_COLUMN_C_LTCD_CREATEDATE_1);
+			}
+			else {
+				bindCreateDate = true;
+
+				sb.append(_FINDER_COLUMN_C_LTCD_CREATEDATE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(companyId);
+
+				if (bindCreateDate) {
+					queryPos.add(new Timestamp(createDate.getTime()));
+				}
+
+				count = (Long)query.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_C_LTCD_COMPANYID_2 =
+		"objectEntryVersion.companyId = ? AND ";
+
+	private static final String _FINDER_COLUMN_C_LTCD_CREATEDATE_1 =
+		"objectEntryVersion.createDate IS NULL";
+
+	private static final String _FINDER_COLUMN_C_LTCD_CREATEDATE_2 =
+		"objectEntryVersion.createDate < ?";
+
 	private FinderPath _finderPathFetchByOEI_V;
 
 	/**
@@ -3090,6 +3663,20 @@ public class ObjectEntryVersionPersistenceImpl
 			new String[] {Long.class.getName()}, new String[] {"objectEntryId"},
 			false);
 
+		_finderPathWithPaginationFindByC_LtCD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_LtCD",
+			new String[] {
+				Long.class.getName(), Date.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "createDate"}, true);
+
+		_finderPathWithPaginationCountByC_LtCD = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_LtCD",
+			new String[] {Long.class.getName(), Date.class.getName()},
+			new String[] {"companyId", "createDate"}, false);
+
 		_finderPathFetchByOEI_V = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByOEI_V",
 			new String[] {Long.class.getName(), Integer.class.getName()},
@@ -3136,6 +3723,14 @@ public class ObjectEntryVersionPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
+
+	private static Long _getTime(Date date) {
+		if (date == null) {
+			return null;
+		}
+
+		return date.getTime();
+	}
 
 	private static final String _SQL_SELECT_OBJECTENTRYVERSION =
 		"SELECT objectEntryVersion FROM ObjectEntryVersion objectEntryVersion";

--- a/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
@@ -37,6 +37,7 @@ create index IX_772D12BC on ObjectEntryFolder (groupId, companyId, treePath[$COL
 create unique index IX_8EC73DF1 on ObjectEntryFolder (groupId, uuid_[$COLUMN_LENGTH:75$]);
 create index IX_56A855AD on ObjectEntryFolder (uuid_[$COLUMN_LENGTH:75$]);
 
+create index IX_494F3EFB on ObjectEntryVersion (companyId, createDate);
 create index IX_9811B7EC on ObjectEntryVersion (objectDefinitionId);
 create unique index IX_50DA0035 on ObjectEntryVersion (objectEntryId, version);
 create index IX_5C2CDBC9 on ObjectEntryVersion (uuid_[$COLUMN_LENGTH:75$]);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryVersionPersistenceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/persistence/test/ObjectEntryVersionPersistenceTest.java
@@ -253,6 +253,14 @@ public class ObjectEntryVersionPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_LtCD() throws Exception {
+		_persistence.countByC_LtCD(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextDate());
+
+		_persistence.countByC_LtCD(0L, RandomTestUtil.nextDate());
+	}
+
+	@Test
 	public void testCountByOEI_V() throws Exception {
 		_persistence.countByOEI_V(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextInt());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryVersionLocalServiceTest.java
@@ -125,7 +125,7 @@ public class ObjectEntryVersionLocalServiceTest {
 			ObjectEntryVersionConfiguration.class,
 			TestPropsValues.getCompanyId(),
 			HashMapDictionaryBuilder.<String, Object>put(
-				"maximumRetentionPeriod", 0
+				"maximumRetentionPeriod", 1
 			).put(
 				"maximumVersionsPerEntry", 3
 			).build());
@@ -658,6 +658,70 @@ public class ObjectEntryVersionLocalServiceTest {
 
 		Assert.assertEquals(
 			0,
+			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
+				objectEntry.getObjectEntryId()));
+	}
+
+	@Test
+	public void testObjectEntryVersionRetention() throws Exception {
+		ObjectEntryVersionConfiguration objectEntryVersionConfiguration =
+			_configurationProvider.getCompanyConfiguration(
+				ObjectEntryVersionConfiguration.class,
+				CompanyThreadLocal.getCompanyId());
+
+		Assert.assertEquals(
+			3, objectEntryVersionConfiguration.maximumVersionsPerEntry());
+		Assert.assertEquals(
+			1, objectEntryVersionConfiguration.maximumRetentionPeriod());
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build());
+
+		_updateLatestObjectEntryVersion(_getPastDate(3), objectEntry);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_updateLatestObjectEntryVersion(_getPastDate(2), objectEntry);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_updateLatestObjectEntryVersion(_getPastDate(2), objectEntry);
+
+		Assert.assertEquals(
+			3,
+			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
+				objectEntry.getObjectEntryId()));
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			3,
+			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
+				objectEntry.getObjectEntryId()));
+
+		_objectEntryVersionLocalService.checkObjectEntryRetention(
+			objectEntry.getCompanyId());
+
+		Assert.assertEquals(
+			1,
 			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
 				objectEntry.getObjectEntryId()));
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
@@ -6,27 +6,38 @@
 package com.liferay.object.web.internal.object.entries.scheduler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.configuration.ObjectEntryVersionConfiguration;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryVersionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -34,10 +45,15 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.Serializable;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,6 +73,31 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				TestPropsValues.getUserId(), 0, null, false, false, true, false,
+				true, true, "-", RandomTestUtil.randomLocaleStringMap(),
+				"A" + StringUtil.randomString(), null, null,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.emptyList(),
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						"textObjectFieldName"
+					).build()));
+
+		_objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_objectDefinition.getObjectDefinitionId());
+	}
 
 	@Test
 	public void testCheckObjectEntryReviewDate() throws Exception {
@@ -123,8 +164,122 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 			jsonObject.get("notificationMessage"));
 	}
 
+	@Test
+	public void testCheckObjectEntryVersionRetention() throws Exception {
+		_configurationProvider.saveCompanyConfiguration(
+			ObjectEntryVersionConfiguration.class,
+			TestPropsValues.getCompanyId(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"maximumRetentionPeriod", 1
+			).put(
+				"maximumVersionsPerEntry", 3
+			).build());
+
+		ObjectEntryVersionConfiguration objectEntryVersionConfiguration =
+			_configurationProvider.getCompanyConfiguration(
+				ObjectEntryVersionConfiguration.class,
+				CompanyThreadLocal.getCompanyId());
+
+		Assert.assertEquals(
+			3, objectEntryVersionConfiguration.maximumVersionsPerEntry());
+		Assert.assertEquals(
+			1, objectEntryVersionConfiguration.maximumRetentionPeriod());
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build());
+
+		_updateObjectEntryVersionDate(objectEntry, 3);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_updateObjectEntryVersionDate(objectEntry, 2);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_updateObjectEntryVersionDate(objectEntry, 2);
+
+		Assert.assertEquals(
+			3,
+			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
+				objectEntry.getObjectEntryId()));
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			3,
+			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
+				objectEntry.getObjectEntryId()));
+
+		UnsafeRunnable<Exception> jobExecutorUnsafeRunnable =
+			_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
+
+		jobExecutorUnsafeRunnable.run();
+
+		Assert.assertEquals(
+			1,
+			_objectEntryVersionLocalService.getObjectEntryVersionsCount(
+				objectEntry.getObjectEntryId()));
+	}
+
+	private ObjectEntryVersion _updateObjectEntryVersionDate(
+			ObjectEntry objectEntry, int months)
+		throws Exception {
+
+		ObjectEntryVersion objectEntryVersion =
+			_objectEntryVersionLocalService.getObjectEntryVersion(
+				objectEntry.getObjectEntryId(), objectEntry.getVersion());
+
+		if (months != 0) {
+			objectEntryVersion.setCreateDate(
+				Date.from(
+					LocalDate.now(
+					).minusMonths(
+						months
+					).atStartOfDay(
+						ZoneId.systemDefault()
+					).toInstant()));
+		}
+		else {
+			objectEntryVersion.setCreateDate(
+				java.sql.Date.valueOf(LocalDate.now()));
+		}
+
+		return _objectEntryVersionLocalService.updateObjectEntryVersion(
+			objectEntryVersion);
+	}
+
+	@Inject
+	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ConfigurationProvider _configurationProvider;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
 
 	@Inject(
 		filter = "component.name=com.liferay.object.web.internal.scheduler.CheckObjectEntrySchedulerJobConfiguration"

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/scheduler/CheckObjectEntrySchedulerJobConfiguration.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/scheduler/CheckObjectEntrySchedulerJobConfiguration.java
@@ -7,6 +7,7 @@ package com.liferay.object.web.internal.scheduler;
 
 import com.liferay.object.configuration.ObjectEntryScheduleConfiguration;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryVersionLocalService;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -35,15 +36,21 @@ public class CheckObjectEntrySchedulerJobConfiguration
 	public UnsafeConsumer<Long, Exception>
 		getCompanyJobExecutorUnsafeConsumer() {
 
-		return companyId -> _objectEntryLocalService.checkObjectEntries(
-			companyId);
+		return companyId -> {
+			_objectEntryLocalService.checkObjectEntries(companyId);
+			_objectEntryVersionLocalService.checkObjectEntryRetention(
+				companyId);
+		};
 	}
 
 	@Override
 	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
 		return () -> _companyLocalService.forEachCompanyId(
-			companyId -> _objectEntryLocalService.checkObjectEntries(
-				companyId));
+			companyId -> {
+				_objectEntryLocalService.checkObjectEntries(companyId);
+				_objectEntryVersionLocalService.checkObjectEntryRetention(
+					companyId);
+			});
 	}
 
 	@Override
@@ -68,6 +75,10 @@ public class CheckObjectEntrySchedulerJobConfiguration
 
 	private volatile ObjectEntryScheduleConfiguration
 		_objectEntryScheduleConfiguration;
+
+	@Reference
+	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
+
 	private TriggerConfiguration _triggerConfiguration;
 
 }

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -12893,7 +12893,6 @@ object-definitions-that-inherit-permission-from-a-root-object-definition-also-fo
 object-entry-check-interval=Object Entry Check Interval
 object-entry-check-interval-description=Set the interval (in minutes) to check for expiration, publishing, and review of object entries.
 object-entry-id=Object Entry ID
-object-entry-retention-configuration-name=Object Entry Version Retention
 object-entry-schedule-configuration-name=Object Entry Schedule
 object-entry-url-separator=Object Entry URL Separator
 object-entry-value-exceeds-integer-field-allowed-size=Object entry value exceeds integer field allowed size.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -12884,7 +12884,7 @@ object-configuration-name=Object
 object-definition=Object Definition
 object-definition-data=Object Data
 object-definition-id=Object ID
-object-definition-storage-type-tooltip=Select if the data will be stored in Liferay (default) or in an external system only. Limitations are applied for object definitions with external storage types.
+object-definition-storage-type-tooltip=Select if the data will be stored in Liferay (default) or in an external system only. LimitatFions are applied for object definitions with external storage types.
 object-definition-successfully-imported=Object definition successfully imported.
 object-definition-table-name=Table Name
 object-definition-x-is-selected=Object definition {0} is selected.
@@ -12893,6 +12893,7 @@ object-definitions-that-inherit-permission-from-a-root-object-definition-also-fo
 object-entry-check-interval=Object Entry Check Interval
 object-entry-check-interval-description=Set the interval (in minutes) to check for expiration, publishing, and review of object entries.
 object-entry-id=Object Entry ID
+object-entry-retention-configuration-name=Object Entry Version Retention
 object-entry-schedule-configuration-name=Object Entry Schedule
 object-entry-url-separator=Object Entry URL Separator
 object-entry-value-exceeds-integer-field-allowed-size=Object entry value exceeds integer field allowed size.


### PR DESCRIPTION
Modifications implemented to allow users to configure the maximum number of versions per Object entry and set a retention period for versions, to manage storage efficiently and ensure old versions are automatically cleaned up based on organizational policies.