### PR TITLE
LPD-47038 Apply lazy reference strategy to Categories when importing a ObjectEntry

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -6,6 +6,8 @@
 package com.liferay.object.rest.internal.manager.v1_0;
 
 import com.liferay.account.exception.NoSuchGroupException;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.batch.engine.attachment.BatchEngineAttachmentManager;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.object.action.engine.ObjectActionEngine;
@@ -36,6 +38,7 @@ import com.liferay.object.rest.dto.v1_0.Folder;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Scope;
 import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.rest.filter.parser.ObjectDefinitionFilterParser;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
@@ -85,6 +88,7 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -92,6 +96,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -99,6 +104,7 @@ import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -141,11 +147,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -170,6 +178,9 @@ public class DefaultObjectEntryManagerImpl
 		validateReadOnlyObjectFields(null, objectDefinition, objectEntry);
 
 		long groupId = getGroupId(objectDefinition, scopeKey);
+
+		_updateTaxonomyCategoryIds(
+			objectDefinition.getCompanyId(), objectEntry);
 
 		ServiceContext serviceContext = _createServiceContext(
 			dtoConverterContext, objectDefinition, objectEntry);
@@ -2268,11 +2279,14 @@ public class DefaultObjectEntryManagerImpl
 			serviceBuilderObjectEntry.getExternalReferenceCode(),
 			objectDefinition, objectEntry);
 
-		String scopeKey = String.valueOf(
-			serviceBuilderObjectEntry.getGroupId());
+		_updateTaxonomyCategoryIds(
+			objectDefinition.getCompanyId(), objectEntry);
 
 		ServiceContext serviceContext = _createServiceContext(
 			dtoConverterContext, objectDefinition, objectEntry);
+
+		String scopeKey = String.valueOf(
+			serviceBuilderObjectEntry.getGroupId());
 
 		if (partialUpdate) {
 			serviceBuilderObjectEntry =
@@ -2300,11 +2314,68 @@ public class DefaultObjectEntryManagerImpl
 				serviceBuilderObjectEntry, scopeKey));
 	}
 
+	private void _updateTaxonomyCategoryIds(
+			long companyId, ObjectEntry objectEntry)
+		throws Exception {
+
+		TaxonomyCategoryBrief[] taxonomyCategoryBriefs =
+			objectEntry.getTaxonomyCategoryBriefs();
+
+		if ((taxonomyCategoryBriefs == null) ||
+			!FeatureFlagManagerUtil.isEnabled("LPD-47858")) {
+
+			return;
+		}
+
+		if (ArrayUtil.isEmpty(taxonomyCategoryBriefs)) {
+			objectEntry.setTaxonomyCategoryIds(() -> new Long[0]);
+		}
+
+		Set<Long> assetCategoryIds = new HashSet<>();
+
+		for (TaxonomyCategoryBrief taxonomyCategoryBrief :
+				taxonomyCategoryBriefs) {
+
+			String externalReferenceCode =
+				taxonomyCategoryBrief.
+					getTaxonomyCategoryExternalReferenceCode();
+
+			Scope scope = taxonomyCategoryBrief.getScope();
+
+			if (Validator.isNull(externalReferenceCode) || (scope == null) ||
+				Validator.isNull(scope.getExternalReferenceCode())) {
+
+				continue;
+			}
+
+			Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
+				scope.getExternalReferenceCode(), companyId);
+
+			if (group == null) {
+				continue;
+			}
+
+			AssetCategory assetCategory =
+				_assetCategoryService.getOrAddIncompleteCategory(
+					externalReferenceCode, group.getGroupId());
+
+			assetCategoryIds.add(assetCategory.getCategoryId());
+		}
+
+		if (SetUtil.isNotEmpty(assetCategoryIds)) {
+			objectEntry.setTaxonomyCategoryIds(
+				() -> assetCategoryIds.toArray(new Long[0]));
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultObjectEntryManagerImpl.class);
 
 	@Reference
 	private Aggregations _aggregations;
+
+	@Reference
+	private AssetCategoryService _assetCategoryService;
 
 	@Reference
 	private AttachmentManager _attachmentManager;
@@ -2322,6 +2393,9 @@ public class DefaultObjectEntryManagerImpl
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
 	)
 	private FilterFactory<Predicate> _filterFactory;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -172,7 +172,7 @@ public class DefaultObjectEntryManagerImpl
 		long groupId = getGroupId(objectDefinition, scopeKey);
 
 		ServiceContext serviceContext = _createServiceContext(
-			dtoConverterContext, objectDefinition, objectEntry);
+			dtoConverterContext, objectDefinition, objectEntry, scopeKey);
 
 		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
 			_objectEntryService.addObjectEntry(
@@ -997,7 +997,7 @@ public class DefaultObjectEntryManagerImpl
 			externalReferenceCode, objectDefinition, objectEntry);
 
 		ServiceContext serviceContext = _createServiceContext(
-			dtoConverterContext, objectDefinition, objectEntry);
+			dtoConverterContext, objectDefinition, objectEntry, scopeKey);
 
 		serviceContext.setCompanyId(companyId);
 
@@ -1042,13 +1042,14 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext.getLocale(), objectDefinition, objectEntry,
 				scopeKey,
 				_createServiceContext(
-					dtoConverterContext, objectDefinition, objectEntry)));
+					dtoConverterContext, objectDefinition, objectEntry,
+					scopeKey)));
 
 		_objectEntryService.validate(
 			getGroupId(objectDefinition, scopeKey), serviceBuilderObjectEntry,
 			objectValidationRuleExternalReferenceCodes,
 			_createServiceContext(
-				dtoConverterContext, objectDefinition, objectEntry));
+				dtoConverterContext, objectDefinition, objectEntry, scopeKey));
 	}
 
 	private Map<String, String> _addAction(
@@ -1087,6 +1088,8 @@ public class DefaultObjectEntryManagerImpl
 		if (objectRelationships.isEmpty()) {
 			return serviceBuilderObjectEntry;
 		}
+
+		long groupId = getGroupId(objectDefinition, scopeKey);
 
 		Map<String, Object> properties = objectEntry.getProperties();
 
@@ -1209,7 +1212,7 @@ public class DefaultObjectEntryManagerImpl
 							serviceBuilderObjectEntry.getPrimaryKey(),
 							nestedObjectEntry.getId(),
 							ServiceContextUtil.createServiceContext(
-								objectDefinition.getCompanyId(),
+								objectDefinition.getCompanyId(), groupId,
 								nestedObjectEntry,
 								dtoConverterContext.getUserId()));
 					}
@@ -1285,7 +1288,8 @@ public class DefaultObjectEntryManagerImpl
 
 	private ServiceContext _createServiceContext(
 			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			String scopeKey)
 		throws Exception {
 
 		ModelPermissions modelPermissions =
@@ -1296,8 +1300,10 @@ public class DefaultObjectEntryManagerImpl
 				_resourcePermissionLocalService, _roleLocalService);
 
 		return ServiceContextUtil.createServiceContext(
-			objectDefinition.getCompanyId(), dtoConverterContext.getLocale(),
-			modelPermissions, objectEntry, dtoConverterContext.getUserId());
+			objectDefinition.getCompanyId(),
+			getGroupId(objectDefinition, scopeKey),
+			dtoConverterContext.getLocale(), modelPermissions, objectEntry,
+			dtoConverterContext.getUserId());
 	}
 
 	private byte[] _decode(String fileBase64) {
@@ -2269,11 +2275,11 @@ public class DefaultObjectEntryManagerImpl
 			serviceBuilderObjectEntry.getExternalReferenceCode(),
 			objectDefinition, objectEntry);
 
-		ServiceContext serviceContext = _createServiceContext(
-			dtoConverterContext, objectDefinition, objectEntry);
-
 		String scopeKey = String.valueOf(
 			serviceBuilderObjectEntry.getGroupId());
+
+		ServiceContext serviceContext = _createServiceContext(
+			dtoConverterContext, objectDefinition, objectEntry, scopeKey);
 
 		if (partialUpdate) {
 			serviceBuilderObjectEntry =

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -6,8 +6,6 @@
 package com.liferay.object.rest.internal.manager.v1_0;
 
 import com.liferay.account.exception.NoSuchGroupException;
-import com.liferay.asset.kernel.model.AssetCategory;
-import com.liferay.asset.kernel.service.AssetCategoryService;
 import com.liferay.batch.engine.attachment.BatchEngineAttachmentManager;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.object.action.engine.ObjectActionEngine;
@@ -38,7 +36,6 @@ import com.liferay.object.rest.dto.v1_0.Folder;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Scope;
 import com.liferay.object.rest.dto.v1_0.Status;
-import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.rest.filter.parser.ObjectDefinitionFilterParser;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
@@ -88,7 +85,6 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -96,7 +92,6 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -104,7 +99,6 @@ import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -147,13 +141,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -178,9 +170,6 @@ public class DefaultObjectEntryManagerImpl
 		validateReadOnlyObjectFields(null, objectDefinition, objectEntry);
 
 		long groupId = getGroupId(objectDefinition, scopeKey);
-
-		_updateTaxonomyCategoryIds(
-			objectDefinition.getCompanyId(), objectEntry);
 
 		ServiceContext serviceContext = _createServiceContext(
 			dtoConverterContext, objectDefinition, objectEntry);
@@ -1220,6 +1209,7 @@ public class DefaultObjectEntryManagerImpl
 							serviceBuilderObjectEntry.getPrimaryKey(),
 							nestedObjectEntry.getId(),
 							ServiceContextUtil.createServiceContext(
+								objectDefinition.getCompanyId(),
 								nestedObjectEntry,
 								dtoConverterContext.getUserId()));
 					}
@@ -2279,9 +2269,6 @@ public class DefaultObjectEntryManagerImpl
 			serviceBuilderObjectEntry.getExternalReferenceCode(),
 			objectDefinition, objectEntry);
 
-		_updateTaxonomyCategoryIds(
-			objectDefinition.getCompanyId(), objectEntry);
-
 		ServiceContext serviceContext = _createServiceContext(
 			dtoConverterContext, objectDefinition, objectEntry);
 
@@ -2314,68 +2301,11 @@ public class DefaultObjectEntryManagerImpl
 				serviceBuilderObjectEntry, scopeKey));
 	}
 
-	private void _updateTaxonomyCategoryIds(
-			long companyId, ObjectEntry objectEntry)
-		throws Exception {
-
-		TaxonomyCategoryBrief[] taxonomyCategoryBriefs =
-			objectEntry.getTaxonomyCategoryBriefs();
-
-		if ((taxonomyCategoryBriefs == null) ||
-			!FeatureFlagManagerUtil.isEnabled("LPD-47858")) {
-
-			return;
-		}
-
-		if (ArrayUtil.isEmpty(taxonomyCategoryBriefs)) {
-			objectEntry.setTaxonomyCategoryIds(() -> new Long[0]);
-		}
-
-		Set<Long> assetCategoryIds = new HashSet<>();
-
-		for (TaxonomyCategoryBrief taxonomyCategoryBrief :
-				taxonomyCategoryBriefs) {
-
-			String externalReferenceCode =
-				taxonomyCategoryBrief.
-					getTaxonomyCategoryExternalReferenceCode();
-
-			Scope scope = taxonomyCategoryBrief.getScope();
-
-			if (Validator.isNull(externalReferenceCode) || (scope == null) ||
-				Validator.isNull(scope.getExternalReferenceCode())) {
-
-				continue;
-			}
-
-			Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
-				scope.getExternalReferenceCode(), companyId);
-
-			if (group == null) {
-				continue;
-			}
-
-			AssetCategory assetCategory =
-				_assetCategoryService.getOrAddIncompleteCategory(
-					externalReferenceCode, group.getGroupId());
-
-			assetCategoryIds.add(assetCategory.getCategoryId());
-		}
-
-		if (SetUtil.isNotEmpty(assetCategoryIds)) {
-			objectEntry.setTaxonomyCategoryIds(
-				() -> assetCategoryIds.toArray(new Long[0]));
-		}
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultObjectEntryManagerImpl.class);
 
 	@Reference
 	private Aggregations _aggregations;
-
-	@Reference
-	private AssetCategoryService _assetCategoryService;
 
 	@Reference
 	private AttachmentManager _attachmentManager;
@@ -2393,9 +2323,6 @@ public class DefaultObjectEntryManagerImpl
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
 	)
 	private FilterFactory<Predicate> _filterFactory;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1089,8 +1089,6 @@ public class DefaultObjectEntryManagerImpl
 			return serviceBuilderObjectEntry;
 		}
 
-		long groupId = getGroupId(objectDefinition, scopeKey);
-
 		Map<String, Object> properties = objectEntry.getProperties();
 
 		for (Map.Entry<String, ObjectRelationship> entry :
@@ -1212,7 +1210,8 @@ public class DefaultObjectEntryManagerImpl
 							serviceBuilderObjectEntry.getPrimaryKey(),
 							nestedObjectEntry.getId(),
 							ServiceContextUtil.createServiceContext(
-								objectDefinition.getCompanyId(), groupId,
+								objectDefinition.getCompanyId(),
+								getGroupId(objectDefinition, scopeKey),
 								nestedObjectEntry,
 								dtoConverterContext.getUserId()));
 					}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -5,21 +5,34 @@
 
 package com.liferay.object.rest.internal.util;
 
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.dto.v1_0.Scope;
 import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.Serializable;
 
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * @author Sergio Jiménez del Coso
@@ -51,7 +64,7 @@ public class ServiceContextUtil {
 		ObjectEntry objectEntry, long userId) {
 
 		ServiceContext serviceContext = createServiceContext(
-			objectEntry, userId);
+			companyId, objectEntry, userId);
 
 		if (FeatureFlagManagerUtil.isEnabled("LPD-21926")) {
 			serviceContext.setAttribute(
@@ -70,12 +83,14 @@ public class ServiceContextUtil {
 	}
 
 	public static ServiceContext createServiceContext(
-		ObjectEntry objectEntry, long userId) {
+		long companyId, ObjectEntry objectEntry, long userId) {
 
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
+
+		_updateTaxonomyCategoryIds(companyId, userId, objectEntry);
 
 		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
 			serviceContext.setAssetCategoryIds(
@@ -105,5 +120,74 @@ public class ServiceContextUtil {
 
 		return false;
 	}
+
+	private static void _updateTaxonomyCategoryIds(
+		long companyId, long userId, ObjectEntry objectEntry) {
+
+		TaxonomyCategoryBrief[] taxonomyCategoryBriefs =
+			objectEntry.getTaxonomyCategoryBriefs();
+
+		if ((taxonomyCategoryBriefs == null) ||
+			!FeatureFlagManagerUtil.isEnabled("LPD-47858")) {
+
+			return;
+		}
+
+		if (ArrayUtil.isEmpty(taxonomyCategoryBriefs)) {
+			objectEntry.setTaxonomyCategoryIds(() -> new Long[0]);
+		}
+
+		Set<Long> assetCategoryIds = new HashSet<>();
+
+		for (TaxonomyCategoryBrief taxonomyCategoryBrief :
+				taxonomyCategoryBriefs) {
+
+			String externalReferenceCode =
+				taxonomyCategoryBrief.
+					getTaxonomyCategoryExternalReferenceCode();
+
+			Scope scope = taxonomyCategoryBrief.getScope();
+
+			if (Validator.isNull(externalReferenceCode) || (scope == null) ||
+				Validator.isNull(scope.getExternalReferenceCode())) {
+
+				continue;
+			}
+
+			Group group =
+				GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+					scope.getExternalReferenceCode(), companyId);
+
+			if (group == null) {
+				continue;
+			}
+
+			try {
+				AssetCategory assetCategory =
+					AssetCategoryLocalServiceUtil.getOrAddIncompleteCategory(
+						externalReferenceCode, userId, group.getGroupId());
+
+				assetCategoryIds.add(assetCategory.getCategoryId());
+			}
+			catch (PortalException portalException) {
+				_log.error(
+					StringBundler.concat(
+						"invalid asset category with the ERC ",
+						externalReferenceCode, " for the group ",
+						group.getGroupId()),
+					portalException);
+
+				throw new RuntimeException(portalException);
+			}
+		}
+
+		if (SetUtil.isNotEmpty(assetCategoryIds)) {
+			objectEntry.setTaxonomyCategoryIds(
+				() -> assetCategoryIds.toArray(new Long[0]));
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ServiceContextUtil.class);
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -60,11 +60,12 @@ public class ServiceContextUtil {
 	}
 
 	public static ServiceContext createServiceContext(
-		long companyId, Locale locale, ModelPermissions modelPermissions,
-		ObjectEntry objectEntry, long userId) {
+		long companyId, long groupId, Locale locale,
+		ModelPermissions modelPermissions, ObjectEntry objectEntry,
+		long userId) {
 
 		ServiceContext serviceContext = createServiceContext(
-			companyId, objectEntry, userId);
+			companyId, groupId, objectEntry, userId);
 
 		if (FeatureFlagManagerUtil.isEnabled("LPD-21926")) {
 			serviceContext.setAttribute(
@@ -83,14 +84,14 @@ public class ServiceContextUtil {
 	}
 
 	public static ServiceContext createServiceContext(
-		long companyId, ObjectEntry objectEntry, long userId) {
+		long companyId, long groupId, ObjectEntry objectEntry, long userId) {
 
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 
-		_updateTaxonomyCategoryIds(companyId, userId, objectEntry);
+		_updateTaxonomyCategoryIds(companyId, groupId, userId, objectEntry);
 
 		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
 			serviceContext.setAssetCategoryIds(
@@ -111,6 +112,42 @@ public class ServiceContextUtil {
 		return serviceContext;
 	}
 
+	private static long _getGroupId(
+		long companyId, long groupId, String externalReferenceCode,
+		TaxonomyCategoryBrief taxonomyCategoryBrief) {
+
+		if (groupId != 0) {
+			return groupId;
+		}
+
+		Scope scope = taxonomyCategoryBrief.getScope();
+
+		if (Validator.isNull(externalReferenceCode) || (scope == null) ||
+			Validator.isNull(scope.getExternalReferenceCode())) {
+
+			_log.error(
+				StringBundler.concat(
+					"invalid asset category with the ERC ",
+					externalReferenceCode, " for the group ", groupId));
+
+			return groupId;
+		}
+
+		Group group = GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
+			scope.getExternalReferenceCode(), companyId);
+
+		if (group == null) {
+			_log.error(
+				StringBundler.concat(
+					"invalid asset category with the ERC ",
+					externalReferenceCode, " for the group ", groupId));
+
+			return groupId;
+		}
+
+		return group.getGroupId();
+	}
+
 	private static boolean _isObjectEntryDraft(Status status) {
 		if ((status != null) &&
 			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
@@ -122,7 +159,7 @@ public class ServiceContextUtil {
 	}
 
 	private static void _updateTaxonomyCategoryIds(
-		long companyId, long userId, ObjectEntry objectEntry) {
+		long companyId, long groupId, long userId, ObjectEntry objectEntry) {
 
 		TaxonomyCategoryBrief[] taxonomyCategoryBriefs =
 			objectEntry.getTaxonomyCategoryBriefs();
@@ -146,26 +183,14 @@ public class ServiceContextUtil {
 				taxonomyCategoryBrief.
 					getTaxonomyCategoryExternalReferenceCode();
 
-			Scope scope = taxonomyCategoryBrief.getScope();
-
-			if (Validator.isNull(externalReferenceCode) || (scope == null) ||
-				Validator.isNull(scope.getExternalReferenceCode())) {
-
-				continue;
-			}
-
-			Group group =
-				GroupLocalServiceUtil.fetchGroupByExternalReferenceCode(
-					scope.getExternalReferenceCode(), companyId);
-
-			if (group == null) {
-				continue;
-			}
+			groupId = _getGroupId(
+				companyId, groupId, externalReferenceCode,
+				taxonomyCategoryBrief);
 
 			try {
 				AssetCategory assetCategory =
 					AssetCategoryLocalServiceUtil.getOrAddIncompleteCategory(
-						externalReferenceCode, userId, group.getGroupId());
+						externalReferenceCode, userId, groupId);
 
 				assetCategoryIds.add(assetCategory.getCategoryId());
 			}
@@ -173,8 +198,7 @@ public class ServiceContextUtil {
 				_log.error(
 					StringBundler.concat(
 						"invalid asset category with the ERC ",
-						externalReferenceCode, " for the group ",
-						group.getGroupId()),
+						externalReferenceCode, " for the group ", groupId),
 					portalException);
 
 				throw new RuntimeException(portalException);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -245,7 +245,8 @@ public class ObjectRelationshipExtensionProvider
 					objectDefinition, objectRelationship, primaryKey,
 					nestedObjectEntry.getId(),
 					ServiceContextUtil.createServiceContext(
-						nestedObjectEntry, userId));
+						objectDefinition.getCompanyId(), nestedObjectEntry,
+						userId));
 			}
 
 			NestedFieldsSupplier.addNestedField(entry.getKey());

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -18,13 +18,17 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectRelationshipElementsParser;
 import com.liferay.object.rest.manager.v1_0.ObjectRelationshipElementsParserRegistry;
+import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -36,6 +40,7 @@ import com.liferay.portal.vulcan.extension.validation.DefaultPropertyValidator;
 import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.GroupUtil;
 
 import jakarta.ws.rs.core.UriInfo;
 
@@ -245,8 +250,10 @@ public class ObjectRelationshipExtensionProvider
 					objectDefinition, objectRelationship, primaryKey,
 					nestedObjectEntry.getId(),
 					ServiceContextUtil.createServiceContext(
-						objectDefinition.getCompanyId(), nestedObjectEntry,
-						userId));
+						objectDefinition.getCompanyId(),
+						_getGroupId(
+							objectDefinition, nestedObjectEntry.getScopeKey()),
+						nestedObjectEntry, userId));
 			}
 
 			NestedFieldsSupplier.addNestedField(entry.getKey());
@@ -274,6 +281,23 @@ public class ObjectRelationshipExtensionProvider
 		defaultDTOConverterContext.setAttribute("addActions", Boolean.FALSE);
 
 		return defaultDTOConverterContext;
+	}
+
+	private long _getGroupId(
+		ObjectDefinition objectDefinition, String scopeKey) {
+
+		ObjectScopeProvider objectScopeProvider =
+			_objectScopeProviderRegistry.getObjectScopeProvider(
+				objectDefinition.getScope());
+
+		if (objectScopeProvider.isGroupAware()) {
+			return GetterUtil.getLong(
+				GroupUtil.getGroupId(
+					objectDefinition.getCompanyId(), scopeKey,
+					_groupLocalService));
+		}
+
+		return 0;
 	}
 
 	private PropertyDefinition.PropertyType _getPropertyType(
@@ -336,6 +360,9 @@ public class ObjectRelationshipExtensionProvider
 	private DTOConverterRegistry _dtoConverterRegistry;
 
 	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
 	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
 
 	@Reference
@@ -351,6 +378,9 @@ public class ObjectRelationshipExtensionProvider
 
 	@Reference
 	private ObjectRelationshipService _objectRelationshipService;
+
+	@Reference
+	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation group: "org.yaml", name: "snakeyaml", version: "2.3"
 	testIntegrationImplementation project(":apps:account:account-api")
+	testIntegrationImplementation project(":apps:asset:asset-entry-rel-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -169,6 +169,8 @@ import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -2247,7 +2249,10 @@ public class DefaultObjectEntryManagerImplTest
 
 		// Lazy referencing disabled
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.object.rest.internal.util.ServiceContextUtil",
+				LoggerTestUtil.ERROR)) {
+
 			_defaultObjectEntryManager.addObjectEntry(
 				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
 				ObjectDefinitionConstants.SCOPE_COMPANY);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -2299,12 +2299,14 @@ public class DefaultObjectEntryManagerImplTest
 				_objectDefinition1.getClassName(), objectEntry.getId());
 
 			Assert.assertArrayEquals(
-				new long[] {
-					assetCategory1.getCategoryId(),
-					assetCategory2.getCategoryId()
-				},
-				_assetEntryAssetCategoryRelLocalService.
-					getAssetCategoryPrimaryKeys(assetEntry.getEntryId()));
+				ArrayUtil.sortedUnique(
+					new long[] {
+						assetCategory1.getCategoryId(),
+						assetCategory2.getCategoryId()
+					}),
+				ArrayUtil.sortedUnique(
+					_assetEntryAssetCategoryRelLocalService.
+						getAssetCategoryPrimaryKeys(assetEntry.getEntryId())));
 		}
 	}
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -834,93 +834,6 @@ public class DefaultObjectEntryManagerImplTest
 			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
-	@FeatureFlag("LPD-47858")
-	@Test
-	public void testAddObjectEntryCategoriesLazyReference() throws Exception {
-		String taxonomyCategoryExternalReferenceCode1 =
-			RandomTestUtil.randomString();
-		String taxonomyCategoryExternalReferenceCode2 =
-			RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = new ObjectEntry() {
-			{
-				setTaxonomyCategoryBriefs(
-					new TaxonomyCategoryBrief[] {
-						new TaxonomyCategoryBrief() {
-							{
-								scope = _getScope(_group);
-								taxonomyCategoryExternalReferenceCode =
-									taxonomyCategoryExternalReferenceCode1;
-							}
-						},
-						new TaxonomyCategoryBrief() {
-							{
-								scope = _getScope(_group);
-								taxonomyCategoryExternalReferenceCode =
-									taxonomyCategoryExternalReferenceCode2;
-							}
-						}
-					});
-			}
-		};
-
-		// Lazy referencing disabled
-
-		try {
-			_defaultObjectEntryManager.addObjectEntry(
-				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
-				ObjectDefinitionConstants.SCOPE_COMPANY);
-
-			Assert.fail();
-		}
-		catch (NoSuchCategoryException noSuchCategoryException) {
-			Assert.assertNotNull(noSuchCategoryException);
-		}
-
-		// Lazy referencing enabled
-
-		try (SafeCloseable safeCloseable =
-				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
-
-			objectEntry = _defaultObjectEntryManager.addObjectEntry(
-				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
-				ObjectDefinitionConstants.SCOPE_COMPANY);
-
-			AssetCategory assetCategory1 =
-				_assetCategoryLocalService.
-					fetchAssetCategoryByExternalReferenceCode(
-						taxonomyCategoryExternalReferenceCode1,
-						_group.getGroupId());
-
-			Assert.assertNotNull(assetCategory1);
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_INCOMPLETE,
-				assetCategory1.getStatus());
-
-			AssetCategory assetCategory2 =
-				_assetCategoryLocalService.
-					fetchAssetCategoryByExternalReferenceCode(
-						taxonomyCategoryExternalReferenceCode2,
-						_group.getGroupId());
-
-			Assert.assertNotNull(assetCategory2);
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_INCOMPLETE,
-				assetCategory2.getStatus());
-
-			AssetEntry assetEntry = _assetEntryLocalService.getEntry(
-				_objectDefinition1.getClassName(), objectEntry.getId());
-
-			Assert.assertArrayEquals(
-				new long[] {
-					assetCategory1.getCategoryId(),
-					assetCategory2.getCategoryId()
-				},
-				_assetEntryAssetCategoryRelLocalService.
-					getAssetCategoryPrimaryKeys(assetEntry.getEntryId()));
-		}
-	}
-
 	@Test
 	public void testAddObjectEntryWithAccountEntryRestricted1()
 		throws Exception {
@@ -2298,6 +2211,96 @@ public class DefaultObjectEntryManagerImplTest
 			).build(),
 			group.getGroupId(), externalReferenceCode, parentObjectDefinition,
 			Collections.emptyMap());
+	}
+
+	@FeatureFlag("LPD-47858")
+	@Test
+	public void testAddObjectEntryWithMissingTaxonomyCategoryBriefReference()
+		throws Exception {
+
+		String taxonomyCategoryExternalReferenceCode1 =
+			RandomTestUtil.randomString();
+		String taxonomyCategoryExternalReferenceCode2 =
+			RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = new ObjectEntry() {
+			{
+				setTaxonomyCategoryBriefs(
+					new TaxonomyCategoryBrief[] {
+						new TaxonomyCategoryBrief() {
+							{
+								scope = _getScope(_group);
+								taxonomyCategoryExternalReferenceCode =
+									taxonomyCategoryExternalReferenceCode1;
+							}
+						},
+						new TaxonomyCategoryBrief() {
+							{
+								scope = _getScope(_group);
+								taxonomyCategoryExternalReferenceCode =
+									taxonomyCategoryExternalReferenceCode2;
+							}
+						}
+					});
+			}
+		};
+
+		// Lazy referencing disabled
+
+		try {
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception.getCause() instanceof NoSuchCategoryException);
+		}
+
+		// Lazy referencing enabled
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			objectEntry = _defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+			AssetCategory assetCategory1 =
+				_assetCategoryLocalService.
+					fetchAssetCategoryByExternalReferenceCode(
+						taxonomyCategoryExternalReferenceCode1,
+						_group.getGroupId());
+
+			Assert.assertNotNull(assetCategory1);
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE,
+				assetCategory1.getStatus());
+
+			AssetCategory assetCategory2 =
+				_assetCategoryLocalService.
+					fetchAssetCategoryByExternalReferenceCode(
+						taxonomyCategoryExternalReferenceCode2,
+						_group.getGroupId());
+
+			Assert.assertNotNull(assetCategory2);
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE,
+				assetCategory2.getStatus());
+
+			AssetEntry assetEntry = _assetEntryLocalService.getEntry(
+				_objectDefinition1.getClassName(), objectEntry.getId());
+
+			Assert.assertArrayEquals(
+				new long[] {
+					assetCategory1.getCategoryId(),
+					assetCategory2.getCategoryId()
+				},
+				_assetEntryAssetCategoryRelLocalService.
+					getAssetCategoryPrimaryKeys(assetEntry.getEntryId()));
+		}
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -14,6 +14,12 @@ import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.account.service.AccountRoleLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
+import com.liferay.asset.kernel.exception.NoSuchCategoryException;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
@@ -71,8 +77,10 @@ import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.Link;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.dto.v1_0.Scope;
 import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.rest.dto.v1_0.SystemProperties;
+import com.liferay.object.rest.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.object.rest.dto.v1_0.Version;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
@@ -824,6 +832,93 @@ public class DefaultObjectEntryManagerImplTest
 			objectDefinitionLocalService,
 			new String[] {"C_A", "C_AA", "C_AB", "C_AAA", "C_AAB"},
 			_objectEntryLocalService, _objectRelationshipLocalService);
+	}
+
+	@FeatureFlag("LPD-47858")
+	@Test
+	public void testAddObjectEntryCategoriesLazyReference() throws Exception {
+		String taxonomyCategoryExternalReferenceCode1 =
+			RandomTestUtil.randomString();
+		String taxonomyCategoryExternalReferenceCode2 =
+			RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = new ObjectEntry() {
+			{
+				setTaxonomyCategoryBriefs(
+					new TaxonomyCategoryBrief[] {
+						new TaxonomyCategoryBrief() {
+							{
+								scope = _getScope(_group);
+								taxonomyCategoryExternalReferenceCode =
+									taxonomyCategoryExternalReferenceCode1;
+							}
+						},
+						new TaxonomyCategoryBrief() {
+							{
+								scope = _getScope(_group);
+								taxonomyCategoryExternalReferenceCode =
+									taxonomyCategoryExternalReferenceCode2;
+							}
+						}
+					});
+			}
+		};
+
+		// Lazy referencing disabled
+
+		try {
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+			Assert.fail();
+		}
+		catch (NoSuchCategoryException noSuchCategoryException) {
+			Assert.assertNotNull(noSuchCategoryException);
+		}
+
+		// Lazy referencing enabled
+
+		try (SafeCloseable safeCloseable =
+				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			objectEntry = _defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, _objectDefinition1, objectEntry,
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+			AssetCategory assetCategory1 =
+				_assetCategoryLocalService.
+					fetchAssetCategoryByExternalReferenceCode(
+						taxonomyCategoryExternalReferenceCode1,
+						_group.getGroupId());
+
+			Assert.assertNotNull(assetCategory1);
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE,
+				assetCategory1.getStatus());
+
+			AssetCategory assetCategory2 =
+				_assetCategoryLocalService.
+					fetchAssetCategoryByExternalReferenceCode(
+						taxonomyCategoryExternalReferenceCode2,
+						_group.getGroupId());
+
+			Assert.assertNotNull(assetCategory2);
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_INCOMPLETE,
+				assetCategory2.getStatus());
+
+			AssetEntry assetEntry = _assetEntryLocalService.getEntry(
+				_objectDefinition1.getClassName(), objectEntry.getId());
+
+			Assert.assertArrayEquals(
+				new long[] {
+					assetCategory1.getCategoryId(),
+					assetCategory2.getCategoryId()
+				},
+				_assetEntryAssetCategoryRelLocalService.
+					getAssetCategoryPrimaryKeys(assetEntry.getEntryId()));
+		}
 	}
 
 	@Test
@@ -7224,6 +7319,22 @@ public class DefaultObjectEntryManagerImplTest
 			StringPool.BLANK, null, null, null);
 	}
 
+	private Scope _getScope(Group group) {
+		Scope scope = new Scope();
+
+		scope.setExternalReferenceCode(group::getExternalReferenceCode);
+		scope.setType(
+			() -> {
+				if (group.getType() == GroupConstants.TYPE_DEPOT) {
+					return Scope.Type.ASSET_LIBRARY;
+				}
+
+				return Scope.Type.SITE;
+			});
+
+		return scope;
+	}
+
 	private Timestamp _getTimestamp(String dateString) throws Exception {
 		Date date = DateUtil.parseDate(
 			"yyyy-MM-dd", dateString, LocaleUtil.getSiteDefault());
@@ -7744,6 +7855,16 @@ public class DefaultObjectEntryManagerImplTest
 
 	@Inject
 	private AccountRoleLocalService _accountRoleLocalService;
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetEntryAssetCategoryRelLocalService
+		_assetEntryAssetCategoryRelLocalService;
+
+	@Inject
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	private Role _buyerRole;
 


### PR DESCRIPTION
LPD-47038 Technical Task | Apply lazy reference strategy to Categories when importing a ObjectEntry

forward PR from https://github.com/liferay-bpm/liferay-portal/pull/4667, rebased with Brian Master beacuse some compilation errors and additional commit solving compilation errors.


# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-46893

If a Object Entry is being imported and its Category do not exist in the destination environment, the import will still succeed and the category created on incomplete status.

# How am I fixing it?

On this PR I adding the businnes capability to the API calls and implementations to, when it's called with the FF/threadLocal lazy active, the incomplete category(if not exists) is been created

# How can you verify that it works?

Run the included automated tests.


# Commits
- **LPD-47038 update Taxonomy Category Ids on the case that we have the data on them and the FF is active, from the data of the TaxonomyCategoryBrief**
- **LPD-47038 add test to check the behaviour when LazyReferencingThreadLocal is enabled or not adding the categories with an objectEntry**
- **LPD-47038 move logic, _updateTaxonomyCategoryIds, to the ServiceContextUtil**
- **LPD-47038 rename test and change exception**
- **LPD-47038 take into account that the group id comes from the scope, if not, see on the inner scope of the category**
- **LPD-47038 digest log to do not show on portal log on tests**
- **LPD-47038 make test not flaky sorting arrays on comparison**
- **LPD-47038 inline and do not create a variable**
