### PR TITLE
LPD-56967 Enable binding draft object definition nodes to many draft root object definitions

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -77,6 +77,8 @@ public interface ObjectDefinition
 
 	public long getRootObjectDefinitionId();
 
+	public long[] getRootObjectDefinitionIds();
+
 	public String getShortName();
 
 	public boolean isApproved();
@@ -87,11 +89,15 @@ public interface ObjectDefinition
 
 	public boolean isModifiableAndSystem();
 
-	public boolean isNodeCandidate();
+	public boolean isNode(long rootObjectDefinitionId);
 
 	public boolean isRootDescendantNode();
 
+	public boolean isRootDescendantNode(long rootObjectDefinitionId);
+
 	public boolean isRootNode();
+
+	public boolean isRootNode(long rootObjectDefinitionId);
 
 	public boolean isUnmodifiableSystemObject();
 
@@ -100,6 +106,8 @@ public interface ObjectDefinition
 
 	public void setPreviousRESTContextPath(String previousRESTContextPath);
 
-	public void setRootObjectDefinitionId(long rootObjectDefinitionId);
+	public void setRootObjectDefinitionIds(
+		long[] rootObjectDefinitionIdsToAdd,
+		long[] rootObjectDefinitionIdsToRemove);
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -882,6 +882,11 @@ public class ObjectDefinitionWrapper
 		return model.getRootObjectDefinitionId();
 	}
 
+	@Override
+	public long[] getRootObjectDefinitionIds() {
+		return model.getRootObjectDefinitionIds();
+	}
+
 	/**
 	 * Returns the scope of this object definition.
 	 *
@@ -1118,8 +1123,8 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
-	public boolean isNodeCandidate() {
-		return model.isNodeCandidate();
+	public boolean isNode(long rootObjectDefinitionId) {
+		return model.isNode(rootObjectDefinitionId);
 	}
 
 	/**
@@ -1138,8 +1143,18 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
+	public boolean isRootDescendantNode(long rootObjectDefinitionId) {
+		return model.isRootDescendantNode(rootObjectDefinitionId);
+	}
+
+	@Override
 	public boolean isRootNode() {
 		return model.isRootNode();
+	}
+
+	@Override
+	public boolean isRootNode(long rootObjectDefinitionId) {
+		return model.isRootNode(rootObjectDefinitionId);
 	}
 
 	/**
@@ -1628,8 +1643,12 @@ public class ObjectDefinitionWrapper
 	}
 
 	@Override
-	public void setRootObjectDefinitionId(long rootObjectDefinitionId) {
-		model.setRootObjectDefinitionId(rootObjectDefinitionId);
+	public void setRootObjectDefinitionIds(
+		long[] rootObjectDefinitionIdsToAdd,
+		long[] rootObjectDefinitionIdsToRemove) {
+
+		model.setRootObjectDefinitionIds(
+			rootObjectDefinitionIdsToAdd, rootObjectDefinitionIdsToRemove);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationship.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationship.java
@@ -53,9 +53,6 @@ public interface ObjectRelationship
 
 	public boolean isAllowedObjectRelationshipType(String type);
 
-	public boolean isEdgeCandidate()
-		throws com.liferay.portal.kernel.exception.PortalException;
-
 	public boolean isSelf();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationshipWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectRelationshipWrapper.java
@@ -522,13 +522,6 @@ public class ObjectRelationshipWrapper
 		return model.isEdge();
 	}
 
-	@Override
-	public boolean isEdgeCandidate()
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return model.isEdgeCandidate();
-	}
-
 	/**
 	 * Returns <code>true</code> if this object relationship is reverse.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -468,10 +468,6 @@ public interface ObjectDefinitionLocalService
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
-	public ObjectDefinition updateRootDescendantNodeObjectDefinition(
-		ObjectDefinition objectDefinition, long rootObjectDefinitionId);
-
-	@Indexable(type = IndexableType.REINDEX)
 	public ObjectDefinition updateSystemObjectDefinition(
 			String externalReferenceCode, long objectDefinitionId,
 			long objectFolderId, long titleObjectFieldId,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -620,13 +620,6 @@ public class ObjectDefinitionLocalServiceUtil {
 		return getService().updatePortlet(objectDefinitionId);
 	}
 
-	public static ObjectDefinition updateRootDescendantNodeObjectDefinition(
-		ObjectDefinition objectDefinition, long rootObjectDefinitionId) {
-
-		return getService().updateRootDescendantNodeObjectDefinition(
-			objectDefinition, rootObjectDefinitionId);
-	}
-
 	public static ObjectDefinition updateSystemObjectDefinition(
 			String externalReferenceCode, long objectDefinitionId,
 			long objectFolderId, long titleObjectFieldId,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -725,17 +725,6 @@ public class ObjectDefinitionLocalServiceWrapper
 
 	@Override
 	public com.liferay.object.model.ObjectDefinition
-		updateRootDescendantNodeObjectDefinition(
-			com.liferay.object.model.ObjectDefinition objectDefinition,
-			long rootObjectDefinitionId) {
-
-		return _objectDefinitionLocalService.
-			updateRootDescendantNodeObjectDefinition(
-				objectDefinition, rootObjectDefinitionId);
-	}
-
-	@Override
-	public com.liferay.object.model.ObjectDefinition
 			updateSystemObjectDefinition(
 				String externalReferenceCode, long objectDefinitionId,
 				long objectFolderId, long titleObjectFieldId,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectDefinitionTreeFactory.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectDefinitionTreeFactory.java
@@ -39,17 +39,23 @@ public class ObjectDefinitionTreeFactory extends BaseTreeFactory {
 		_objectDefinitionPersistence = objectDefinitionPersistence;
 	}
 
-	public Tree create(boolean excludeDifferentStatus, long objectDefinitionId)
+	public Tree create(
+			boolean excludeDifferentStatus,
+			boolean excludeDifferentRootObjectDefinitionIds,
+			long objectDefinitionId)
 		throws PortalException {
 
 		return create(
-			excludeDifferentStatus, objectDefinitionId,
+			excludeDifferentStatus, excludeDifferentRootObjectDefinitionIds,
+			objectDefinitionId,
 			pk -> objectRelationshipLocalService.getObjectRelationships(
 				pk, true));
 	}
 
 	public Tree create(
-			boolean excludeDifferentStatus, long objectDefinitionId,
+			boolean excludeDifferentStatus,
+			boolean excludeDifferentRootObjectDefinitionIds,
+			long objectDefinitionId,
 			UnsafeFunction<Long, List<ObjectRelationship>, PortalException>
 				unsafeFunction)
 		throws PortalException {
@@ -68,8 +74,9 @@ public class ObjectDefinitionTreeFactory extends BaseTreeFactory {
 					if ((excludeDifferentStatus &&
 						 (rootObjectDefinition.getStatus() !=
 							 objectDefinition2.getStatus())) ||
-						(rootObjectDefinition.getObjectDefinitionId() !=
-							objectDefinition2.getRootObjectDefinitionId())) {
+						(excludeDifferentRootObjectDefinitionIds &&
+						 !objectDefinition2.isNode(
+							 rootObjectDefinition.getObjectDefinitionId()))) {
 
 						return null;
 					}
@@ -81,7 +88,7 @@ public class ObjectDefinitionTreeFactory extends BaseTreeFactory {
 	}
 
 	public Tree create(long objectDefinitionId) throws PortalException {
-		return create(true, objectDefinitionId);
+		return create(true, true, objectDefinitionId);
 	}
 
 	private ObjectDefinition _getObjectDefinition(long objectDefinitionId)

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/tree/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/tree/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -288,11 +288,11 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		if (objectRelationshipsMap == null) {
 			tree = objectDefinitionTreeFactory.create(
-				true, rootNodeObjectDefinition.getObjectDefinitionId());
+				rootNodeObjectDefinition.getObjectDefinitionId());
 		}
 		else {
 			tree = objectDefinitionTreeFactory.create(
-				true, rootNodeObjectDefinition.getObjectDefinitionId(),
+				true, true, rootNodeObjectDefinition.getObjectDefinitionId(),
 				pk -> ListUtil.filter(
 					objectRelationshipsMap.getOrDefault(
 						pk, Collections.emptyList()),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -21,12 +21,14 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -210,6 +212,17 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 
 	@Override
 	public long getRootObjectDefinitionId() {
+		long[] rootObjectDefinitionIds = getRootObjectDefinitionIds();
+
+		if (rootObjectDefinitionIds.length == 0) {
+			return 0L;
+		}
+
+		return rootObjectDefinitionIds[0];
+	}
+
+	@Override
+	public long[] getRootObjectDefinitionIds() {
 		ObjectDefinitionSetting objectDefinitionSetting =
 			ObjectDefinitionSettingLocalServiceUtil.
 				fetchObjectDefinitionSetting(
@@ -218,10 +231,12 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 						NAME_ROOT_OBJECT_DEFINITION_IDS);
 
 		if (objectDefinitionSetting == null) {
-			return 0L;
+			return new long[0];
 		}
 
-		return GetterUtil.getLong(objectDefinitionSetting.getValue());
+		return ListUtil.toLongArray(
+			Arrays.asList(StringUtil.split(objectDefinitionSetting.getValue())),
+			GetterUtil::getLong);
 	}
 
 	@Override
@@ -263,21 +278,29 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
-	public boolean isNodeCandidate() {
-		if (!isApproved() && !isUnmodifiableSystemObject()) {
-			return true;
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean isRootDescendantNode() {
+	public boolean isNode(long rootObjectDefinitionId) {
 		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-34594")) {
 			return false;
 		}
 
-		if ((getRootObjectDefinitionId() > 0) && !isRootNode()) {
+		return ArrayUtil.contains(
+			getRootObjectDefinitionIds(), rootObjectDefinitionId);
+	}
+
+	@Override
+	public boolean isRootDescendantNode() {
+		return isRootDescendantNode(getRootObjectDefinitionId());
+	}
+
+	@Override
+	public boolean isRootDescendantNode(long rootObjectDefinitionId) {
+		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-34594")) {
+			return false;
+		}
+
+		if (isNode(rootObjectDefinitionId) &&
+			(getObjectDefinitionId() != rootObjectDefinitionId)) {
+
 			return true;
 		}
 
@@ -286,11 +309,18 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 
 	@Override
 	public boolean isRootNode() {
+		return isRootNode(getRootObjectDefinitionId());
+	}
+
+	@Override
+	public boolean isRootNode(long rootObjectDefinitionId) {
 		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-34594")) {
 			return false;
 		}
 
-		if (getObjectDefinitionId() == getRootObjectDefinitionId()) {
+		if (isNode(rootObjectDefinitionId) &&
+			(getObjectDefinitionId() == rootObjectDefinitionId)) {
+
 			return true;
 		}
 
@@ -319,7 +349,7 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
-	public void setRootObjectDefinitionId(long rootObjectDefinitionId) {
+	public void setRootObjectDefinitionIds(long[] rootObjectDefinitionIds) {
 		ObjectDefinitionSetting objectDefinitionSetting =
 			ObjectDefinitionSettingLocalServiceUtil.
 				fetchObjectDefinitionSetting(
@@ -334,11 +364,15 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 						getUserId(), getObjectDefinitionId(),
 						ObjectDefinitionSettingConstants.
 							NAME_ROOT_OBJECT_DEFINITION_IDS,
-						String.valueOf(rootObjectDefinitionId));
+						StringUtil.merge(rootObjectDefinitionIds));
 			}
 			else {
 				objectDefinitionSetting.setValue(
-					String.valueOf(rootObjectDefinitionId));
+					StringUtil.merge(
+						ArrayUtil.append(
+							StringUtil.split(
+								objectDefinitionSetting.getValue()),
+							StringUtil.merge(rootObjectDefinitionIds))));
 
 				ObjectDefinitionSettingLocalServiceUtil.
 					updateObjectDefinitionSetting(objectDefinitionSetting);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
@@ -349,7 +350,10 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
-	public void setRootObjectDefinitionIds(long[] rootObjectDefinitionIds) {
+	public void setRootObjectDefinitionIds(
+		long[] rootObjectDefinitionIdsToAdd,
+		long[] rootObjectDefinitionIdsToRemove) {
+
 		ObjectDefinitionSetting objectDefinitionSetting =
 			ObjectDefinitionSettingLocalServiceUtil.
 				fetchObjectDefinitionSetting(
@@ -364,15 +368,28 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 						getUserId(), getObjectDefinitionId(),
 						ObjectDefinitionSettingConstants.
 							NAME_ROOT_OBJECT_DEFINITION_IDS,
-						StringUtil.merge(rootObjectDefinitionIds));
+						StringUtil.merge(rootObjectDefinitionIdsToAdd));
 			}
 			else {
+				List<String> rootObjectDefinitionIds = ListUtil.fromArray(
+					StringUtil.split(objectDefinitionSetting.getValue()));
+
+				for (long rootObjectDefinitionIdToAdd :
+						rootObjectDefinitionIdsToAdd) {
+
+					rootObjectDefinitionIds.add(
+						String.valueOf(rootObjectDefinitionIdToAdd));
+				}
+
+				for (long rootObjectDefinitionIdToRemove :
+						rootObjectDefinitionIdsToRemove) {
+
+					rootObjectDefinitionIds.remove(
+						String.valueOf(rootObjectDefinitionIdToRemove));
+				}
+
 				objectDefinitionSetting.setValue(
-					StringUtil.merge(
-						ArrayUtil.append(
-							StringUtil.split(
-								objectDefinitionSetting.getValue()),
-							StringUtil.merge(rootObjectDefinitionIds))));
+					StringUtil.merge(rootObjectDefinitionIds));
 
 				ObjectDefinitionSettingLocalServiceUtil.
 					updateObjectDefinitionSetting(objectDefinitionSetting);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
@@ -5,11 +5,7 @@
 
 package com.liferay.object.model.impl;
 
-import com.liferay.object.constants.ObjectRelationshipConstants;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 
 import java.util.Objects;
 import java.util.Set;
@@ -31,31 +27,6 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 			ObjectRelationshipUtil.getDefaultObjectRelationshipTypes();
 
 		return defaultObjectRelationshipTypes.contains(type);
-	}
-
-	@Override
-	public boolean isEdgeCandidate() throws PortalException {
-		if (isSelf() ||
-			!Objects.equals(
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, getType())) {
-
-			return false;
-		}
-
-		ObjectDefinition objectDefinition1 =
-			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-				getObjectDefinitionId1());
-		ObjectDefinition objectDefinition2 =
-			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-				getObjectDefinitionId2());
-
-		if (!objectDefinition1.isNodeCandidate() ||
-			!objectDefinition2.isNodeCandidate()) {
-
-			return false;
-		}
-
-		return true;
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -141,7 +141,6 @@ import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -1280,28 +1279,6 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public ObjectDefinition updateRootDescendantNodeObjectDefinition(
-		ObjectDefinition objectDefinition, long rootObjectDefinitionId) {
-
-		objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
-
-		objectDefinition = objectDefinitionPersistence.update(objectDefinition);
-
-		_resourceActions.removeModelResource(
-			objectDefinition.getClassName(), ActionKeys.DELETE);
-		_resourceActions.removeModelResource(
-			objectDefinition.getClassName(), ActionKeys.UPDATE);
-		_resourceActions.removeModelResource(
-			objectDefinition.getClassName(), ActionKeys.VIEW);
-
-		_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLinks(
-			objectDefinition.getCompanyId(), objectDefinition.getClassName());
-
-		return objectDefinition;
-	}
-
-	@Indexable(type = IndexableType.REINDEX)
-	@Override
 	public ObjectDefinition updateSystemObjectDefinition(
 			String externalReferenceCode, long objectDefinitionId,
 			long objectFolderId, long titleObjectFieldId,
@@ -2412,11 +2389,9 @@ public class ObjectDefinitionLocalServiceImpl
 				String previousRESTContextPath =
 					nodeObjectDefinition.getRESTContextPath();
 
-				nodeObjectDefinition =
-					objectDefinitionLocalService.
-						updateRootDescendantNodeObjectDefinition(
-							nodeObjectDefinition,
-							objectDefinition1.getRootObjectDefinitionId());
+				nodeObjectDefinition.setRootObjectDefinitionIds(
+					objectDefinition1.getRootObjectDefinitionIds(),
+					new long[] {objectDefinition2.getObjectDefinitionId()});
 
 				nodeObjectDefinition.setPreviousRESTContextPath(
 					previousRESTContextPath);
@@ -2427,7 +2402,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 		if (containsDraftDescendantNodeObjectDefinitions) {
 			Tree tree = objectDefinitionTreeFactory.create(
-				false, objectDefinition1.getObjectDefinitionId());
+				false, true, objectDefinition1.getObjectDefinitionId());
 
 			Node rootNode = tree.getRootNode();
 
@@ -2442,10 +2417,9 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinitionLocalService.getObjectDefinition(
 							node.getPrimaryKey());
 
-					nodeObjectDefinition.setRootObjectDefinitionId(
-						childNode.getPrimaryKey());
-
-					objectDefinitionPersistence.update(nodeObjectDefinition);
+					nodeObjectDefinition.setRootObjectDefinitionIds(
+						new long[] {childNode.getPrimaryKey()},
+						new long[] {objectDefinition1.getObjectDefinitionId()});
 				}
 			}
 		}
@@ -2470,18 +2444,14 @@ public class ObjectDefinitionLocalServiceImpl
 		String previousRESTContextPath = objectDefinition2.getRESTContextPath();
 
 		if (objectDefinition1.isApproved()) {
-			objectDefinition2 =
-				objectDefinitionLocalService.
-					updateRootDescendantNodeObjectDefinition(
-						objectDefinition2,
-						objectDefinition1.getRootObjectDefinitionId());
+			objectDefinition2.setRootObjectDefinitionIds(
+				objectDefinition1.getRootObjectDefinitionIds(),
+				new long[] {objectDefinition2.getObjectDefinitionId()});
 		}
 		else {
-			objectDefinition2.setRootObjectDefinitionId(
-				objectDefinition2.getObjectDefinitionId());
-
-			objectDefinition2 = objectDefinitionPersistence.update(
-				objectDefinition2);
+			objectDefinition2.setRootObjectDefinitionIds(
+				new long[] {objectDefinition2.getObjectDefinitionId()},
+				objectDefinition2.getRootObjectDefinitionIds());
 		}
 
 		objectDefinition2.setPreviousRESTContextPath(previousRESTContextPath);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1652,13 +1652,11 @@ public class ObjectDefinitionLocalServiceImpl
 		for (ObjectDefinitionSetting objectDefinitionSetting :
 				objectDefinitionSettings) {
 
-			if (objectDefinitionSetting.isReadOnly()) {
-				continue;
+			if (!objectDefinitionSetting.isReadOnly()) {
+				objectDefinitionSettingsValuesMap.put(
+					objectDefinitionSetting.getName(),
+					objectDefinitionSetting.getValue());
 			}
-
-			objectDefinitionSettingsValuesMap.put(
-				objectDefinitionSetting.getName(),
-				objectDefinitionSetting.getValue());
 		}
 
 		_validateObjectDefinitionSettings(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1283,8 +1283,6 @@ public class ObjectDefinitionLocalServiceImpl
 	public ObjectDefinition updateRootDescendantNodeObjectDefinition(
 		ObjectDefinition objectDefinition, long rootObjectDefinitionId) {
 
-		objectDefinition.setPanelCategoryKey(StringPool.BLANK);
-		objectDefinition.setPortlet(false);
 		objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
 
 		objectDefinition = objectDefinitionPersistence.update(objectDefinition);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -775,16 +775,6 @@ public class ObjectFieldLocalServiceImpl
 				businessType,
 				ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
 
-			ObjectRelationship objectRelationship =
-				_objectRelationshipPersistence.fetchByObjectFieldId2(
-					oldObjectField.getObjectFieldId());
-
-			if ((objectRelationship != null) && objectRelationship.isEdge() &&
-				!required) {
-
-				throw new ObjectFieldRequiredException();
-			}
-
 			_validateObjectRelationshipDeletionType(
 				oldObjectField.getObjectFieldId(), required);
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1381,9 +1381,6 @@ public class ObjectRelationshipLocalServiceImpl
 			objectRelationshipLocalService.updateObjectRelationship(
 				objectRelationship);
 
-		_objectFieldLocalService.updateRequired(
-			objectRelationship.getObjectFieldId2(), true);
-
 		ObjectDefinition objectDefinition1 =
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectRelationship.getObjectDefinitionId1());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -2006,9 +2006,24 @@ public class ObjectRelationshipLocalServiceImpl
 
 		String previousRESTContextPath = objectDefinition.getRESTContextPath();
 
+		long[] rootObjectDefinitionIdsToAdd = new long[0];
+
+		if (newRootObjectDefinitionId != 0) {
+			rootObjectDefinitionIdsToAdd = new long[] {
+				newRootObjectDefinitionId
+			};
+		}
+
+		long[] rootObjectDefinitionIdsToRemove = new long[0];
+
+		if (oldRootObjectDefinitionId != 0) {
+			rootObjectDefinitionIdsToRemove = new long[] {
+				oldRootObjectDefinitionId
+			};
+		}
+
 		objectDefinition.setRootObjectDefinitionIds(
-			new long[] {newRootObjectDefinitionId},
-			new long[] {oldRootObjectDefinitionId});
+			rootObjectDefinitionIdsToAdd, rootObjectDefinitionIdsToRemove);
 
 		objectDefinition.setPreviousRESTContextPath(previousRESTContextPath);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -94,6 +94,7 @@ import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.servlet.InitialRequestSyncUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -1094,20 +1095,27 @@ public class ObjectRelationshipLocalServiceImpl
 	}
 
 	private void _addArguments(
-			List<Object> arguments, ObjectDefinition objectDefinition)
+			List<Object> arguments, ObjectDefinition objectDefinition,
+			long[] rootObjectDefinitionIds)
 		throws PortalException {
 
 		int incompleteWorkflowInstancesCount = 0;
 
-		if (objectDefinition.isRootDescendantNode()) {
-			incompleteWorkflowInstancesCount =
-				_getIncompleteWorkflowInstancesCount(
-					_objectDefinitionPersistence.fetchByPrimaryKey(
-						objectDefinition.getRootObjectDefinitionId()));
-		}
-		else {
+		if (ArrayUtil.isEmpty(rootObjectDefinitionIds)) {
 			incompleteWorkflowInstancesCount =
 				_getIncompleteWorkflowInstancesCount(objectDefinition);
+		}
+		else {
+			for (long rootObjectDefinitionId : rootObjectDefinitionIds) {
+				incompleteWorkflowInstancesCount =
+					_getIncompleteWorkflowInstancesCount(
+						_objectDefinitionPersistence.fetchByPrimaryKey(
+							rootObjectDefinitionId));
+
+				if (incompleteWorkflowInstancesCount > 0) {
+					break;
+				}
+			}
 		}
 
 		if (incompleteWorkflowInstancesCount > 0) {
@@ -2034,15 +2042,17 @@ public class ObjectRelationshipLocalServiceImpl
 			return;
 		}
 
+		long[] objectDefinition1RootObjectDefinitionIds =
+			objectDefinition1.getRootObjectDefinitionIds();
+
 		if (!edge && (objectRelationship != null) &&
 			objectRelationship.isEdge()) {
 
 			List<Object> arguments = new ArrayList<>();
 
 			_addArguments(
-				arguments,
-				_objectDefinitionPersistence.fetchByPrimaryKey(
-					objectDefinition1.getRootObjectDefinitionId()));
+				arguments, objectDefinition1,
+				objectDefinition1RootObjectDefinitionIds);
 
 			if (ListUtil.isNotEmpty(arguments)) {
 				throw new ObjectRelationshipEdgeException(
@@ -2105,8 +2115,8 @@ public class ObjectRelationshipLocalServiceImpl
 		// Circular reference in a root context must be validated before
 		// the tree maximum height
 
-		if ((objectDefinition1.getRootObjectDefinitionId() != 0) &&
-			(objectDefinition1.getRootObjectDefinitionId() ==
+		if (ArrayUtil.contains(
+				objectDefinition1RootObjectDefinitionIds,
 				objectDefinition2.getObjectDefinitionId())) {
 
 			throw new ObjectRelationshipEdgeException(
@@ -2116,27 +2126,46 @@ public class ObjectRelationshipLocalServiceImpl
 					"reference-in-a-root-context");
 		}
 
+		long[] objectDefinition2RootObjectDefinitionIds =
+			objectDefinition2.getRootObjectDefinitionIds();
+
 		int treeHeight = 1;
 
 		ObjectDefinitionTreeFactory objectDefinitionTreeFactory =
 			new ObjectDefinitionTreeFactory(
 				_objectDefinitionPersistence, objectRelationshipLocalService);
 
-		if (objectDefinition1.getRootObjectDefinitionId() != 0) {
+		int objectDefinition1MaxDepth = 0;
+
+		for (long objectDefinition1RootObjectDefinitionId :
+				objectDefinition1RootObjectDefinitionIds) {
+
 			Tree tree = objectDefinitionTreeFactory.create(
-				objectDefinition1.getRootObjectDefinitionId());
+				objectDefinition1RootObjectDefinitionId);
 
 			Node node = tree.getNode(objectDefinition1.getObjectDefinitionId());
 
-			treeHeight += node.getDepth();
+			if (node.getDepth() > objectDefinition1MaxDepth) {
+				objectDefinition1MaxDepth = node.getDepth();
+			}
 		}
 
-		if (objectDefinition2.getRootObjectDefinitionId() != 0) {
+		int objectDefinition2MaxHeight = 0;
+
+		for (long objectDefinition2RootObjectDefinitionId :
+				objectDefinition2RootObjectDefinitionIds) {
+
 			Tree tree = objectDefinitionTreeFactory.create(
-				objectDefinition2.getRootObjectDefinitionId());
+				objectDefinition2RootObjectDefinitionId);
 
-			treeHeight += tree.getHeight(tree.getRootNode());
+			int height = tree.getHeight(tree.getRootNode());
+
+			if (height > objectDefinition2MaxHeight) {
+				objectDefinition2MaxHeight = height;
+			}
 		}
+
+		treeHeight += objectDefinition1MaxDepth + objectDefinition2MaxHeight;
 
 		if (treeHeight > TreeConstants.MAX_HEIGHT) {
 			throw new ObjectRelationshipEdgeException(
@@ -2173,8 +2202,12 @@ public class ObjectRelationshipLocalServiceImpl
 
 			List<Object> arguments = new ArrayList<>();
 
-			_addArguments(arguments, objectDefinition1);
-			_addArguments(arguments, objectDefinition2);
+			_addArguments(
+				arguments, objectDefinition1,
+				objectDefinition1RootObjectDefinitionIds);
+			_addArguments(
+				arguments, objectDefinition2,
+				objectDefinition2RootObjectDefinitionIds);
 
 			if (arguments.size() == 2) {
 				throw new ObjectRelationshipEdgeException(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1389,15 +1389,13 @@ public class ObjectRelationshipLocalServiceImpl
 			objectDefinition1.getRESTContextPath();
 
 		if (objectDefinition1.getRootObjectDefinitionId() == 0) {
-			objectDefinition1.setRootObjectDefinitionId(
-				objectDefinition1.getObjectDefinitionId());
+			objectDefinition1.setRootObjectDefinitionIds(
+				new long[] {objectDefinition1.getObjectDefinitionId()},
+				new long[0]);
 		}
 
 		ObjectDefinitionLocalService objectDefinitionLocalService =
 			_objectDefinitionLocalServiceSnapshot.get();
-
-		objectDefinition1 = objectDefinitionLocalService.updateObjectDefinition(
-			objectDefinition1);
 
 		ObjectDefinition objectDefinition2 =
 			_objectDefinitionPersistence.findByPrimaryKey(
@@ -1426,7 +1424,7 @@ public class ObjectRelationshipLocalServiceImpl
 					objectRelationshipLocalService);
 
 			Tree tree = objectDefinitionTreeFactory.create(
-				objectDefinition2.getObjectDefinitionId());
+				true, false, objectDefinition2.getObjectDefinitionId());
 
 			Iterator<Node> iterator = tree.iterator();
 
@@ -1440,11 +1438,9 @@ public class ObjectRelationshipLocalServiceImpl
 				String nodeObjectDefinitionPreviousRESTContextPath =
 					nodeObjectDefinition.getRESTContextPath();
 
-				nodeObjectDefinition =
-					objectDefinitionLocalService.
-						updateRootDescendantNodeObjectDefinition(
-							nodeObjectDefinition,
-							objectDefinition1.getRootObjectDefinitionId());
+				nodeObjectDefinition.setRootObjectDefinitionIds(
+					objectDefinition1.getRootObjectDefinitionIds(),
+					new long[] {objectDefinition2.getObjectDefinitionId()});
 
 				if (nodeObjectDefinition.isApproved() &&
 					objectDefinition1.isApproved()) {
@@ -1462,12 +1458,9 @@ public class ObjectRelationshipLocalServiceImpl
 				return;
 			}
 
-			objectDefinition2.setRootObjectDefinitionId(
-				objectDefinition2.getObjectDefinitionId());
-
-			objectDefinition2 =
-				objectDefinitionLocalService.updateObjectDefinition(
-					objectDefinition2);
+			objectDefinition2.setRootObjectDefinitionIds(
+				new long[] {objectDefinition2.getObjectDefinitionId()},
+				new long[0]);
 
 			if (objectDefinition2.isApproved()) {
 				objectDefinitionLocalService.deployObjectDefinition(
@@ -2005,10 +1998,9 @@ public class ObjectRelationshipLocalServiceImpl
 
 		String previousRESTContextPath = objectDefinition.getRESTContextPath();
 
-		objectDefinition.setRootObjectDefinitionId(newRootObjectDefinitionId);
-
-		objectDefinition = _objectDefinitionPersistence.update(
-			objectDefinition);
+		objectDefinition.setRootObjectDefinitionIds(
+			new long[] {newRootObjectDefinitionId},
+			new long[] {oldRootObjectDefinitionId});
 
 		objectDefinition.setPreviousRESTContextPath(previousRESTContextPath);
 
@@ -2208,20 +2200,6 @@ public class ObjectRelationshipLocalServiceImpl
 						"enable-inheritance-x-(x-object-entries)-and-x-(x-" +
 							"object-entries)");
 			}
-		}
-
-		long objectDefinition2RootObjectDefinitionId =
-			objectDefinition2.getRootObjectDefinitionId();
-
-		if ((objectDefinition2RootObjectDefinitionId != 0) &&
-			(objectDefinition2RootObjectDefinitionId !=
-				objectDefinition2.getObjectDefinitionId())) {
-
-			throw new ObjectRelationshipEdgeException(
-				"Unable to bind the object definitions when the child object " +
-					"definition is bound to another object definition",
-				"unable-to-bind-the-object-definitions-when-the-child-object-" +
-					"definition-is-bound-to-another-object-definition");
 		}
 
 		if (!StringUtil.equals(

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/model/impl/ObjectDefinitionImplTest.java
@@ -129,7 +129,8 @@ public class ObjectDefinitionImplTest {
 
 			long rootObjectDefinitionId = RandomTestUtil.randomLong();
 
-			objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
+			objectDefinition.setRootObjectDefinitionIds(
+				new long[] {rootObjectDefinitionId}, new long[0]);
 
 			ObjectDefinitionLocalService objectDefinitionLocalService =
 				Mockito.mock(ObjectDefinitionLocalService.class);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -104,7 +104,6 @@ import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -2524,7 +2523,6 @@ public class ObjectDefinitionLocalServiceTest {
 		_addObjectAction("C_AA");
 
 		_assertModelResourceNames(ListUtil.fromArray("C_A", "C_AA"));
-		_assertRootDescendantNodeObjectDefinition("C_AA");
 
 		_testCreateObjectDefinitionTree(
 			true,
@@ -2539,7 +2537,6 @@ public class ObjectDefinitionLocalServiceTest {
 		_addObjectAction("C_AAAAA");
 
 		_assertModelResourceNames(ListUtil.fromArray("C_AAAA", "C_AAAAA"));
-		_assertRootDescendantNodeObjectDefinition("C_AAAAA");
 
 		ObjectDefinition objectDefinitionAAA =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition("AAA");
@@ -2562,8 +2559,6 @@ public class ObjectDefinitionLocalServiceTest {
 			objectDefinitionAAA.getObjectDefinitionId());
 
 		_assertModelResourceNames(ListUtil.fromArray("C_A", "C_AA", "C_AAAAA"));
-		_assertRootDescendantNodeObjectDefinition("C_AAA");
-		_assertRootDescendantNodeObjectDefinition("C_AAAA");
 
 		ObjectDefinition objectDefinitionA =
 			_objectDefinitionLocalService.getObjectDefinition(
@@ -3616,37 +3611,6 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertEquals(required, objectField.isRequired());
 	}
 
-	private void _assertRootDescendantNodeObjectDefinition(String name)
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				TestPropsValues.getCompanyId(), name);
-
-		Assert.assertEquals(
-			StringPool.BLANK, objectDefinition.getPanelCategoryKey());
-		Assert.assertFalse(objectDefinition.isPortlet());
-
-		Assert.assertNull(
-			_resourceActionLocalService.fetchResourceAction(
-				objectDefinition.getClassName(), ActionKeys.DELETE));
-		Assert.assertNull(
-			_resourceActionLocalService.fetchResourceAction(
-				objectDefinition.getClassName(), ActionKeys.PERMISSIONS));
-		Assert.assertNull(
-			_resourceActionLocalService.fetchResourceAction(
-				objectDefinition.getClassName(), ActionKeys.UPDATE));
-		Assert.assertNull(
-			_resourceActionLocalService.fetchResourceAction(
-				objectDefinition.getClassName(), ActionKeys.VIEW));
-
-		Assert.assertTrue(
-			ListUtil.isEmpty(
-				_workflowDefinitionLinkLocalService.getWorkflowDefinitionLinks(
-					objectDefinition.getCompanyId(),
-					objectDefinition.getClassName())));
-	}
-
 	private void _assertSystemObjectFields(
 		ObjectField expectedObjectField, ObjectField objectField) {
 
@@ -3885,11 +3849,6 @@ public class ObjectDefinitionLocalServiceTest {
 		TreeTestUtil.bind(_objectRelationshipLocalService, objectRelationships);
 
 		for (ObjectRelationship objectRelationship : objectRelationships) {
-			ObjectField objectField2 = _objectFieldLocalService.getObjectField(
-				objectRelationship.getObjectFieldId2());
-
-			Assert.assertTrue(objectField2.isRequired());
-
 			objectRelationship =
 				_objectRelationshipLocalService.getObjectRelationship(
 					objectRelationship.getObjectRelationshipId());
@@ -3897,22 +3856,6 @@ public class ObjectDefinitionLocalServiceTest {
 			Assert.assertEquals(
 				objectRelationship.getDeletionType(),
 				ObjectRelationshipConstants.DELETION_TYPE_CASCADE);
-
-			ObjectDefinition objectDefinition1 =
-				_objectDefinitionLocalService.getObjectDefinition(
-					objectRelationship.getObjectDefinitionId1());
-
-			if (objectDefinition1.isRootDescendantNode()) {
-				Assert.assertFalse(objectDefinition1.isPortlet());
-			}
-
-			ObjectDefinition objectDefinition2 =
-				_objectDefinitionLocalService.getObjectDefinition(
-					objectRelationship.getObjectDefinitionId2());
-
-			if (objectDefinition2.isRootDescendantNode()) {
-				Assert.assertFalse(objectDefinition2.isPortlet());
-			}
 		}
 
 		TreeTestUtil.assertObjectDefinitionTree(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -2940,16 +2940,20 @@ public class ObjectEntryLocalServiceTest {
 				objectDefinition2.getClassName()),
 			CoreMatchers.hasItem(objectAction.getName()));
 
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			0, objectDefinition1.getObjectDefinitionId(),
-			Collections.emptyMap());
 		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 			objectRelationship.getObjectFieldId2());
 
 		ObjectEntry objectEntry2 = _addObjectEntry(
 			0, objectDefinition2.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
-				objectField.getName(), objectEntry1.getObjectEntryId()
+				objectField.getName(),
+				() -> {
+					ObjectEntry objectEntry = _addObjectEntry(
+						0, objectDefinition1.getObjectDefinitionId(),
+						Collections.emptyMap());
+
+					return objectEntry.getObjectEntryId();
+				}
 			).build());
 
 		Assert.assertTrue(
@@ -2973,16 +2977,6 @@ public class ObjectEntryLocalServiceTest {
 				objectAction.getName(),
 			() -> _hasResourcePermission(
 				objectAction, objectDefinition2, objectEntry2));
-
-		ObjectEntry objectEntry3 = _addObjectEntry(
-			0, objectDefinition2.getObjectDefinitionId(),
-			HashMapBuilder.<String, Serializable>put(
-				objectField.getName(), objectEntry1.getObjectEntryId()
-			).build());
-
-		Assert.assertFalse(
-			_hasResourcePermission(
-				objectAction, objectDefinition2, objectEntry3));
 
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -88,6 +88,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -140,6 +141,7 @@ import org.osgi.framework.ServiceReference;
 /**
  * @author Brian Wing Shun Chan
  */
+@DataGuard(scope = DataGuard.Scope.METHOD)
 @FeatureFlag("LPD-34594")
 @RunWith(Arquillian.class)
 public class ObjectRelationshipLocalServiceTest {
@@ -959,6 +961,66 @@ public class ObjectRelationshipLocalServiceTest {
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
 			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// Bind two non-root draft object definitions from different object
+		// definition trees
+
+		Tree treeA = TreeTestUtil.createObjectDefinitionTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			false,
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[0]
+			).build());
+		Tree treeB = TreeTestUtil.createObjectDefinitionTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			false,
+			LinkedHashMapBuilder.put(
+				"B", new String[] {"BB"}
+			).put(
+				"BB", new String[] {"BBB"}
+			).put(
+				"BBB", new String[0]
+			).build());
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService,
+					_objectDefinitionLocalService.getObjectDefinition(
+						TestPropsValues.getCompanyId(), "C_AA"),
+					_objectDefinitionLocalService.getObjectDefinition(
+						TestPropsValues.getCompanyId(), "C_BB"))));
+
+		Node rootNodeA = treeA.getRootNode();
+
+		TreeTestUtil.assertObjectDefinitionTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[] {"BB"}
+			).put(
+				"BB", new String[] {"BBB"}
+			).put(
+				"BBB", new String[0]
+			).build(),
+			_objectDefinitionTreeFactory.create(rootNodeA.getPrimaryKey()),
+			_objectDefinitionLocalService);
+
+		Node rootNodeB = treeB.getRootNode();
+
+		TreeTestUtil.assertObjectDefinitionTree(
+			LinkedHashMapBuilder.put(
+				"B", new String[] {"BB"}
+			).put(
+				"BB", new String[] {"BBB"}
+			).put(
+				"BBB", new String[0]
+			).build(),
+			_objectDefinitionTreeFactory.create(rootNodeB.getPrimaryKey()),
+			_objectDefinitionLocalService);
 	}
 
 	@Test
@@ -1231,17 +1293,6 @@ public class ObjectRelationshipLocalServiceTest {
 				objectDefinitionBBB.getObjectDefinitionId(),
 				objectDefinitionB.getObjectDefinitionId()));
 
-		// Unable to bind the object definitions when the child object
-		// definition is bound to another object definition
-
-		AssertUtils.assertFailure(
-			ObjectRelationshipEdgeException.class,
-			"Unable to bind the object definitions when the child object " +
-				"definition is bound to another object definition",
-			() -> _bindObjectDefinitions(
-				objectDefinitionB.getObjectDefinitionId(),
-				objectDefinitionBBB.getObjectDefinitionId()));
-
 		ObjectDefinition objectDefinitionC =
 			_addAndPublishCustomObjectDefinition("C");
 		ObjectDefinition objectDefinitionCC =
@@ -1250,14 +1301,6 @@ public class ObjectRelationshipLocalServiceTest {
 		_bindObjectDefinitions(
 			objectDefinitionC.getObjectDefinitionId(),
 			objectDefinitionCC.getObjectDefinitionId());
-
-		AssertUtils.assertFailure(
-			ObjectRelationshipEdgeException.class,
-			"Unable to bind the object definitions when the child object " +
-				"definition is bound to another object definition",
-			() -> _bindObjectDefinitions(
-				objectDefinitionB.getObjectDefinitionId(),
-				objectDefinitionCC.getObjectDefinitionId()));
 
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,
@@ -1485,7 +1528,8 @@ public class ObjectRelationshipLocalServiceTest {
 			objectDefinitionAA.getClassName(),
 			objectEntryAA.getObjectEntryId());
 
-		_bindObjectDefinitions(objectRelationship);
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService, List.of(objectRelationship));
 
 		objectEntryAA = _objectEntryLocalService.getObjectEntry(
 			objectEntryAA.getObjectEntryId());
@@ -2824,11 +2868,6 @@ public class ObjectRelationshipLocalServiceTest {
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 			objectRelationship.getDeletionType());
 
-		ObjectField objectField = _objectFieldLocalService.getObjectField(
-			objectRelationship.getObjectFieldId2());
-
-		Assert.assertTrue(objectField.isRequired());
-
 		biConsumer.accept(
 			_objectDefinitionLocalService.getObjectDefinition(
 				objectDefinition1.getObjectDefinitionId()),
@@ -3070,11 +3109,6 @@ public class ObjectRelationshipLocalServiceTest {
 
 		Assert.assertEquals(
 			objectDefinition1.getScope(), objectDefinition2.getScope());
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectRelationship.getObjectFieldId2());
-
-		Assert.assertTrue(objectField.isRequired());
 	}
 
 	@Inject


### PR DESCRIPTION
Related: [LPD-56967](https://liferay.atlassian.net/browse/LPD-56967)

[LPD-56967]: https://liferay.atlassian.net/browse/LPD-56967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ