### PR TITLE
LPD-57356  Object Validation Not Working Post Upgrade

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2302,8 +2302,8 @@ public class ObjectEntryLocalServiceImpl
 			}
 
 			_putLocalizedValues(
-				objectFieldColumn.getName(), (Serializable)localizedValues,
-				values);
+				objectFieldColumn.getName(), objectEntry.getDefaultLanguageId(),
+				localizedValues, values);
 		}
 	}
 
@@ -4390,8 +4390,8 @@ public class ObjectEntryLocalServiceImpl
 								column.getName(), StringPool.UNDERLINE)));
 
 					_putLocalizedValues(
-						column.getName(), (Serializable)localizedValues,
-						insertedValues);
+						column.getName(), objectField.getDefaultLanguageId(),
+						localizedValues, insertedValues);
 				}
 
 				preparedStatement.addBatch();
@@ -4674,13 +4674,16 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _putLocalizedValues(
-		String columnName, Serializable localizedValues,
+		String columnName, String defaultLanguageId,
+		Map<String, Serializable> localizedValues,
 		Map<String, Serializable> values) {
 
-		values.put(columnName + "i18n", localizedValues);
+		values.put(columnName + "i18n", (Serializable)localizedValues);
 		values.putIfAbsent(
 			StringUtil.removeLast(columnName, StringPool.UNDERLINE),
-			StringPool.BLANK);
+			localizedValues.getOrDefault(
+				defaultLanguageId, StringPool.BLANK
+			).toString());
 	}
 
 	private void _putObjectFilterParser(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -2788,6 +2788,101 @@ public class ObjectEntryLocalServiceTest {
 		_objectValidationRuleLocalService.updateObjectValidationRule(
 			objectValidationRule6);
 
+		// Can not be empty
+
+		ObjectField localizedObjectField =
+			ObjectFieldUtil.addCustomObjectField(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).localized(
+					true
+				).name(
+					"customField"
+				).objectDefinitionId(
+					_objectDefinition.getObjectDefinitionId()
+				).userId(
+					TestPropsValues.getUserId()
+				).build());
+
+		Map<String, Serializable> localizedValues = Collections.singletonMap(
+			localizedObjectField.getI18nObjectFieldName(),
+			HashMapBuilder.put(
+				"en_US", RandomTestUtil.randomString()
+			).put(
+				"pt_BR", RandomTestUtil.randomString()
+			).build());
+
+		ObjectValidationRule objectValidationRule7 = _addObjectValidationRule(
+			ObjectValidationRuleConstants.ENGINE_TYPE_DDM,
+			LocalizedMapUtil.getLocalizedMap("Can not be empty"),
+			"NOT(isEmpty(customField))");
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"birthday", "2000-12-25"
+			).put(
+				"date", tomorrowLocalDate.toString()
+			).put(
+				"emailAddressRequired", "bob@liferay.com"
+			).put(
+				"lastName", "Doe"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).put(
+				"middleName", "Doe"
+			).put(
+				"time", timeString
+			).putAll(
+				localizedValues
+			).build());
+
+		_assertCount(7);
+
+		localizedValues = Collections.singletonMap(
+			localizedObjectField.getI18nObjectFieldName(),
+			HashMapBuilder.put(
+				"en_US", StringPool.BLANK
+			).put(
+				"pt_BR", StringPool.BLANK
+			).build());
+
+		values = HashMapBuilder.<String, Serializable>put(
+			"emailAddressRequired", RandomTestUtil.randomString()
+		).put(
+			"listTypeEntryKeyRequired", "listTypeEntryKey1"
+		).putAll(
+			localizedValues
+		).build();
+
+		try {
+			_addObjectEntry(values);
+
+			Assert.fail();
+		}
+		catch (ModelListenerException modelListenerException) {
+			ObjectValidationRuleEngineException
+				objectValidationRuleEngineException =
+					(ObjectValidationRuleEngineException)
+						modelListenerException.getCause();
+
+			List<ObjectValidationRuleResult> objectValidationRuleResults =
+				objectValidationRuleEngineException.
+					getObjectValidationRuleResults();
+
+			_assertObjectValidationRuleResult(
+				objectValidationRule7.getErrorLabel(LocaleUtil.getDefault()),
+				null,
+				objectValidationRuleResults.get(
+					objectValidationRuleResults.size() - 1));
+		}
+
+		objectValidationRule7.setActive(false);
+
+		_objectValidationRuleLocalService.updateObjectValidationRule(
+			objectValidationRule7);
+
 		_addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"birthday", "2000-12-25"
@@ -2805,7 +2900,7 @@ public class ObjectEntryLocalServiceTest {
 				"time", timeString
 			).build());
 
-		_assertCount(7);
+		_assertCount(8);
 
 		// No such engine
 
@@ -2843,7 +2938,7 @@ public class ObjectEntryLocalServiceTest {
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null, values, serviceContext);
 
-		_assertCount(8);
+		_assertCount(9);
 	}
 
 	@FeatureFlag("LPD-31212")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -2790,21 +2790,19 @@ public class ObjectEntryLocalServiceTest {
 
 		// Can not be empty
 
-		ObjectField localizedObjectField =
-			ObjectFieldUtil.addCustomObjectField(
-				new TextObjectFieldBuilder(
-				).labelMap(
-					LocalizedMapUtil.getLocalizedMap(
-						RandomTestUtil.randomString())
-				).localized(
-					true
-				).name(
-					"customField"
-				).objectDefinitionId(
-					_objectDefinition.getObjectDefinitionId()
-				).userId(
-					TestPropsValues.getUserId()
-				).build());
+		ObjectField localizedObjectField = ObjectFieldUtil.addCustomObjectField(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).localized(
+				true
+			).name(
+				"customField"
+			).objectDefinitionId(
+				_objectDefinition.getObjectDefinitionId()
+			).userId(
+				TestPropsValues.getUserId()
+			).build());
 
 		Map<String, Serializable> localizedValues = Collections.singletonMap(
 			localizedObjectField.getI18nObjectFieldName(),


### PR DESCRIPTION
* In `_putLocalizedValues`, localized field value was being set as blank instead of using the entry value.