### PR TITLE
LPD-57869 [Test Fix] object-web/main/objectFields.spec.ts > Manage object fields through Model Builder › can see the translation of the object fields businesses types in object definition node

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectFields.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectFields.spec.ts
@@ -511,16 +511,17 @@ test.describe('Manage object fields through Model Builder', () => {
 
 		const objectFieldBusinessTypeNameLabel = {
 			Attachment: 'Anexo',
-			Boolean: 'Boolean',
+			Boolean: 'Verdadeiro/falso',
 			Date: 'Data',
+			DateTime: 'Data/Hora',
 			Decimal: 'Decimal',
 			Integer: 'Inteiro',
 			LongInteger: 'Número inteiro longo',
-			LongText: 'Texto longo',
+			LongText: 'Texto Longo',
 			Picklist: 'Lista de seleção',
 			PrecisionDecimal: 'Casa decimal',
 			RichText: 'Rich Text',
-			Text: 'Texto',
+			Text: 'Campo de texto',
 		};
 
 		const asyncArray = new AsyncArray<Locator, boolean>();


### PR DESCRIPTION
Related issue https://liferay.atlassian.net/browse/LPD-57519