### PR TITLE
LPD-59513 Unable to search or filter Objects with arabic expression

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -1267,7 +1267,7 @@ public class ObjectDefinitionResourceTest
 						deletionType = ObjectRelationship.DeletionType.CASCADE;
 						externalReferenceCode = "TESTOBJECTRELATIONSHIP";
 						label = objectRelationshipLabelMap;
-						name = "anyFirstLowercaseLetterName";
+						name = StringUtil.randomId();
 						objectDefinitionExternalReferenceCode1 =
 							"TESTOBJECTDEFINITION1";
 						objectDefinitionExternalReferenceCode2 =

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -1267,11 +1267,12 @@ public class ObjectDefinitionResourceTest
 						deletionType = ObjectRelationship.DeletionType.CASCADE;
 						externalReferenceCode = "TESTOBJECTRELATIONSHIP";
 						label = objectRelationshipLabelMap;
-						name = RandomTestUtil.randomString();
+						name = "anyFirstLowercaseLetterName";
 						objectDefinitionExternalReferenceCode1 =
 							"TESTOBJECTDEFINITION1";
 						objectDefinitionExternalReferenceCode2 =
 							"TESTOBJECTDEFINITION2";
+						type = ObjectRelationship.Type.ONE_TO_MANY;
 					}
 				}
 			});

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -1267,7 +1267,7 @@ public class ObjectDefinitionResourceTest
 						deletionType = ObjectRelationship.DeletionType.CASCADE;
 						externalReferenceCode = "TESTOBJECTRELATIONSHIP";
 						label = objectRelationshipLabelMap;
-						name = StringUtil.randomId();
+						name = RandomTestUtil.randomString();
 						objectDefinitionExternalReferenceCode1 =
 							"TESTOBJECTDEFINITION1";
 						objectDefinitionExternalReferenceCode2 =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
@@ -67,11 +67,6 @@ public class ObjectEntrySearchUtil {
 		return dynamicObjectDefinitionLocalizationTable.getForeignKeyColumn(
 		).eq(
 			dynamicObjectDefinitionTable.getPrimaryKeyColumn()
-		).and(
-			dynamicObjectDefinitionLocalizationTable.getLanguageIdColumn(
-			).eq(
-				getLanguageId()
-			)
 		);
 	}
 


### PR DESCRIPTION
Removing LanguageId validation on query to return results in all languages on the Object Entry API when a search term is included on the GET entries request.