### PR TITLE
LPD-58872 [Test fix] tests/object-web/main/objectValidations.spec.ts > can display error messages under object fields in a mapped form container when submitting invalid entries

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectValidations.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectValidations.spec.ts
@@ -695,9 +695,13 @@ test(
 				`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
 			);
 
-			await page.getByLabel('objectFieldLabelDouble').fill('7.1');
+			await page
+				.getByRole('spinbutton', {name: 'objectFieldLabelDouble'})
+				.fill('7.1');
 
-			await page.getByLabel('objectFieldLabelInt').fill('4');
+			await page
+				.getByRole('spinbutton', {name: 'objectFieldLabelInt'})
+				.fill('4');
 
 			await page.getByText('Submit').click();
 
@@ -705,7 +709,9 @@ test(
 				page.getByText(objectValidationErrorLabelDouble)
 			).toBeVisible();
 
-			await page.getByLabel('objectFieldLabelDouble').fill('5.2');
+			await page
+				.getByRole('spinbutton', {name: 'objectFieldLabelDouble'})
+				.fill('5.2');
 
 			await page.getByText('Submit').click();
 
@@ -713,7 +719,9 @@ test(
 				page.getByText(objectValidationErrorLabelInt)
 			).toBeVisible();
 
-			await page.getByLabel('objectFieldLabelInt').fill('6');
+			await page
+				.getByRole('spinbutton', {name: 'objectFieldLabelInt'})
+				.fill('6');
 
 			await page.getByText('Submit').click();
 


### PR DESCRIPTION
[Related task](https://liferay.atlassian.net/browse/LPD-58871)