### PR TITLE
LPD-56967 Enable binding draft object definition nodes to many draft root object definitions

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -77,6 +77,8 @@ public interface ObjectDefinition
 
 	public long getRootObjectDefinitionId();
 
+	public long[] getRootObjectDefinitionIds();
+
 	public String getShortName();
 
 	public boolean isApproved();
@@ -87,11 +89,15 @@ public interface ObjectDefinition
 
 	public boolean isModifiableAndSystem();
 
-	public boolean isNodeCandidate();
+	public boolean isNode(long rootObjectDefinitionId);
 
 	public boolean isRootDescendantNode();
 
+	public boolean isRootDescendantNode(long rootObjectDefinitionId);
+
 	public boolean isRootNode();
+
+	public boolean isRootNode(long rootObjectDefinitionId);
 
 	public boolean isUnmodifiableSystemObject();
 
@@ -100,6 +106,6 @@ public interface ObjectDefinition
 
 	public void setPreviousRESTContextPath(String previousRESTContextPath);
 
-	public void setRootObjectDefinitionId(long rootObjectDefinitionId);
+	public void setRootObjectDefinitionIds(long[] rootObjectDefinitionIds);
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -882,6 +882,11 @@ public class ObjectDefinitionWrapper
 		return model.getRootObjectDefinitionId();
 	}
 
+	@Override
+	public long[] getRootObjectDefinitionIds() {
+		return model.getRootObjectDefinitionIds();
+	}
+
 	/**
 	 * Returns the scope of this object definition.
 	 *
@@ -1118,8 +1123,8 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
-	public boolean isNodeCandidate() {
-		return model.isNodeCandidate();
+	public boolean isNode(long rootObjectDefinitionId) {
+		return model.isNode(rootObjectDefinitionId);
 	}
 
 	/**
@@ -1138,8 +1143,18 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
+	public boolean isRootDescendantNode(long rootObjectDefinitionId) {
+		return model.isRootDescendantNode(rootObjectDefinitionId);
+	}
+
+	@Override
 	public boolean isRootNode() {
 		return model.isRootNode();
+	}
+
+	@Override
+	public boolean isRootNode(long rootObjectDefinitionId) {
+		return model.isRootNode(rootObjectDefinitionId);
 	}
 
 	/**
@@ -1628,8 +1643,8 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
-	public void setRootObjectDefinitionId(long rootObjectDefinitionId) {
-		model.setRootObjectDefinitionId(rootObjectDefinitionId);
+	public void setRootObjectDefinitionIds(long[] rootObjectDefinitionIds) {
+		model.setRootObjectDefinitionIds(rootObjectDefinitionIds);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationship.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationship.java
@@ -53,9 +53,6 @@ public interface ObjectRelationship
 
 	public boolean isAllowedObjectRelationshipType(String type);
 
-	public boolean isEdgeCandidate()
-		throws com.liferay.portal.kernel.exception.PortalException;
-
 	public boolean isSelf();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationshipWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationshipWrapper.java
@@ -522,13 +522,6 @@ public class ObjectRelationshipWrapper
 		return model.isEdge();
 	}
 
-	@Override
-	public boolean isEdgeCandidate()
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return model.isEdgeCandidate();
-	}
-
 	/**
 	 * Returns <code>true</code> if this object relationship is reverse.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -468,10 +468,6 @@ public interface ObjectDefinitionLocalService
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
-	public ObjectDefinition updateRootDescendantNodeObjectDefinition(
-		ObjectDefinition objectDefinition, long rootObjectDefinitionId);
-
-	@Indexable(type = IndexableType.REINDEX)
 	public ObjectDefinition updateSystemObjectDefinition(
 			String externalReferenceCode, long objectDefinitionId,
 			long objectFolderId, long titleObjectFieldId,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -620,13 +620,6 @@ public class ObjectDefinitionLocalServiceUtil {
 		return getService().updatePortlet(objectDefinitionId);
 	}
 
-	public static ObjectDefinition updateRootDescendantNodeObjectDefinition(
-		ObjectDefinition objectDefinition, long rootObjectDefinitionId) {
-
-		return getService().updateRootDescendantNodeObjectDefinition(
-			objectDefinition, rootObjectDefinitionId);
-	}
-
 	public static ObjectDefinition updateSystemObjectDefinition(
 			String externalReferenceCode, long objectDefinitionId,
 			long objectFolderId, long titleObjectFieldId,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -725,17 +725,6 @@ public class ObjectDefinitionLocalServiceWrapper
 
 	@Override
 	public com.liferay.object.model.ObjectDefinition
-		updateRootDescendantNodeObjectDefinition(
-			com.liferay.object.model.ObjectDefinition objectDefinition,
-			long rootObjectDefinitionId) {
-
-		return _objectDefinitionLocalService.
-			updateRootDescendantNodeObjectDefinition(
-				objectDefinition, rootObjectDefinitionId);
-	}
-
-	@Override
-	public com.liferay.object.model.ObjectDefinition
 			updateSystemObjectDefinition(
 				String externalReferenceCode, long objectDefinitionId,
 				long objectFolderId, long titleObjectFieldId,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectDefinitionTreeFactory.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectDefinitionTreeFactory.java
@@ -39,17 +39,23 @@ public class ObjectDefinitionTreeFactory extends BaseTreeFactory {
 		_objectDefinitionPersistence = objectDefinitionPersistence;
 	}
 
-	public Tree create(boolean excludeDifferentStatus, long objectDefinitionId)
+	public Tree create(
+			boolean excludeDifferentStatus,
+			boolean excludeDifferentRootObjectDefinitionIds,
+			long objectDefinitionId)
 		throws PortalException {
 
 		return create(
-			excludeDifferentStatus, objectDefinitionId,
+			excludeDifferentStatus, excludeDifferentRootObjectDefinitionIds,
+			objectDefinitionId,
 			pk -> objectRelationshipLocalService.getObjectRelationships(
 				pk, true));
 	}
 
 	public Tree create(
-			boolean excludeDifferentStatus, long objectDefinitionId,
+			boolean excludeDifferentStatus,
+			boolean excludeDifferentRootObjectDefinitionIds,
+			long objectDefinitionId,
 			UnsafeFunction<Long, List<ObjectRelationship>, PortalException>
 				unsafeFunction)
 		throws PortalException {
@@ -68,8 +74,9 @@ public class ObjectDefinitionTreeFactory extends BaseTreeFactory {
 					if ((excludeDifferentStatus &&
 						 (rootObjectDefinition.getStatus() !=
 							 objectDefinition2.getStatus())) ||
-						(rootObjectDefinition.getObjectDefinitionId() !=
-							objectDefinition2.getRootObjectDefinitionId())) {
+						(excludeDifferentRootObjectDefinitionIds &&
+						 !objectDefinition2.isNode(
+							 rootObjectDefinition.getObjectDefinitionId()))) {
 
 						return null;
 					}
@@ -81,7 +88,7 @@ public class ObjectDefinitionTreeFactory extends BaseTreeFactory {
 	}
 
 	public Tree create(long objectDefinitionId) throws PortalException {
-		return create(true, objectDefinitionId);
+		return create(true, true, objectDefinitionId);
 	}
 
 	private ObjectDefinition _getObjectDefinition(long objectDefinitionId)

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/tree/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/tree/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -288,11 +288,11 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		if (objectRelationshipsMap == null) {
 			tree = objectDefinitionTreeFactory.create(
-				true, rootNodeObjectDefinition.getObjectDefinitionId());
+				rootNodeObjectDefinition.getObjectDefinitionId());
 		}
 		else {
 			tree = objectDefinitionTreeFactory.create(
-				true, rootNodeObjectDefinition.getObjectDefinitionId(),
+				true, true, rootNodeObjectDefinition.getObjectDefinitionId(),
 				pk -> ListUtil.filter(
 					objectRelationshipsMap.getOrDefault(
 						pk, Collections.emptyList()),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -210,6 +211,17 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 
 	@Override
 	public long getRootObjectDefinitionId() {
+		long[] rootObjectDefinitionIds = getRootObjectDefinitionIds();
+
+		if (rootObjectDefinitionIds.length == 0) {
+			return 0L;
+		}
+
+		return rootObjectDefinitionIds[0];
+	}
+
+	@Override
+	public long[] getRootObjectDefinitionIds() {
 		ObjectDefinitionSetting objectDefinitionSetting =
 			ObjectDefinitionSettingLocalServiceUtil.
 				fetchObjectDefinitionSetting(
@@ -218,10 +230,18 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 						NAME_ROOT_OBJECT_DEFINITION_IDS);
 
 		if (objectDefinitionSetting == null) {
-			return 0L;
+			return new long[0];
 		}
 
-		return GetterUtil.getLong(objectDefinitionSetting.getValue());
+		String[] values = StringUtil.split(objectDefinitionSetting.getValue());
+
+		long[] rootObjectDefinitionIds = new long[values.length];
+
+		for (int i = 0; i < rootObjectDefinitionIds.length; i++) {
+			rootObjectDefinitionIds[i] = GetterUtil.getLong(values[i]);
+		}
+
+		return rootObjectDefinitionIds;
 	}
 
 	@Override
@@ -263,21 +283,29 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
-	public boolean isNodeCandidate() {
-		if (!isApproved() && !isUnmodifiableSystemObject()) {
-			return true;
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean isRootDescendantNode() {
+	public boolean isNode(long rootObjectDefinitionId) {
 		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-34594")) {
 			return false;
 		}
 
-		if ((getRootObjectDefinitionId() > 0) && !isRootNode()) {
+		return ArrayUtil.contains(
+			getRootObjectDefinitionIds(), rootObjectDefinitionId);
+	}
+
+	@Override
+	public boolean isRootDescendantNode() {
+		return isRootDescendantNode(getRootObjectDefinitionId());
+	}
+
+	@Override
+	public boolean isRootDescendantNode(long rootObjectDefinitionId) {
+		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-34594")) {
+			return false;
+		}
+
+		if (isNode(rootObjectDefinitionId) &&
+			(getObjectDefinitionId() != rootObjectDefinitionId)) {
+
 			return true;
 		}
 
@@ -286,11 +314,18 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 
 	@Override
 	public boolean isRootNode() {
+		return isRootNode(getRootObjectDefinitionId());
+	}
+
+	@Override
+	public boolean isRootNode(long rootObjectDefinitionId) {
 		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-34594")) {
 			return false;
 		}
 
-		if (getObjectDefinitionId() == getRootObjectDefinitionId()) {
+		if (isNode(rootObjectDefinitionId) &&
+			(getObjectDefinitionId() == rootObjectDefinitionId)) {
+
 			return true;
 		}
 
@@ -319,7 +354,7 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
-	public void setRootObjectDefinitionId(long rootObjectDefinitionId) {
+	public void setRootObjectDefinitionIds(long[] rootObjectDefinitionIds) {
 		ObjectDefinitionSetting objectDefinitionSetting =
 			ObjectDefinitionSettingLocalServiceUtil.
 				fetchObjectDefinitionSetting(
@@ -334,11 +369,15 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 						getUserId(), getObjectDefinitionId(),
 						ObjectDefinitionSettingConstants.
 							NAME_ROOT_OBJECT_DEFINITION_IDS,
-						String.valueOf(rootObjectDefinitionId));
+						StringUtil.merge(rootObjectDefinitionIds));
 			}
 			else {
 				objectDefinitionSetting.setValue(
-					String.valueOf(rootObjectDefinitionId));
+					StringUtil.merge(
+						ArrayUtil.append(
+							StringUtil.split(
+								objectDefinitionSetting.getValue()),
+							StringUtil.merge(rootObjectDefinitionIds))));
 
 				ObjectDefinitionSettingLocalServiceUtil.
 					updateObjectDefinitionSetting(objectDefinitionSetting);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
@@ -5,11 +5,7 @@
 
 package com.liferay.object.model.impl;
 
-import com.liferay.object.constants.ObjectRelationshipConstants;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 
 import java.util.Objects;
 import java.util.Set;
@@ -31,31 +27,6 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 			ObjectRelationshipUtil.getDefaultObjectRelationshipTypes();
 
 		return defaultObjectRelationshipTypes.contains(type);
-	}
-
-	@Override
-	public boolean isEdgeCandidate() throws PortalException {
-		if (isSelf() ||
-			!Objects.equals(
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, getType())) {
-
-			return false;
-		}
-
-		ObjectDefinition objectDefinition1 =
-			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-				getObjectDefinitionId1());
-		ObjectDefinition objectDefinition2 =
-			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-				getObjectDefinitionId2());
-
-		if (!objectDefinition1.isNodeCandidate() ||
-			!objectDefinition2.isNodeCandidate()) {
-
-			return false;
-		}
-
-		return true;
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1652,13 +1652,11 @@ public class ObjectDefinitionLocalServiceImpl
 		for (ObjectDefinitionSetting objectDefinitionSetting :
 				objectDefinitionSettings) {
 
-			if (objectDefinitionSetting.isReadOnly()) {
-				continue;
+			if (!objectDefinitionSetting.isReadOnly()) {
+				objectDefinitionSettingsValuesMap.put(
+					objectDefinitionSetting.getName(),
+					objectDefinitionSetting.getValue());
 			}
-
-			objectDefinitionSettingsValuesMap.put(
-				objectDefinitionSetting.getName(),
-				objectDefinitionSetting.getValue());
 		}
 
 		_validateObjectDefinitionSettings(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1283,8 +1283,6 @@ public class ObjectDefinitionLocalServiceImpl
 	public ObjectDefinition updateRootDescendantNodeObjectDefinition(
 		ObjectDefinition objectDefinition, long rootObjectDefinitionId) {
 
-		objectDefinition.setPanelCategoryKey(StringPool.BLANK);
-		objectDefinition.setPortlet(false);
 		objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
 
 		objectDefinition = objectDefinitionPersistence.update(objectDefinition);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -142,7 +142,6 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -1280,28 +1279,6 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public ObjectDefinition updateRootDescendantNodeObjectDefinition(
-		ObjectDefinition objectDefinition, long rootObjectDefinitionId) {
-
-		objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
-
-		objectDefinition = objectDefinitionPersistence.update(objectDefinition);
-
-		_resourceActions.removeModelResource(
-			objectDefinition.getClassName(), ActionKeys.DELETE);
-		_resourceActions.removeModelResource(
-			objectDefinition.getClassName(), ActionKeys.UPDATE);
-		_resourceActions.removeModelResource(
-			objectDefinition.getClassName(), ActionKeys.VIEW);
-
-		_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLinks(
-			objectDefinition.getCompanyId(), objectDefinition.getClassName());
-
-		return objectDefinition;
-	}
-
-	@Indexable(type = IndexableType.REINDEX)
-	@Override
 	public ObjectDefinition updateSystemObjectDefinition(
 			String externalReferenceCode, long objectDefinitionId,
 			long objectFolderId, long titleObjectFieldId,
@@ -2408,11 +2385,8 @@ public class ObjectDefinitionLocalServiceImpl
 				String previousRESTContextPath =
 					nodeObjectDefinition.getRESTContextPath();
 
-				nodeObjectDefinition =
-					objectDefinitionLocalService.
-						updateRootDescendantNodeObjectDefinition(
-							nodeObjectDefinition,
-							objectDefinition1.getRootObjectDefinitionId());
+				nodeObjectDefinition.setRootObjectDefinitionIds(
+					objectDefinition1.getRootObjectDefinitionIds());
 
 				nodeObjectDefinition.setPreviousRESTContextPath(
 					previousRESTContextPath);
@@ -2423,7 +2397,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 		if (containsDraftDescendantNodeObjectDefinitions) {
 			Tree tree = objectDefinitionTreeFactory.create(
-				false, objectDefinition1.getObjectDefinitionId());
+				false, true, objectDefinition1.getObjectDefinitionId());
 
 			Node rootNode = tree.getRootNode();
 
@@ -2438,10 +2412,8 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinitionLocalService.getObjectDefinition(
 							node.getPrimaryKey());
 
-					nodeObjectDefinition.setRootObjectDefinitionId(
-						childNode.getPrimaryKey());
-
-					objectDefinitionPersistence.update(nodeObjectDefinition);
+					nodeObjectDefinition.setRootObjectDefinitionIds(
+						new long[] {childNode.getPrimaryKey()});
 				}
 			}
 		}
@@ -2466,18 +2438,12 @@ public class ObjectDefinitionLocalServiceImpl
 		String previousRESTContextPath = objectDefinition2.getRESTContextPath();
 
 		if (objectDefinition1.isApproved()) {
-			objectDefinition2 =
-				objectDefinitionLocalService.
-					updateRootDescendantNodeObjectDefinition(
-						objectDefinition2,
-						objectDefinition1.getRootObjectDefinitionId());
+			objectDefinition2.setRootObjectDefinitionIds(
+				objectDefinition1.getRootObjectDefinitionIds());
 		}
 		else {
-			objectDefinition2.setRootObjectDefinitionId(
-				objectDefinition2.getObjectDefinitionId());
-
-			objectDefinition2 = objectDefinitionPersistence.update(
-				objectDefinition2);
+			objectDefinition2.setRootObjectDefinitionIds(
+				new long[] {objectDefinition2.getObjectDefinitionId()});
 		}
 
 		objectDefinition2.setPreviousRESTContextPath(previousRESTContextPath);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1381,9 +1381,6 @@ public class ObjectRelationshipLocalServiceImpl
 			objectRelationshipLocalService.updateObjectRelationship(
 				objectRelationship);
 
-		_objectFieldLocalService.updateRequired(
-			objectRelationship.getObjectFieldId2(), true);
-
 		ObjectDefinition objectDefinition1 =
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectRelationship.getObjectDefinitionId1());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1389,15 +1389,12 @@ public class ObjectRelationshipLocalServiceImpl
 			objectDefinition1.getRESTContextPath();
 
 		if (objectDefinition1.getRootObjectDefinitionId() == 0) {
-			objectDefinition1.setRootObjectDefinitionId(
-				objectDefinition1.getObjectDefinitionId());
+			objectDefinition1.setRootObjectDefinitionIds(
+				new long[] {objectDefinition1.getObjectDefinitionId()});
 		}
 
 		ObjectDefinitionLocalService objectDefinitionLocalService =
 			_objectDefinitionLocalServiceSnapshot.get();
-
-		objectDefinition1 = objectDefinitionLocalService.updateObjectDefinition(
-			objectDefinition1);
 
 		ObjectDefinition objectDefinition2 =
 			_objectDefinitionPersistence.findByPrimaryKey(
@@ -1426,7 +1423,7 @@ public class ObjectRelationshipLocalServiceImpl
 					objectRelationshipLocalService);
 
 			Tree tree = objectDefinitionTreeFactory.create(
-				objectDefinition2.getObjectDefinitionId());
+				true, false, objectDefinition2.getObjectDefinitionId());
 
 			Iterator<Node> iterator = tree.iterator();
 
@@ -1440,11 +1437,8 @@ public class ObjectRelationshipLocalServiceImpl
 				String nodeObjectDefinitionPreviousRESTContextPath =
 					nodeObjectDefinition.getRESTContextPath();
 
-				nodeObjectDefinition =
-					objectDefinitionLocalService.
-						updateRootDescendantNodeObjectDefinition(
-							nodeObjectDefinition,
-							objectDefinition1.getRootObjectDefinitionId());
+				nodeObjectDefinition.setRootObjectDefinitionIds(
+					objectDefinition1.getRootObjectDefinitionIds());
 
 				if (nodeObjectDefinition.isApproved() &&
 					objectDefinition1.isApproved()) {
@@ -1462,12 +1456,8 @@ public class ObjectRelationshipLocalServiceImpl
 				return;
 			}
 
-			objectDefinition2.setRootObjectDefinitionId(
-				objectDefinition2.getObjectDefinitionId());
-
-			objectDefinition2 =
-				objectDefinitionLocalService.updateObjectDefinition(
-					objectDefinition2);
+			objectDefinition2.setRootObjectDefinitionIds(
+				new long[] {objectDefinition2.getObjectDefinitionId()});
 
 			if (objectDefinition2.isApproved()) {
 				objectDefinitionLocalService.deployObjectDefinition(
@@ -2005,10 +1995,8 @@ public class ObjectRelationshipLocalServiceImpl
 
 		String previousRESTContextPath = objectDefinition.getRESTContextPath();
 
-		objectDefinition.setRootObjectDefinitionId(newRootObjectDefinitionId);
-
-		objectDefinition = _objectDefinitionPersistence.update(
-			objectDefinition);
+		objectDefinition.setRootObjectDefinitionIds(
+			new long[] {newRootObjectDefinitionId});
 
 		objectDefinition.setPreviousRESTContextPath(previousRESTContextPath);
 
@@ -2208,20 +2196,6 @@ public class ObjectRelationshipLocalServiceImpl
 						"enable-inheritance-x-(x-object-entries)-and-x-(x-" +
 							"object-entries)");
 			}
-		}
-
-		long objectDefinition2RootObjectDefinitionId =
-			objectDefinition2.getRootObjectDefinitionId();
-
-		if ((objectDefinition2RootObjectDefinitionId != 0) &&
-			(objectDefinition2RootObjectDefinitionId !=
-				objectDefinition2.getObjectDefinitionId())) {
-
-			throw new ObjectRelationshipEdgeException(
-				"Unable to bind the object definitions when the child object " +
-					"definition is bound to another object definition",
-				"unable-to-bind-the-object-definitions-when-the-child-object-" +
-					"definition-is-bound-to-another-object-definition");
 		}
 
 		if (!StringUtil.equals(

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
@@ -129,7 +129,8 @@ public class ObjectDefinitionImplTest {
 
 			long rootObjectDefinitionId = RandomTestUtil.randomLong();
 
-			objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
+			objectDefinition.setRootObjectDefinitionIds(
+				new long[] {rootObjectDefinitionId});
 
 			ObjectDefinitionLocalService objectDefinitionLocalService =
 				Mockito.mock(ObjectDefinitionLocalService.class);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -842,6 +842,105 @@ public class ObjectRelationshipLocalServiceTest {
 	}
 
 	@Test
+	public void testBindDraftObjectDefinitionNodesToManyRootObjectDefinitions()
+		throws Exception {
+
+		Tree treeA = TreeTestUtil.createObjectDefinitionTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			false,
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[0]
+			).build());
+		Tree treeB = TreeTestUtil.createObjectDefinitionTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			false,
+			LinkedHashMapBuilder.put(
+				"B", new String[] {"BB"}
+			).put(
+				"BB", new String[] {"BBB"}
+			).put(
+				"BBB", new String[0]
+			).build());
+		Tree treeC = TreeTestUtil.createObjectDefinitionTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			false,
+			LinkedHashMapBuilder.put(
+				"C", new String[] {"CC"}
+			).put(
+				"CC", new String[] {"CCC"}
+			).put(
+				"CCC", new String[0]
+			).build());
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			Arrays.asList(
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService,
+					_objectDefinitionLocalService.getObjectDefinition(
+						TestPropsValues.getCompanyId(), "C_AA"),
+					_objectDefinitionLocalService.getObjectDefinition(
+						TestPropsValues.getCompanyId(), "C_BB")),
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService,
+					_objectDefinitionLocalService.getObjectDefinition(
+						TestPropsValues.getCompanyId(), "C_BB"),
+					_objectDefinitionLocalService.getObjectDefinition(
+						TestPropsValues.getCompanyId(), "C_CC"))));
+
+		Node rootNodeA = treeA.getRootNode();
+
+		TreeTestUtil.assertObjectDefinitionTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[] {"BB"}
+			).put(
+				"BB", new String[] {"BBB", "CC"}
+			).put(
+				"BBB", new String[0]
+			).put(
+				"CC", new String[] {"CCC"}
+			).put(
+				"CCC", new String[0]
+			).build(),
+			_objectDefinitionTreeFactory.create(rootNodeA.getPrimaryKey()),
+			_objectDefinitionLocalService);
+
+		Node rootNodeB = treeB.getRootNode();
+
+		TreeTestUtil.assertObjectDefinitionTree(
+			LinkedHashMapBuilder.put(
+				"B", new String[] {"BB"}
+			).put(
+				"BB", new String[] {"BBB", "CC"}
+			).put(
+				"BBB", new String[0]
+			).put(
+				"CC", new String[] {"CCC"}
+			).put(
+				"CCC", new String[0]
+			).build(),
+			_objectDefinitionTreeFactory.create(rootNodeB.getPrimaryKey()),
+			_objectDefinitionLocalService);
+
+		Node rootNodeC = treeC.getRootNode();
+
+		TreeTestUtil.assertObjectDefinitionTree(
+			LinkedHashMapBuilder.put(
+				"C", new String[] {"CC"}
+			).put(
+				"CC", new String[] {"CCC"}
+			).put(
+				"CCC", new String[0]
+			).build(),
+			_objectDefinitionTreeFactory.create(rootNodeC.getPrimaryKey()),
+			_objectDefinitionLocalService);
+	}
+
+	@Test
 	public void testBindDraftObjectDefinitions() throws Exception {
 
 		// Bind a draft object definition as a child node in a draft object


### PR DESCRIPTION
Related: [LPD-56967](https://liferay.atlassian.net/browse/LPD-56967)

[LPD-56967]: https://liferay.atlassian.net/browse/LPD-56967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ