### PR TITLE
LPD-35408 Wrong value of current version of Workflow Definition

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/macros/ProcessBuilderKaleoDesignerReact.macro
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/macros/ProcessBuilderKaleoDesignerReact.macro
@@ -1945,13 +1945,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro viewRevisionHistoryFieldsPresent() {
-		AssertVisible(
-			key_fieldOption = "Current Version",
-			locator1 = "ProcessBuilderKaleoDesignerReact#DETAILS_FIELDS");
-	}
-
-	@summary = "Default summary"
 	macro viewRevisionHistoryVersion(number = null) {
 		AssertVisible(
 			key_number = ${number},

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/ProcessBuilderKaleoDesignerReact.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/ProcessBuilderKaleoDesignerReact.testcase
@@ -3705,29 +3705,6 @@ definition {
 			defaultStatus = "True");
 	}
 
-	@description = "Verify that the user can switch between Details and Revision Story Tab"
-	@priority = 4
-	test CanSwitchBetweenDetailsRevisionTabs {
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		Workflow.openWorkflowListView();
-
-		Workflow.addNewDefinition(workflowDefinitionTitle = "New Workflow Definition");
-
-		Workflow.saveDefinition(newKaleoDesigner = "True");
-
-		ProcessBuilderKaleoDesignerReact.gotoInfoWorkflowDefinition();
-
-		Navigator.gotoNavTab(navTab = "Revision History");
-
-		ProcessBuilderKaleoDesignerReact.viewRevisionHistoryFieldsPresent();
-
-		Navigator.gotoNavTab(navTab = "Details");
-
-		ProcessBuilderKaleoDesignerReact.viewDetailsFieldsPresent();
-	}
-
 	@description = "Verify that the user can turn on the Timers recurrence mode"
 	@priority = 4
 	test CanTurnOnTimerRecurrenceMode {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/DefinitionInfo/RevisionHistory.tsx
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/DefinitionInfo/RevisionHistory.tsx
@@ -22,16 +22,6 @@ export function RevisionHistory({
 }: RevisionHistoryProps) {
 	return (
 		<>
-			<div className="info-group">
-				<label>
-					{Liferay.Language.get('current-version')}:{' '}
-
-					{workflowDefinitionVersions.length + 1}
-				</label>
-
-				<div className="sheet-subtitle" />
-			</div>
-
 			{workflowDefinitionVersions.map(
 				({creatorName, dateCreated, version}, index) => (
 					<VersionRow

--- a/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/revisionHistory.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/revisionHistory.spec.ts
@@ -152,10 +152,9 @@ test.describe('Revision History tab', () => {
 		await test.step('Assert that the Revision History tab displays a list of versions in descending order', async () => {
 			const versionLabels = page.getByText('version');
 
-			await expect(versionLabels).toHaveCount(4);
+			await expect(versionLabels).toHaveCount(3);
 
 			await expect(versionLabels).toHaveText([
-				'Current Version: 4',
 				'Version 3',
 				'Version 2',
 				'Version 1',


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-35408

Goal:
Remove current version block from workflow's revision history tab. This changed is approved by Lawrence in this slack [thread](https://liferay.slack.com/archives/C026UR5976G/p1751057934984149) and daily meeting
![image](https://github.com/user-attachments/assets/77ef9296-9a51-4548-a49f-a1b539fb0bef)
