### PR TITLE
LPD-56897 Ensured calendar events ending at midnight display correctly on a single day in the month view

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
@@ -914,6 +914,64 @@ AUI.add(
 			NAME: 'scheduler-month-view',
 
 			prototype: {
+				_getEvtSplitInfo(event, celDate, rowStartDate, rowEndDate) {
+					const eventEndDate = event.getClearEndDate();
+					const eventStartDate = event.getClearStartDate();
+
+					const maxColspan = DateMath.countDays(rowEndDate, celDate);
+
+					const info = {
+						colspan:
+							Math.min(
+								DateMath.countDays(eventEndDate, celDate),
+								maxColspan
+							) + 1,
+						left: DateMath.before(eventStartDate, rowStartDate),
+						right: DateMath.after(eventEndDate, rowEndDate),
+					};
+
+					return info;
+				},
+
+				_getRenderableEvent(events, rowStartDate, rowEndDate, celDate) {
+					const instance = this;
+					const key = instance._getEvtRenderedStackKey(celDate);
+					let i;
+
+					if (!instance.evtRenderedStack[key]) {
+						instance.evtRenderedStack[key] = [];
+					}
+
+					for (i = 0; i < events.length; i++) {
+						const event = events[i];
+
+						const eventStartDate = event.get('startDate');
+
+						const isEventDateContinuation =
+							DateMath.after(celDate, eventStartDate) &&
+							!DateMath.isDayOverlap(celDate, rowStartDate);
+						const isEventStartDateDay = !DateMath.isDayOverlap(
+							eventStartDate,
+							celDate
+						);
+
+						const isRendered =
+							A.Array.indexOf(
+								instance.evtRenderedStack[key],
+								event
+							) > -1;
+
+						if (
+							!isRendered &&
+							(isEventStartDateDay || isEventDateContinuation)
+						) {
+							return event;
+						}
+					}
+
+					return null;
+				},
+
 				_syncCellDimensions() {
 					const instance = this;
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js
@@ -918,6 +918,16 @@ AUI.add(
 					const eventEndDate = event.getClearEndDate();
 					const eventStartDate = event.getClearStartDate();
 
+					if (
+						DateMath.compare(
+							event.get('endDate'),
+							DateMath.toMidnight(eventEndDate)
+						)
+					) {
+						eventEndDate.setDate(eventEndDate.getDate() - 1);
+						eventEndDate.setSeconds(eventEndDate.getSeconds() - 1);
+					}
+
 					const maxColspan = DateMath.countDays(rowEndDate, celDate);
 
 					const info = {
@@ -945,27 +955,36 @@ AUI.add(
 					for (i = 0; i < events.length; i++) {
 						const event = events[i];
 
+						const eventEndDate = event.get('endDate');
 						const eventStartDate = event.get('startDate');
 
-						const isEventDateContinuation =
-							DateMath.after(celDate, eventStartDate) &&
-							!DateMath.isDayOverlap(celDate, rowStartDate);
-						const isEventStartDateDay = !DateMath.isDayOverlap(
-							eventStartDate,
-							celDate
-						);
-
-						const isRendered =
-							A.Array.indexOf(
-								instance.evtRenderedStack[key],
-								event
-							) > -1;
+						const weekEndDate = DateMath.toLastHour(rowEndDate);
+						const weekStartDate = DateMath.toMidnight(rowStartDate);
 
 						if (
-							!isRendered &&
-							(isEventStartDateDay || isEventDateContinuation)
+							DateMath.before(eventStartDate, weekEndDate) &&
+							DateMath.after(eventEndDate, weekStartDate)
 						) {
-							return event;
+							const isEventDateContinuation =
+								DateMath.after(celDate, eventStartDate) &&
+								!DateMath.isDayOverlap(celDate, rowStartDate);
+							const isEventStartDateDay = !DateMath.isDayOverlap(
+								eventStartDate,
+								celDate
+							);
+
+							const isRendered =
+								A.Array.indexOf(
+									instance.evtRenderedStack[key],
+									event
+								) > -1;
+
+							if (
+								!isRendered &&
+								(isEventStartDateDay || isEventDateContinuation)
+							) {
+								return event;
+							}
 						}
 					}
 

--- a/modules/test/playwright/pages/calendar-web/CalendarWidgetPage.ts
+++ b/modules/test/playwright/pages/calendar-web/CalendarWidgetPage.ts
@@ -152,14 +152,20 @@ export class CalendarWidgetPage {
 
 	async addEvent({
 		allDay,
-		dateEnd,
+		endDate,
+		endTime,
 		publishEvent,
+		startDate,
+		startTime,
 		throughCalendarActionMenu,
 		title,
 	}: {
 		allDay: boolean;
-		dateEnd?: string;
+		endDate?: string;
+		endTime?: string;
 		publishEvent?: boolean;
+		startDate?: string;
+		startTime?: string;
 		throughCalendarActionMenu?: {calendarName: string};
 		title?: string;
 	}) {
@@ -176,12 +182,24 @@ export class CalendarWidgetPage {
 		await this.allDayCheckbox.hover();
 		await this.allDayCheckbox.setChecked(allDay);
 
-		if (dateEnd) {
-			await this.endDate.fill(dateEnd);
-		}
-
 		if (title) {
 			await this.title.fill(title);
+		}
+
+		if (startDate) {
+			await this.startDate.fill(startDate);
+		}
+
+		if (startTime) {
+			await this.startTime.pressSequentially(startTime, {delay: 100});
+		}
+
+		if (endDate) {
+			await this.endDate.fill(endDate);
+		}
+
+		if (endTime) {
+			await this.endTime.pressSequentially(endTime, {delay: 100});
 		}
 
 		if (publishEvent) {

--- a/modules/test/playwright/tests/calendar-web/main/calendarEvent.spec.ts
+++ b/modules/test/playwright/tests/calendar-web/main/calendarEvent.spec.ts
@@ -22,6 +22,7 @@ import performLogin, {
 import {journalPagesTest} from '../../journal-web/main/fixtures/journalPagesTest';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
 import getWidgetDefinition from '../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
+import {getNextOrPreviousSaturday} from './utils/getNextOrPreviousSaturday';
 import {toLocalDateTimeFormatted} from './utils/toLocalDateTimeFormatted';
 
 export const test = mergeTests(
@@ -287,7 +288,7 @@ test('can create calendar event different start/end dates ensuring that the end 
 
 	await calendarWidgetPage.addEvent({
 		allDay: false,
-		dateEnd: endDateFormatted,
+		endDate: endDateFormatted,
 		publishEvent: true,
 		title,
 	});
@@ -472,4 +473,41 @@ test('can update an event with recurrence', async ({
 	await calendarWidgetPage.publishEvent({recurrenceOption: 'Single Event'});
 
 	await expect(calendarWidgetPage.successAlert).toBeVisible();
+});
+
+test('event ending at midnight does not render on the next day', async ({
+	calendarWidgetPage,
+	page,
+}) => {
+	const today = new Date();
+
+	const saturday = getNextOrPreviousSaturday(today);
+
+	const sunday = new Date(saturday);
+	sunday.setDate(saturday.getDate() + 1);
+
+	const [startDate, endDate] = [saturday, sunday].map((date) =>
+		toLocalDateTimeFormatted(date.toUTCString(), {
+			day: '2-digit',
+			month: '2-digit',
+			year: 'numeric',
+		})
+	);
+
+	const title = getRandomInt().toString();
+
+	await calendarWidgetPage.addEvent({
+		allDay: false,
+		endDate,
+		endTime: '1200AM',
+		publishEvent: true,
+		startDate,
+		startTime: '1200PM',
+		title,
+	});
+
+	await calendarWidgetPage.closeModalEvent();
+	await calendarWidgetPage.monthViewTab.click();
+
+	await expect(page.getByTitle(title)).toHaveCount(1);
 });

--- a/modules/test/playwright/tests/calendar-web/main/utils/getNextOrPreviousSaturday.ts
+++ b/modules/test/playwright/tests/calendar-web/main/utils/getNextOrPreviousSaturday.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export function getNextOrPreviousSaturday(referenceDate: Date): Date {
+	const dayOfWeek = referenceDate.getDay();
+
+	const result = new Date(referenceDate);
+	const isFirstHalfOfMonth = referenceDate.getDate() <= 15;
+
+	if (isFirstHalfOfMonth) {
+		const daysUntilSaturday = (6 - dayOfWeek + 7) % 7 || 7;
+
+		result.setDate(referenceDate.getDate() + daysUntilSaturday);
+	}
+	else {
+		const daysSinceSaturday = (dayOfWeek + 1) % 7 || 7;
+
+		result.setDate(referenceDate.getDate() - daysSinceSaturday);
+	}
+
+	return result;
+}


### PR DESCRIPTION
The purpose of these changes is to make it so that an event that ends at midnight is not rendered the next day using the month view.

### 🧩 Architecture Summary:

This pull request involves code that interacts with Liferay's legacy calendar system. Below is a high-level summary of how the relevant repositories and layers work together:

1️⃣ Liferay Portal	[liferay-portal](https://github.com/liferay/liferay-portal) Provides the Calendar portlet UI, services, and configuration. It renders the calendar using <aui:scheduler> taglibs and sends/receives event data (JSON) from the backend.

2️⃣ UI Components [alloy-ui](https://github.com/liferay/liferay-frontend-projects/tree/master/third-party/projects/alloy-ui)	Contains the aui-scheduler widget, which extends and customizes YUI3’s scheduler. Files like aui-schedule-view-table.js handle visual rendering and layout logic (e.g., splitting events across rows/days).

3️⃣ JS Framework [YUI3](https://github.com/liferay/yui3) The foundational JavaScript library used by AlloyUI. Provides modules for attributes, events, drag-and-drop, and the base scheduler logic.

### Understanding the changes

On the Liferay Portal, we are instantiating a SchedulerMonthView class that [extends A.SchedulerMonthView](https://github.com/igor-franca/liferay-portal/blob/95377cc36a29f887f02b6f9e58b595508081ee86/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/scheduler.js#L912) from AlloyUI, which in turn [extends SchedulerTableView](https://github.com/liferay/liferay-frontend-projects/blob/8feda87f314b310c0f5cdd7c1704a49833cd48c7/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-month.js#L101). By analyzing the [SchedulerTableView#buildEventsRow](https://github.com/liferay/liferay-frontend-projects/blob/8feda87f314b310c0f5cdd7c1704a49833cd48c7/third-party/projects/alloy-ui/src/aui-scheduler/js/aui-scheduler-view-table.js#L412-L495) method, I was able to understand how events are constructed during the week rendering process.

With that understanding, both `_getRenderableEvent` and `_getEvtSplitInfo` have been overridden to achieve the expected behavior in the current calendar rendering.

### Visual Impact

![image](https://github.com/user-attachments/assets/c034b6c7-9c62-45d1-8c03-0f79c8e60dd8)