### PR TITLE
LPD-57844 Update the logic to show translated fields in web content considering field groups

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
@@ -20,6 +20,8 @@ import {FieldFeedback} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import {getFilteredPage} from './translation';
+
 import './FieldBase.scss';
 
 export function updateFieldNameLocale(editingLanguageId, locale, name) {
@@ -366,80 +368,22 @@ export default function FieldBase({
 			switch (event.option) {
 				case 'translated':
 					dispatch({
-						payload: pagesVisitor.mapFields(
-							(field) => {
-								if (!field.localizable) {
-									return {
-										...field,
-										disabled: true,
-										hidden: true,
-										visible: false,
-									};
-								}
-								if (
-									field.localizedValueEdited?.[
-										editingLanguageId
-									]
-								) {
-									return {
-										...field,
-										disabled: false,
-										hidden: false,
-										visible: true,
-									};
-								}
-								else {
-									return {
-										...field,
-										disabled: true,
-										hidden: true,
-										visible: false,
-									};
-								}
-							},
-							false,
-							true
-						),
+						payload: getFilteredPage({
+							editingLanguageId,
+							filter: 'translated',
+							pagesVisitor,
+						}),
 						type: CORE_EVENT_TYPES.PAGE.UPDATE,
 					});
 
 					break;
 				case 'untranslated':
 					dispatch({
-						payload: pagesVisitor.mapFields(
-							(field) => {
-								if (!field.localizable) {
-									return {
-										...field,
-										disabled: true,
-										hidden: true,
-										visible: false,
-									};
-								}
-								if (
-									field.localizedValueEdited?.[
-										editingLanguageId
-									]
-								) {
-									return {
-										...field,
-										disabled: true,
-										hidden: true,
-										visible: false,
-									};
-								}
-								else {
-									return {
-										...field,
-										disabled: false,
-										hidden: false,
-										visible: true,
-									};
-								}
-							},
-							false,
-							true
-						),
+						payload: getFilteredPage({
+							editingLanguageId,
+							filter: 'untranslated',
+							pagesVisitor,
+						}),
 						type: CORE_EVENT_TYPES.PAGE.UPDATE,
 					});
 					break;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/translation.ts
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/translation.ts
@@ -1,0 +1,204 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {PagesVisitor} from 'data-engine-js-components-web';
+
+import {LocalizedValue} from './ReactFieldBase';
+
+interface Column {
+	fields: WebContentField[];
+	size: number;
+}
+
+type WebContentFieldType =
+	| 'checkbox_multiple'
+	| 'captcha'
+	| 'checkbox'
+	| 'color'
+	| 'date'
+	| 'document_library'
+	| 'fieldset'
+	| 'grid'
+	| 'image'
+	| 'localizable_text'
+	| 'numeric'
+	| 'options'
+	| 'paragraph'
+	| 'radio'
+	| 'rich_text'
+	| 'separator'
+	| 'select'
+	| 'text';
+
+export interface WebContentField<T = unknown> {
+	disabled?: boolean;
+	fieldName: string;
+	hidden?: boolean;
+	localizable?: boolean;
+	localizedValueEdited?: LocalizedValue<any>;
+	name: string;
+	nestedFields?: WebContentField[];
+	settingsContext: {pages: unknown[]};
+	type: WebContentFieldType;
+	value?: T;
+	visible?: boolean;
+}
+
+interface PageVisitor extends PagesVisitor {
+	mapColumns: (mapper: (column: Column) => void) => void;
+}
+
+/**
+ * Returns an array with all the occurences of the string 'Fieldset' followed by digits.
+ * Used to find all fieldsets that are ancestors of a nested field.
+ */
+
+export function getAllFieldsetsFromName(name: string) {
+	const pattern = /Fieldset\d+/g;
+
+	return name.match(pattern) || [];
+}
+
+/**
+ * Add a fieldset fieldname in the provided set if it appears on the nested field name.
+ * Used to track if the fieldset should be shown in the chosen filter section.
+ */
+
+export function addVisibleFieldsets({
+	name,
+	visibleFieldsets,
+}: {
+	name: string;
+	visibleFieldsets: Set<string>;
+}) {
+	const parsedName = getAllFieldsetsFromName(name);
+
+	if (parsedName) {
+		parsedName.forEach((fieldset: string) =>
+			visibleFieldsets.add(fieldset)
+		);
+	}
+}
+
+/**
+ * Returns a boolean to determine if a field should be shown or not.
+ * If the field is not localizable it will never appear.
+ * If the filter is translated, the field should have a translation for the editingLanguageId to appear.
+ * If the filter is untranslated, the field shouldn't have a translation for the editingLanguageId to appear.
+ */
+
+export function isFieldVisible({
+	editingLanguageId,
+	field,
+	filter,
+}: {
+	editingLanguageId: Liferay.Language.Locale;
+	field: WebContentField;
+	filter: string;
+}) {
+	const hasValueInEditingLanguage =
+		!!field.localizedValueEdited?.[editingLanguageId];
+
+	if (!field.localizable) {
+		return false;
+	}
+
+	if (hasValueInEditingLanguage && filter === 'translated') {
+		return true;
+	}
+
+	if (!hasValueInEditingLanguage && filter === 'untranslated') {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Returns an array of fields with updated props depending on the filter chosen.
+ * Considers fieldsets and uses recursion to update the nested fields when necessary.
+ */
+
+export function showFilteredFields({
+	editingLanguageId,
+	fields,
+	filter,
+	visibleFieldsets,
+}: {
+	editingLanguageId: Liferay.Language.Locale;
+	fields: WebContentField[];
+	filter: string;
+	visibleFieldsets: Set<string>;
+}) {
+	const newFields = [...fields];
+
+	return newFields.map((field: WebContentField) => {
+		if (field.nestedFields) {
+			const newNestedFields: WebContentField[] = showFilteredFields({
+				editingLanguageId,
+				fields: field.nestedFields,
+				filter,
+				visibleFieldsets,
+			});
+
+			const visible = visibleFieldsets.has(field.fieldName);
+
+			return {
+				...field,
+				disabled: !visible,
+				hidden: !visible,
+				nestedFields: newNestedFields,
+				visible,
+			};
+		}
+
+		if (isFieldVisible({editingLanguageId, field, filter})) {
+			addVisibleFieldsets({name: field.name, visibleFieldsets});
+
+			return {
+				...field,
+				disabled: false,
+				hidden: false,
+				visible: true,
+			};
+		}
+		else {
+			return {
+				...field,
+				disabled: true,
+				hidden: true,
+				visible: false,
+			};
+		}
+	});
+}
+
+/**
+ * Returns the updated page depending on the filter chosen.
+ */
+
+export function getFilteredPage({
+	editingLanguageId,
+	filter,
+	pagesVisitor,
+}: {
+	editingLanguageId: Liferay.Language.Locale;
+	filter: string;
+	pagesVisitor: PageVisitor;
+}) {
+	return pagesVisitor.mapColumns((column: Column) => {
+		const visibleFieldsets = new Set<string>();
+
+		return {
+			...column,
+			fields: showFilteredFields({
+				editingLanguageId,
+				fields: column.fields,
+				filter,
+				visibleFieldsets,
+			}),
+		};
+	});
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/translation.spec.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/translation.spec.tsx
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+
+import {
+	WebContentField,
+	addVisibleFieldsets,
+	getAllFieldsetsFromName,
+	isFieldVisible,
+	showFilteredFields,
+} from '../../../src/main/resources/META-INF/resources/js/api/FieldBase/translation';
+
+const fieldLocalizableNotTranslated: WebContentField = {
+	fieldName: 'Text567',
+	localizable: true,
+	localizedValueEdited: {en_US: 'value'},
+	name: 'Text567',
+	settingsContext: {pages: []},
+	type: 'text',
+	value: 'value',
+};
+
+const fieldLocalizableTranslated: WebContentField = {
+	fieldName: 'Text890',
+	localizable: true,
+	localizedValueEdited: {en_US: 'value', pt_BR: 'valor'},
+	name: 'Text890#Fieldset123',
+	settingsContext: {pages: []},
+	type: 'text',
+	value: 'value',
+};
+
+const fieldNotLocalizable: WebContentField = {
+	fieldName: 'Text123',
+	localizable: false,
+	name: 'Text123',
+	settingsContext: {pages: []},
+	type: 'text',
+	value: 'value',
+};
+
+const fieldset: WebContentField = {
+	fieldName: 'Fieldset123',
+	localizable: false,
+	name: 'Fieldset123',
+	nestedFields: [fieldLocalizableTranslated],
+	settingsContext: {pages: []},
+	type: 'fieldset',
+};
+
+describe('addVisibleFieldsets(visibleFieldsets, name)', () => {
+	it('adds all the fieldsets that should be visible inside the set', () => {
+		const visibleFieldsets = new Set<string>();
+
+		addVisibleFieldsets({
+			name: 'Fieldset123Fieldset567Fieldset890',
+			visibleFieldsets,
+		});
+
+		expect(visibleFieldsets.has('Fieldset123')).toBe(true);
+		expect(visibleFieldsets.has('Fieldset567')).toBe(true);
+		expect(visibleFieldsets.has('Fieldset890')).toBe(true);
+	});
+});
+
+describe('getAllFieldsetsFromName(name)', () => {
+	it('returns an array of all the fieldsets fieldnames related to the corresponding nested field', () => {
+		let fieldsets = getAllFieldsetsFromName(
+			'Fieldset123Fieldset567Fieldset890'
+		);
+
+		expect(fieldsets[0]).toBe('Fieldset123');
+		expect(fieldsets[1]).toBe('Fieldset567');
+		expect(fieldsets[2]).toBe('Fieldset890');
+		expect(fieldsets.length).toBe(3);
+
+		fieldsets = getAllFieldsetsFromName(
+			'Field||set123Fieldset$#567Fieldset890'
+		);
+		expect(fieldsets[0]).toBe('Fieldset890');
+		expect(fieldsets.length).toBe(1);
+
+		fieldsets = getAllFieldsetsFromName('');
+		expect(fieldsets.length).toBe(0);
+	});
+});
+
+describe('isFieldVisible(editingLanguageId, field, filter)', () => {
+	it('returns false if field is not localizable regardless of filter choice', () => {
+		expect(
+			isFieldVisible({
+				editingLanguageId: 'en_US',
+				field: fieldNotLocalizable,
+				filter: 'translated',
+			})
+		).toBe(false);
+
+		expect(
+			isFieldVisible({
+				editingLanguageId: 'en_US',
+				field: fieldNotLocalizable,
+				filter: 'untranslated',
+			})
+		).toBe(false);
+	});
+
+	it('returns false if the field is localizable but is not translated and filter is set as translated', () => {
+		expect(
+			isFieldVisible({
+				editingLanguageId: 'pt_BR',
+				field: fieldLocalizableNotTranslated,
+				filter: 'translated',
+			})
+		).toBe(false);
+	});
+
+	it('returns false if the field is localizable but is translated and filter is set as untranslated', () => {
+		expect(
+			isFieldVisible({
+				editingLanguageId: 'pt_BR',
+				field: fieldLocalizableTranslated,
+				filter: 'untranslated',
+			})
+		).toBe(false);
+	});
+
+	it('returns true if the field is localizable, translated and filter is set as translated', () => {
+		expect(
+			isFieldVisible({
+				editingLanguageId: 'pt_BR',
+				field: fieldLocalizableTranslated,
+				filter: 'translated',
+			})
+		).toBe(true);
+	});
+
+	it('returns true if the field is localizable, untranslated and filter is set as untranslated', () => {
+		expect(
+			isFieldVisible({
+				editingLanguageId: 'pt_BR',
+				field: fieldLocalizableNotTranslated,
+				filter: 'untranslated',
+			})
+		).toBe(true);
+	});
+});
+
+describe('showFilteredFields(editingLanguageId, fields, filter, visibleFieldsets)', () => {
+	it('returns an array of fields having the visible properties correctly updated using the filter translated', () => {
+		const editingLanguageId = 'pt_BR';
+		const visibleFieldsets = new Set<string>();
+
+		const fields = showFilteredFields({
+			editingLanguageId,
+			fields: [fieldset],
+			filter: 'translated',
+			visibleFieldsets,
+		});
+
+		fields.forEach((field: WebContentField) => {
+			if (
+				field.name === 'Fieldset123' ||
+				field.name === 'Text890#Fieldset123'
+			) {
+				expect(field.disabled).toBe(false);
+				expect(field.hidden).toBe(false);
+				expect(field.visible).toBe(true);
+			}
+			else {
+				expect(field.disabled).toBe(true);
+				expect(field.hidden).toBe(true);
+				expect(field.visible).toBe(false);
+			}
+		});
+	});
+
+	it('returns an array of fields having the visible properties correctly updated using the filter untranslated', () => {
+		const editingLanguageId = 'pt_BR';
+		const visibleFieldsets = new Set<string>();
+
+		const fields = showFilteredFields({
+			editingLanguageId,
+			fields: [fieldset],
+			filter: 'untranslated',
+			visibleFieldsets,
+		});
+
+		fields.forEach((field: WebContentField) => {
+			if (
+				field.name === 'Fieldset123' ||
+				field.name === 'Text890#Fieldset123'
+			) {
+				expect(field.disabled).toBe(true);
+				expect(field.hidden).toBe(true);
+				expect(field.visible).toBe(false);
+			}
+			else {
+				expect(field.disabled).toBe(false);
+				expect(field.hidden).toBe(false);
+				expect(field.visible).toBe(true);
+			}
+		});
+	});
+});


### PR DESCRIPTION
Related issues:
- https://liferay.atlassian.net/browse/LPD-57844
- https://liferay.atlassian.net/browse/LPP-59070

hello reviewer! :cherry_blossom: here is some context for this ticket:

**bug: fieldsets are not being shown inside the translated or untranslated sections of web content**

the problem happens because the logic implemented didn't consider that fieldsets can't be localizable, since they don't have content on their own. however, the fields inside the fieldsets can be localizable and have different translations, so the fieldsets need to appear alongside these fields. the fieldsets were being hidden since the condition `(!field.localizable)` was always returning the props `visible: false`, `disabled: true` and `hidden: true`.

the solution follows:
- filter can have the values `translated` or `untranslated`
- first we verify if the field is a fieldset
- if true, it calls the function again using their `nestedFields` as parameter
- if false its a simple field and it will check using `showField`
- if `showField` is true, verify if this field is nested and needs fieldsets to appear as well, adding them inside the `set`
- if its false, the field will be hidden
- the fieldset will have the values for `visible`, `disabled` and `hidden` based if their `fieldName` is inside the `set`

let me know if you have any questions about this, thanks a lot!
