### PR TITLE
LPD-58967 refactor: Improve fieldBase accessibility

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Checkbox/CheckboxBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Checkbox/CheckboxBase.tsx
@@ -130,7 +130,7 @@ export default function CheckboxBase({
 			<Toggle
 				accessibleProps={{
 					...((otherProps.errorMessage || otherProps.tip) && {
-						'aria-describedby': `${otherProps.id ?? name}_fieldFeedback`,
+						'aria-describedby': `${name}_fieldFeedback`,
 					}),
 					'aria-required': !!otherProps.required,
 				}}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/CheckboxMultiple/CheckboxMultiple.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/CheckboxMultiple/CheckboxMultiple.es.js
@@ -25,7 +25,6 @@ const Switcher = ({checked, inline, ...otherProps}) => {
 const CheckboxMultiple = ({
 	accessibleProps,
 	disabled,
-	id,
 	inline,
 	isSwitcher,
 	localizedValueEdited,
@@ -67,17 +66,17 @@ const CheckboxMultiple = ({
 
 	return (
 		<div className="lfr-ddm-checkbox-multiple">
-			{options.map((option, index) => (
+			{options.map((option) => (
 				<Toggle
 					{...accessibleProps}
 					checked={displayValues.includes(option.value)}
 					data-option-reference={option.reference}
 					disabled={disabled}
-					id={id}
+					id={`${name}_${option.label}`}
 					inline={inline}
 					key={option.value}
 					label={option.label}
-					name={`${name}_${index}`}
+					name={`${name}_${option.label}`}
 					onBlur={onBlur}
 					onChange={handleChange}
 					onFocus={onFocus}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/CheckboxMultiple/CheckboxMultiple.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/CheckboxMultiple/CheckboxMultiple.es.js
@@ -25,6 +25,7 @@ const Switcher = ({checked, inline, ...otherProps}) => {
 const CheckboxMultiple = ({
 	accessibleProps,
 	disabled,
+	id,
 	inline,
 	isSwitcher,
 	localizedValueEdited,
@@ -72,6 +73,7 @@ const CheckboxMultiple = ({
 					checked={displayValues.includes(option.value)}
 					data-option-reference={option.reference}
 					disabled={disabled}
+					id={id}
 					inline={inline}
 					key={option.value}
 					label={option.label}
@@ -111,12 +113,9 @@ const Main = ({
 	localizedValueEdited,
 	...otherProps
 }) => (
-	<FieldBase name={name} readOnly={readOnly} {...otherProps}>
+	<FieldBase name={name} readOnly={readOnly} showGroup {...otherProps}>
 		<CheckboxMultiple
 			accessibleProps={{
-				...((otherProps.errorMessage || otherProps.tip) && {
-					'aria-describedby': `${otherProps.id ?? name}_fieldFeedback`,
-				}),
 				'aria-required': otherProps.required,
 			}}
 			disabled={readOnly}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ColorPicker/ColorPicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ColorPicker/ColorPicker.es.js
@@ -24,7 +24,6 @@ const DEFAULT_COLORS = [
 
 const ClayColorPickerWithState = ({
 	accessibleProps,
-	id,
 	inputValue,
 	name,
 	onBlur,
@@ -54,7 +53,7 @@ const ClayColorPickerWithState = ({
 				}}
 				colors={customColors}
 				disabled={readOnly}
-				id={id}
+				id={name}
 				label={Liferay.Language.get('color-field-type-label')}
 				onBlur={onBlur}
 				onColorsChange={setCustoms}
@@ -134,7 +133,7 @@ const ColorPicker = ({
 
 	return (
 		<FieldBase
-			fieldLabelHtmlFor={otherProps.id ?? name}
+			fieldLabelHtmlFor={name}
 			name={name}
 			onClick={handleColorDropDownClicked}
 			readOnly={readOnly}
@@ -145,7 +144,6 @@ const ColorPicker = ({
 				accessibleProps={{
 					'aria-required': otherProps.required,
 				}}
-				id={otherProps.id ?? name}
 				inputValue={value ? value : predefinedValue}
 				name={name}
 				onBlur={onBlur}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ColorPicker/ColorPicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ColorPicker/ColorPicker.es.js
@@ -24,6 +24,7 @@ const DEFAULT_COLORS = [
 
 const ClayColorPickerWithState = ({
 	accessibleProps,
+	id,
 	inputValue,
 	name,
 	onBlur,
@@ -53,6 +54,7 @@ const ClayColorPickerWithState = ({
 				}}
 				colors={customColors}
 				disabled={readOnly}
+				id={id}
 				label={Liferay.Language.get('color-field-type-label')}
 				onBlur={onBlur}
 				onColorsChange={setCustoms}
@@ -132,6 +134,7 @@ const ColorPicker = ({
 
 	return (
 		<FieldBase
+			fieldLabelHtmlFor={otherProps.id ?? name}
 			name={name}
 			onClick={handleColorDropDownClicked}
 			readOnly={readOnly}
@@ -142,6 +145,7 @@ const ColorPicker = ({
 				accessibleProps={{
 					'aria-required': otherProps.required,
 				}}
+				id={otherProps.id ?? name}
 				inputValue={value ? value : predefinedValue}
 				name={name}
 				onBlur={onBlur}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePicker.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePicker.tsx
@@ -136,6 +136,7 @@ export default function DatePicker({
 			{...otherProps}
 			displayErrors={validField.displayErrors}
 			errorMessage={validField.errorMessage}
+			fieldLabelHtmlFor={name}
 			name={name}
 			type={type}
 			valid={validField.valid}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePickerBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePickerBase.tsx
@@ -74,7 +74,6 @@ export default function DatePickerBase({
 	displayErrors,
 	errorMessage,
 	htmlAutocompleteAttribute,
-	id,
 	locale,
 	months,
 	name,
@@ -268,7 +267,7 @@ export default function DatePickerBase({
 						autoComplete: htmlAutocompleteAttribute,
 					})}
 					{...((errorMessage || tip) && {
-						'aria-describedby': `${id ?? name}_fieldFeedback`,
+						'aria-describedby': `${name}_fieldFeedback`,
 					})}
 					aria-required={required}
 					ariaLabels={{

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -75,7 +75,6 @@ const DocumentLibrary = ({
 	editingLanguageId,
 	fileEntryTitle = '',
 	fileEntryURL = '',
-	id,
 	message,
 	name,
 	onClearButtonClicked,
@@ -150,7 +149,7 @@ const DocumentLibrary = ({
 			)}
 
 			<input
-				id={id}
+				id={name}
 				name={name}
 				placeholder={placeholder}
 				type="hidden"
@@ -164,7 +163,6 @@ const DocumentLibrary = ({
 
 const GuestUploadFile = ({
 	fileEntryTitle = '',
-	id,
 	message,
 	name,
 	onClearButtonClicked,
@@ -235,7 +233,7 @@ const GuestUploadFile = ({
 			</ClayInput.Group>
 
 			<input
-				id={id}
+				id={name}
 				name={name}
 				placeholder={placeholder}
 				type="hidden"
@@ -261,7 +259,6 @@ const Main = ({
 	fileEntryTitle,
 	fileEntryURL,
 	guestUploadURL,
-	id,
 	itemSelectorURL,
 	maximumRepetitions,
 	maximumSubmissionLimitReached,
@@ -636,8 +633,8 @@ const Main = ({
 			{...otherProps}
 			displayErrors={hasCustomError ? true : displayErrors}
 			errorMessage={errorMessage}
-			fieldLabelHtmlFor={id ?? name}
-			id={id}
+			fieldLabelHtmlFor={name}
+			id={name}
 			name={name}
 			overMaximumRepetitionsLimit={
 				maximumRepetitions > 0 ? checkMaximumRepetitions() : false
@@ -648,7 +645,7 @@ const Main = ({
 			{allowGuestUsers && !isSignedIn ? (
 				<GuestUploadFile
 					fileEntryTitle={fileEntryTitle}
-					id={id}
+					id={name}
 					message={message}
 					name={name}
 					onBlur={onBlur}
@@ -668,14 +665,14 @@ const Main = ({
 				<DocumentLibrary
 					accessibleProps={{
 						...((errorMessage || otherProps.tip) && {
-							'aria-describedby': `${id ?? name}_fieldFeedback`,
+							'aria-describedby': `${name}_fieldFeedback`,
 						}),
 						'aria-required': otherProps.required,
 					}}
 					editingLanguageId={editingLanguageId}
 					fileEntryTitle={fileEntryTitle}
 					fileEntryURL={fileEntryURL}
-					id={id}
+					id={name}
 					message={message}
 					name={name}
 					onClearButtonClicked={(event) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -636,6 +636,7 @@ const Main = ({
 			{...otherProps}
 			displayErrors={hasCustomError ? true : displayErrors}
 			errorMessage={errorMessage}
+			fieldLabelHtmlFor={id ?? name}
 			id={id}
 			name={name}
 			overMaximumRepetitionsLimit={

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/FieldSet/FieldSet.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/FieldSet/FieldSet.es.js
@@ -97,20 +97,13 @@ const FieldSet = ({
 			readOnly={readOnly}
 			repeatable={collapsible ? false : repeatable}
 			required={false}
-			showLabel={false}
+			separator
+			showGroup
+			showLabel={collapsible ? false : showLabel}
 			tip={null}
 			type={type}
 		>
 			<div className="ddm-field-types-fieldset__nested">
-				{showLabel && !collapsible && (
-					<>
-						<label className="text-uppercase">{label}</label>
-						<div className="ddm-field-types-fieldset__nested-separator">
-							<hr className="mt-1 separator" />
-						</div>
-					</>
-				)}
-
 				{collapsible ? (
 					<Panel
 						name={name}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Grid/Grid.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Grid/Grid.es.js
@@ -137,7 +137,7 @@ const Main = ({
 	const [state, setState] = useSyncValue(value, false);
 
 	return (
-		<FieldBase name={name} readOnly={readOnly} {...otherProps}>
+		<FieldBase name={name} readOnly={readOnly} showGroup {...otherProps}>
 			<Grid
 				accessibleProps={{
 					'aria-required': otherProps.required,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ImagePicker/ImagePicker.es.js
@@ -19,7 +19,6 @@ const defaultValue = {description: '', title: '', url: ''};
 const ImagePicker = ({
 	accessibleProps,
 	editingLanguageId,
-	id,
 	inputValue,
 	itemSelectorURL,
 	message,
@@ -153,7 +152,7 @@ const ImagePicker = ({
 							className="field"
 							dir={Liferay.Language.direction[editingLanguageId]}
 							disabled={readOnly}
-							id={id}
+							id={name}
 							lang={editingLanguageId}
 							onClick={handleItemSelectorTriggerClick}
 							type="text"
@@ -284,7 +283,6 @@ const Main = ({
 	displayErrors,
 	editingLanguageId,
 	errorMessage,
-	id,
 	inputValue,
 	itemSelectorURL,
 	localizable,
@@ -342,8 +340,8 @@ const Main = ({
 			{...otherProps}
 			displayErrors={isSignedIn ? displayErrors : true}
 			errorMessage={getErrorMessages(errorMessage, isSignedIn)}
-			fieldLabelHtmlFor={otherProps.id ?? name}
-			id={id}
+			fieldLabelHtmlFor={name}
+			id={name}
 			localizedValue={localizedValue}
 			name={name}
 			readOnly={isSignedIn ? readOnly : true}
@@ -352,13 +350,12 @@ const Main = ({
 			<ImagePicker
 				accessibleProps={{
 					...((otherProps.errorMessage || otherProps.tip) && {
-						'aria-describedby': `${otherProps.id ?? name}_fieldFeedback`,
+						'aria-describedby': `${name}_fieldFeedback`,
 					}),
 					'aria-invalid': !valid,
 					'aria-required': otherProps.required,
 				}}
 				editingLanguageId={editingLanguageId}
-				id={id ?? name}
 				inputValue={
 					transformValue(inputValue) ??
 					transformValue(value) ??

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ImagePicker/ImagePicker.es.js
@@ -342,6 +342,7 @@ const Main = ({
 			{...otherProps}
 			displayErrors={isSignedIn ? displayErrors : true}
 			errorMessage={getErrorMessages(errorMessage, isSignedIn)}
+			fieldLabelHtmlFor={otherProps.id ?? name}
 			id={id}
 			localizedValue={localizedValue}
 			name={name}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/LocalizableText/LocalizableText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/LocalizableText/LocalizableText.es.js
@@ -35,7 +35,6 @@ const LocalizableText = ({
 	displayStyle = 'singleline',
 	editingLocale = INITIAL_EDITING_LOCALE,
 	fieldName,
-	id,
 	label,
 	localizedObjectField,
 	name,
@@ -126,7 +125,6 @@ const LocalizableText = ({
 				dir={Liferay.Language.direction[currentEditingLocale.localeId]}
 				displayStyle={displayStyle}
 				fieldName={fieldName}
-				id={id}
 				inputValue={inputValue}
 				label={label}
 				name={name}
@@ -161,7 +159,7 @@ const LocalizableText = ({
 			/>
 
 			<input
-				id={id}
+				id={name}
 				name={name}
 				type="hidden"
 				value={currentValue || ''}
@@ -210,7 +208,6 @@ const Main = ({
 	displayStyle,
 	editingLocale,
 	fieldName,
-	id,
 	label,
 	localizedObjectField,
 	name,
@@ -230,7 +227,7 @@ const Main = ({
 	return (
 		<FieldBase
 			{...otherProps}
-			id={id}
+			id={name}
 			label={label}
 			name={name}
 			readOnly={readOnly}
@@ -257,7 +254,6 @@ const Main = ({
 						: editingLocale
 				}
 				fieldName={fieldName}
-				id={id}
 				label={label}
 				localizedObjectField={localizedObjectField}
 				name={name}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Numeric/Numeric.tsx
@@ -105,6 +105,7 @@ const Main = ({
 		<FieldBase
 			{...otherProps}
 			{...(!localizedObjectField && {localizedValue})}
+			fieldLabelHtmlFor={otherProps.id ?? otherProps.name}
 		>
 			<ClayInput.Group>
 				<Component {...otherProps} localizedValue={localizedValue} />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Numeric/Numeric.tsx
@@ -105,7 +105,7 @@ const Main = ({
 		<FieldBase
 			{...otherProps}
 			{...(!localizedObjectField && {localizedValue})}
-			fieldLabelHtmlFor={otherProps.id ?? otherProps.name}
+			fieldLabelHtmlFor={otherProps.name}
 		>
 			<ClayInput.Group>
 				<Component {...otherProps} localizedValue={localizedValue} />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Numeric/NumericBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Numeric/NumericBase.tsx
@@ -31,7 +31,6 @@ const NumericBase = ({
 	errorMessage,
 	focused,
 	htmlAutocompleteAttribute,
-	id,
 	inputMask,
 	inputMaskFormat,
 	inputValue,
@@ -51,7 +50,7 @@ const NumericBase = ({
 }) => {
 	const accessibleProperties = {
 		...((errorMessage || tip) && {
-			'aria-describedby': `${id ?? name}_fieldFeedback`,
+			'aria-describedby': `${name}_fieldFeedback`,
 		}),
 		'aria-invalid': !valid,
 		'aria-required': required,
@@ -94,7 +93,7 @@ const NumericBase = ({
 							'rtl',
 					})}
 					disabled={readOnly}
-					id={id ?? name}
+					id={name}
 					name={`${name}${inputMask ? '_masked' : ''}`}
 					onBlur={onBlur}
 					onChange={handleChange}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Paragraph/Paragraph.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Paragraph/Paragraph.es.js
@@ -7,7 +7,7 @@ import {ReactFieldBase as FieldBase} from 'dynamic-data-mapping-form-field-type/
 import React from 'react';
 
 const Paragraph = ({name, text, ...otherProps}) => (
-	<FieldBase {...otherProps} name={name} text={text}>
+	<FieldBase {...otherProps} name={name} showGroup text={text}>
 		<div
 			className="form-group liferay-ddm-form-field-paragraph"
 			data-field-name={name}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Radio/Radio.es.js
@@ -40,7 +40,7 @@ const Radio = ({
 }) => {
 	const accessibleProps = {
 		...((otherProps.errorMessage || otherProps.tip) && {
-			'aria-describedby': `${otherProps.id ?? name}_fieldFeedback`,
+			'aria-describedby': `${name}_fieldFeedback`,
 		}),
 		'aria-required': otherProps.required,
 	};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Radio/Radio.es.js
@@ -67,7 +67,7 @@ const Radio = ({
 	);
 
 	return (
-		<FieldBase {...otherProps} name={name} readOnly={disabled}>
+		<FieldBase {...otherProps} name={name} readOnly={disabled} showGroup>
 			<div className="ddm__radio" onBlur={onBlur} onFocus={onFocus}>
 				<ClayRadioGroup
 					inline={inline}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/RichText/RichText.es.js
@@ -353,7 +353,7 @@ const RichText = ({
 					) : (
 						<ClassicEditor
 							ariaLabel={label}
-							ariaRequired={otherProps.required}
+							ariaRequired={!!otherProps.required}
 							className="w-100"
 							contents={
 								currentValue

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/RichText/RichText.es.js
@@ -56,7 +56,6 @@ const RichText = ({
 	editorConfig,
 	evaluable,
 	fieldName,
-	id,
 	label = '',
 	locale,
 	name,
@@ -331,7 +330,7 @@ const RichText = ({
 		<FieldBase
 			{...otherProps}
 			fieldName={fieldName}
-			id={id}
+			id={name}
 			label={label}
 			name={name}
 			readOnly={readOnly}
@@ -406,7 +405,7 @@ const RichText = ({
 				</ClayInput.GroupItem>
 
 				<input
-					id={id}
+					id={name}
 					name={name}
 					type="hidden"
 					value={

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/SearchLocation/SearchLocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/SearchLocation/SearchLocation.es.js
@@ -70,6 +70,7 @@ const Field = ({
 	return (
 		<FieldBase
 			{...otherProps}
+			fieldLabelHtmlFor={id}
 			hideEditedFlag
 			label={label[editingLanguageId] ?? label}
 			localizedValue={{}}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/SearchLocation/SearchLocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/SearchLocation/SearchLocation.es.js
@@ -33,7 +33,6 @@ const isEmpty = (object) => {
 const Field = ({
 	disabled,
 	editingLanguageId,
-	id,
 	label,
 	name,
 	onBlur,
@@ -61,7 +60,7 @@ const Field = ({
 
 	const accessibleProps = {
 		...((otherProps.errorMessage || otherProps.tip) && {
-			'aria-describedby': `${id ?? name}_fieldFeedback`,
+			'aria-describedby': `${name}_fieldFeedback`,
 		}),
 		'aria-invalid': !valid,
 		'aria-required': otherProps.required,
@@ -85,7 +84,7 @@ const Field = ({
 				className="ddm-field-text"
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={disabled}
-				id={id}
+				id={name}
 				name={name}
 				onBlur={(event) => {
 					setValid(initialValid);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/MultipleSelectBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/MultipleSelectBase.tsx
@@ -23,7 +23,7 @@ const MultipleSelectBase = ({
 
 	const accessibleProps = {
 		...((errorMessage || tip) && {
-			'aria-describedby': `${id ?? name}_fieldFeedback`,
+			'aria-describedby': `${name}_fieldFeedback`,
 		}),
 		'aria-required': required,
 	};
@@ -61,7 +61,7 @@ const MultipleSelectBase = ({
 			{...accessibleProps}
 			clearAllTitle={Liferay.Language.get('clear-all')}
 			disabled={readOnly}
-			id={id}
+			id={name}
 			items={items}
 			messages={messages}
 			onItemsChange={(itemsChanged: MultiSelectItem[]) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/MultipleSelectBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/MultipleSelectBase.tsx
@@ -11,8 +11,6 @@ import {MultiSelectItem, MultipleSelectBaseProps} from './select.d';
 
 const MultipleSelectBase = ({
 	errorMessage,
-	id,
-	label,
 	name,
 	onChange,
 	options,
@@ -24,9 +22,6 @@ const MultipleSelectBase = ({
 	const [items, setItems] = useState<MultiSelectItem[]>([]);
 
 	const accessibleProps = {
-		...(label && {
-			'aria-labelledby': `${id ?? name}`,
-		}),
 		...((errorMessage || tip) && {
 			'aria-describedby': `${id ?? name}_fieldFeedback`,
 		}),
@@ -66,6 +61,7 @@ const MultipleSelectBase = ({
 			{...accessibleProps}
 			clearAllTitle={Liferay.Language.get('clear-all')}
 			disabled={readOnly}
+			id={id}
 			items={items}
 			messages={messages}
 			onItemsChange={(itemsChanged: MultiSelectItem[]) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/Select.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/Select.tsx
@@ -99,6 +99,7 @@ const Select = ({
 
 	return (
 		<FieldBase
+			fieldLabelHtmlFor={id ?? name}
 			label={label}
 			localizedValue={localizedValue}
 			name={name}
@@ -109,6 +110,7 @@ const Select = ({
 				<MultipleSelectionComponent
 					defaultLanguageId={defaultLanguageId}
 					fixedOptions={[]}
+					id={id ?? name}
 					label={label}
 					name={name}
 					onChange={onChange}
@@ -126,7 +128,7 @@ const Select = ({
 				<SingleSelectBase
 					defaultLanguageId={defaultLanguageId}
 					fixedOptions={fixedOptions}
-					id={id}
+					id={id ?? name}
 					label={label}
 					multiple={multiple}
 					name={name}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/Select.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/Select.tsx
@@ -28,7 +28,6 @@ const Select = ({
 	multiple = false,
 	name,
 	onChange,
-	id,
 	onSelectionChange,
 	options = [],
 	placeholder = Liferay.Language.get('choose-an-option'),
@@ -99,7 +98,7 @@ const Select = ({
 
 	return (
 		<FieldBase
-			fieldLabelHtmlFor={id ?? name}
+			fieldLabelHtmlFor={name}
 			label={label}
 			localizedValue={localizedValue}
 			name={name}
@@ -110,7 +109,6 @@ const Select = ({
 				<MultipleSelectionComponent
 					defaultLanguageId={defaultLanguageId}
 					fixedOptions={[]}
-					id={id ?? name}
 					label={label}
 					name={name}
 					onChange={onChange}
@@ -128,7 +126,6 @@ const Select = ({
 				<SingleSelectBase
 					defaultLanguageId={defaultLanguageId}
 					fixedOptions={fixedOptions}
-					id={id ?? name}
 					label={label}
 					multiple={multiple}
 					name={name}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/SingleSelectBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/SingleSelectBase.tsx
@@ -72,13 +72,10 @@ export default function SingleSelectBase({
 	}
 
 	const accessibleProps = {
-		...(label && {
-			'aria-labelledby': `${id ?? name}`,
-		}),
 		...((errorMessage || tip) && {
 			'aria-describedby': `${id ?? name}_fieldFeedback`,
 		}),
-		'aria-required': required,
+		'aria-required': !!required,
 	};
 
 	useEffect(() => {
@@ -120,6 +117,7 @@ export default function SingleSelectBase({
 					{...accessibleProps}
 					data-testid={id}
 					disabled={readOnly}
+					id={id}
 					items={[{items: options, label}]}
 					onSelectionChange={onSelectionChange}
 					placeholder={placeholder}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/SingleSelectBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/SingleSelectBase.tsx
@@ -21,7 +21,6 @@ interface SingleSelectBaseProps
 export default function SingleSelectBase({
 	className,
 	errorMessage,
-	id,
 	label,
 	name,
 	onSelectionChange,
@@ -73,7 +72,7 @@ export default function SingleSelectBase({
 
 	const accessibleProps = {
 		...((errorMessage || tip) && {
-			'aria-describedby': `${id ?? name}_fieldFeedback`,
+			'aria-describedby': `${name}_fieldFeedback`,
 		}),
 		'aria-required': !!required,
 	};
@@ -115,9 +114,9 @@ export default function SingleSelectBase({
 			{!loading && (
 				<Picker
 					{...accessibleProps}
-					data-testid={id}
+					data-testid={name}
 					disabled={readOnly}
-					id={id}
+					id={name}
 					items={[{items: options, label}]}
 					onSelectionChange={onSelectionChange}
 					placeholder={placeholder}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Text/Text.es.js
@@ -72,7 +72,6 @@ const Text = ({
 	error,
 	fieldName,
 	htmlAutocompleteAttribute,
-	id,
 	invalidCharacters,
 	localizable,
 	localizedValue,
@@ -170,7 +169,7 @@ const Text = ({
 						className="ddm-field-text"
 						dir={Liferay.Language.direction[editingLanguageId]}
 						disabled={disabled}
-						id={id}
+						id={name}
 						lang={editingLanguageId?.replaceAll('_', '-')}
 						maxLength={showCounter ? '' : maxLength}
 						name={name}
@@ -459,7 +458,6 @@ const Main = ({
 	showCounter,
 	fieldName,
 	htmlAutocompleteAttribute,
-	id,
 	invalidCharacters = '',
 	locale,
 	localizable,
@@ -504,7 +502,7 @@ const Main = ({
 			displayErrors={error.displayErrors ?? displayErrors}
 			fieldLabelHtmlFor={name}
 			fieldName={fieldName}
-			id={id}
+			id={name}
 			localizedValue={localizedValue}
 			name={name}
 			popover={fieldPopoverMap[fieldName]}
@@ -515,7 +513,7 @@ const Main = ({
 			<Component
 				accessibleProps={{
 					...((otherProps.errorMessage || otherProps.tip) && {
-						'aria-describedby': `${otherProps.id ?? name}_fieldFeedback`,
+						'aria-describedby': `${name}_fieldFeedback`,
 					}),
 					'aria-invalid': !valid,
 					'aria-required': otherProps.required,
@@ -527,7 +525,7 @@ const Main = ({
 				error={error}
 				fieldName={fieldName}
 				htmlAutocompleteAttribute={htmlAutocompleteAttribute}
-				id={id ?? name}
+				id={name}
 				invalidCharacters={invalidCharacters}
 				localizable={localizable}
 				localizedValue={localizedValue}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Text/Text.es.js
@@ -502,6 +502,7 @@ const Main = ({
 			{...otherProps}
 			{...error}
 			displayErrors={error.displayErrors ?? displayErrors}
+			fieldLabelHtmlFor={name}
 			fieldName={fieldName}
 			id={id}
 			localizedValue={localizedValue}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.d.ts
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.d.ts
@@ -8,10 +8,10 @@ type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 export default function FieldBase(props: IFieldBase): JSX.Element;
 
 interface IFieldBase {
-	accessible?: boolean;
 	children?: any;
 	displayErrors?: any;
 	errorMessage?: any;
+	fieldLabelHtmlFor?: string;
 	fieldName?: any;
 	hideEditedFlag?: any;
 	hideField?: any;
@@ -25,6 +25,8 @@ interface IFieldBase {
 	readOnly?: any;
 	repeatable?: any;
 	required?: any;
+	separator?: boolean;
+	showGroup?: boolean;
 	showLabel?: boolean;
 	style?: any;
 	text?: any;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
@@ -180,7 +180,6 @@ export default function FieldBase({
 	fieldReference,
 	hideField,
 	hideEditedFlag,
-	id,
 	instanceId,
 	isLocalizationSupported,
 	itemPath,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
@@ -46,44 +46,6 @@ export function normalizeInputValue(fieldType, value) {
 	return value;
 }
 
-const getFieldDetails = ({
-	errorMessage,
-	hasError,
-	label,
-	required,
-	text,
-	tip,
-	warningMessage,
-}) => {
-	const fieldDetails = [];
-
-	if (label) {
-		fieldDetails.push(Liferay.Util.escape(label));
-	}
-
-	if (tip) {
-		fieldDetails.push(Liferay.Util.escape(tip));
-	}
-
-	if (text) {
-		fieldDetails.push(Liferay.Util.escape(text));
-	}
-
-	if (hasError) {
-		fieldDetails.push(Liferay.Util.escape(errorMessage));
-	}
-	else {
-		if (warningMessage) {
-			fieldDetails.push(Liferay.Util.escape(warningMessage));
-		}
-		if (required) {
-			fieldDetails.push(Liferay.Language.get('required'));
-		}
-	}
-
-	return fieldDetails.length ? fieldDetails.join('<br>') : false;
-};
-
 const HideFieldProperty = () => {
 	return (
 		<ClayLabel className="ml-1" displayType="secondary">
@@ -92,8 +54,20 @@ const HideFieldProperty = () => {
 	);
 };
 
-const LabelProperty = ({hideField, label}) => {
-	return hideField ? <span className="text-secondary">{label}</span> : label;
+const LabelProperty = ({hideField, label, required}) => {
+	return (
+		<>
+			{hideField ? (
+				<span className="text-secondary">{label}</span>
+			) : (
+				label
+			)}
+
+			{required && <RequiredProperty />}
+
+			{hideField && <HideFieldProperty />}
+		</>
+	);
 };
 
 const RequiredProperty = () => {
@@ -116,6 +90,34 @@ const FieldInformation = ({popover, tooltip}) => {
 		>
 			<ClayIcon symbol="question-circle-full" />
 		</span>
+	);
+};
+
+const FieldInformations = ({
+	children,
+	nonLocalizableFieldMessage,
+	popover,
+	popoverOrTooltip,
+	showDisabledFieldIcon,
+	showLabel,
+	tooltip,
+}) => {
+	return (
+		<>
+			{showLabel && popoverOrTooltip && (
+				<FieldInformation popover={popover} tooltip={tooltip} />
+			)}
+
+			{showDisabledFieldIcon && (
+				<FieldInformation tooltip={nonLocalizableFieldMessage} />
+			)}
+
+			{children}
+
+			{!showLabel && popoverOrTooltip && (
+				<FieldInformation popover={popover} tooltip={tooltip} />
+			)}
+		</>
 	);
 };
 
@@ -169,12 +171,12 @@ const FIELDSET_REGEX = /Fieldset\d+/g;
 const FIELDSET_REPEAT_INDEX_REGEX = /\$(\d+)(?:#|\$|$)/g;
 
 export default function FieldBase({
-	accessible = true,
 	children,
 	displayErrors,
 	editOnlyInDefaultLanguage,
 	errorMessage,
 	fieldName,
+	fieldLabelHtmlFor,
 	fieldReference,
 	hideField,
 	hideEditedFlag,
@@ -193,9 +195,10 @@ export default function FieldBase({
 	readOnly,
 	repeatable,
 	required,
+	separator,
+	showGroup,
 	showLabel = true,
 	style,
-	text,
 	tip,
 	tooltip,
 	type,
@@ -206,20 +209,9 @@ export default function FieldBase({
 	const {editingLanguageId, pages} = useFormState();
 	const dispatch = useForm();
 
+	const fieldFeedbackId = `${name}_fieldFeedback`;
+	const fieldLabelId = `${name}_fieldLabel`;
 	const hasError = displayErrors && errorMessage && !valid;
-
-	const fieldDetails = getFieldDetails({
-		errorMessage,
-		hasError,
-		label,
-		required,
-		text,
-		tip,
-		warningMessage,
-	});
-
-	const fieldDetailsId = `${id ?? name}_fieldDetails`;
-	const fieldLabelId = `${id ?? name}_fieldLabel`;
 
 	const hiddenTranslations = useMemo(() => {
 		if (!localizedValue) {
@@ -268,38 +260,11 @@ export default function FieldBase({
 
 	const renderLabel =
 		(label && showLabel) || hideField || repeatable || required || tooltip;
+
 	const showDisabledFieldIcon =
 		editOnlyInDefaultLanguage && showLabel && readOnly;
-	const showGroup =
-		type === 'checkbox_multiple' ||
-		type === 'grid' ||
-		type === 'paragraph' ||
-		type === 'radio';
+
 	const popoverOrTooltip = !!popover || !!tooltip;
-	const showFor =
-		type === 'date' ||
-		type === 'date_time' ||
-		type === 'document_library' ||
-		type === 'image' ||
-		type === 'numeric' ||
-		type === 'rich_text' ||
-		type === 'search_location' ||
-		type === 'text';
-	const readFieldDetails = !showFor;
-	const hasFieldDetails =
-		accessible && fieldDetails && readFieldDetails && type !== 'select';
-
-	const accessiblePropsGroup = {
-		...(!renderLabel &&
-			hasFieldDetails && {'aria-labelledby': fieldDetailsId}),
-		...(type === 'fieldset' && {role: 'group'}),
-	};
-
-	const accessiblePropsFields = {
-		...(hasFieldDetails && {'aria-labelledby': fieldDetailsId}),
-		...(showFor && {htmlFor: id ?? name}),
-		...readFieldDetails,
-	};
 
 	const defaultRows = nestedFields?.map((field) => ({
 		columns: [{fields: [field], size: 12}],
@@ -490,7 +455,6 @@ export default function FieldBase({
 
 	return (
 		<ClayForm.Group
-			{...accessiblePropsGroup}
 			className={classNames({
 				'has-error': hasError,
 				'has-warning': warningMessage && !hasError,
@@ -500,6 +464,11 @@ export default function FieldBase({
 			data-field-reference={fieldReference}
 			onClick={onClick}
 			style={style}
+			{...(repeatable &&
+				label && {
+					'aria-labelledby': fieldLabelId,
+					'role': 'group',
+				})}
 		>
 			{repeatable && (
 				<div className="lfr-ddm-form-field-repeatable-toolbar">
@@ -578,79 +547,77 @@ export default function FieldBase({
 			{renderLabel && (
 				<>
 					{showGroup ? (
-						<div aria-labelledby={fieldLabelId} role="group">
-							<label
-								{...accessiblePropsFields}
+						<fieldset>
+							<legend
+								aria-describedby={fieldFeedbackId}
 								className={classNames('lfr-ddm-legend', {
 									'text-muted': showDisabledFieldIcon,
+									'text-uppercase': separator,
 								})}
 								id={fieldLabelId}
 							>
-								{showLabel && label}
+								{showLabel && (
+									<LabelProperty
+										hideField={hideField}
+										label={label}
+										required={required}
+									/>
+								)}
+							</legend>
 
-								{required && <RequiredProperty />}
-							</label>
-
-							{popoverOrTooltip && (
-								<FieldInformation
-									popover={popover}
-									tooltip={tooltip}
-								/>
+							{separator && (
+								<div className="ddm-field-types-fieldset__nested-separator">
+									<hr className="mt-1 separator" />
+								</div>
 							)}
 
-							{showDisabledFieldIcon && (
-								<FieldInformation
-									tooltip={nonLocalizableFieldMessage}
-								/>
-							)}
-
-							{children}
-						</div>
+							<FieldInformations
+								nonLocalizableFieldMessage={
+									nonLocalizableFieldMessage
+								}
+								popover={popover}
+								popoverOrTooltip={popoverOrTooltip}
+								showDisabledFieldIcon={showDisabledFieldIcon}
+								showLabel={showLabel}
+								tooltip={tooltip}
+							>
+								{children}
+							</FieldInformations>
+						</fieldset>
 					) : (
 						<>
 							<label
-								{...accessiblePropsFields}
 								className={classNames({
 									'ddm-empty': !showLabel && !required,
 									'ddm-label': showLabel || required,
 									'ddm-repeatable': repeatable,
 									'text-muted': showDisabledFieldIcon,
 								})}
-								{...(type === 'select' && {id: id ?? name})}
+								{...(fieldLabelHtmlFor && {
+									htmlFor: fieldLabelHtmlFor,
+								})}
+								id={fieldLabelId}
 							>
-								{showLabel && label && (
+								{showLabel && (
 									<LabelProperty
 										hideField={hideField}
 										label={label}
+										required={required}
 									/>
 								)}
-
-								{required && <RequiredProperty />}
-
-								{hideField && <HideFieldProperty />}
 							</label>
 
-							{showLabel && popoverOrTooltip && (
-								<FieldInformation
-									popover={popover}
-									tooltip={tooltip}
-								/>
-							)}
-
-							{showDisabledFieldIcon && (
-								<FieldInformation
-									tooltip={nonLocalizableFieldMessage}
-								/>
-							)}
-
-							{children}
-
-							{!showLabel && popoverOrTooltip && (
-								<FieldInformation
-									popover={popover}
-									tooltip={tooltip}
-								/>
-							)}
+							<FieldInformations
+								nonLocalizableFieldMessage={
+									nonLocalizableFieldMessage
+								}
+								popover={popover}
+								popoverOrTooltip={popoverOrTooltip}
+								showDisabledFieldIcon={showDisabledFieldIcon}
+								showLabel={showLabel}
+							>
+								{children}
+							</FieldInformations>
 						</>
 					)}
 				</>
@@ -671,19 +638,9 @@ export default function FieldBase({
 			<FieldFeedback
 				errorMessage={hasError ? errorMessage : undefined}
 				helpMessage={typeof tip === 'string' ? tip : undefined}
-				id={`${id ?? name}_fieldFeedback`}
+				id={fieldFeedbackId}
 				warningMessage={warningMessage}
 			/>
-
-			{hasFieldDetails && (
-				<span
-					className="sr-only"
-					dangerouslySetInnerHTML={{
-						__html: fieldDetails,
-					}}
-					id={fieldDetailsId}
-				/>
-			)}
 
 			{defaultRows && <Layout itemPath={itemPath} rows={defaultRows} />}
 		</ClayForm.Group>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/localizedObjectFields/MultipleSelectLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/localizedObjectFields/MultipleSelectLocalizedObjectField.tsx
@@ -28,7 +28,6 @@ function getDefaultValue(locale: Locale, value: valueTypes) {
 export default function MultipleSelectLocalizedObjectField({
 	errorMessage,
 	fieldName,
-	id,
 	label,
 	name,
 	onChange,
@@ -86,7 +85,6 @@ export default function MultipleSelectLocalizedObjectField({
 				defaultLanguageId={defaultLanguageId}
 				errorMessage={errorMessage}
 				fieldName={fieldName}
-				id={id}
 				label={label}
 				name={name}
 				onChange={handleChange}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/localizedObjectFields/SelectLocalizedObjectField.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/localizedObjectFields/SelectLocalizedObjectField.tsx
@@ -62,7 +62,6 @@ function normalizeValues(
 export default function SelectLocalizedObjectField({
 	fieldName,
 	fixedOptions = [],
-	id,
 	label,
 	name,
 	onChange,
@@ -142,7 +141,6 @@ export default function SelectLocalizedObjectField({
 					className="ddm-object-field-single-select-localized"
 					defaultLanguageId={defaultLanguageId}
 					fieldName={fieldName}
-					id={id}
 					label={label}
 					name={name}
 					onSelectionChange={handleChange}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/__snapshots__/Checkbox.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/__snapshots__/Checkbox.es.js.snap
@@ -3,7 +3,6 @@
 exports[`Field Checkbox has a helptext 1`] = `
 <div>
   <div
-    aria-labelledby="ID_fieldDetails"
     class="form-group hide"
   >
     <div
@@ -22,7 +21,7 @@ exports[`Field Checkbox has a helptext 1`] = `
               class="toggle-switch-check-bar"
             >
               <input
-                aria-describedby="ID_fieldFeedback"
+                aria-describedby="undefined_fieldFeedback"
                 aria-required="false"
                 class="toggle-switch-check"
                 role="switch"
@@ -54,7 +53,7 @@ exports[`Field Checkbox has a helptext 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="ID_fieldFeedback"
+      id="undefined_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -64,12 +63,6 @@ exports[`Field Checkbox has a helptext 1`] = `
         Type something
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="ID_fieldDetails"
-    >
-      Type something
-    </span>
   </div>
 </div>
 `;
@@ -381,7 +374,7 @@ exports[`Field Checkbox has an id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="ID_fieldFeedback"
+      id="undefined_fieldFeedback"
     >
       <div
         aria-live="assertive"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/CheckboxMultiple.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/CheckboxMultiple.es.js
@@ -5,7 +5,7 @@
 
 import '@testing-library/jest-dom/extend-expect';
 import {screen} from '@testing-library/dom';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, render, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {PageProvider} from 'data-engine-js-components-web';
 import React from 'react';
@@ -95,21 +95,29 @@ describe('Field Checkbox Multiple', () => {
 	});
 
 	it('has a helptext', () => {
-		render(<CheckboxMultipleWithProvider tip="Help Text Content" />);
-
-		const helpTextElements = screen.getAllByText('Help Text Content');
-
-		expect(helpTextElements[0]).toBeVisible();
-		expect(helpTextElements[1]).toHaveClass('sr-only');
-	});
-
-	it('appends id to field-feedback element id', () => {
 		const {container} = render(
-			<CheckboxMultipleWithProvider id="CheckboxMultipleId" />
+			<CheckboxMultipleWithProvider
+				label="CheckboxMultipleLabel"
+				name="CheckboxMultiple"
+				tip="Help Text Content"
+			/>
+		);
+
+		const checkboxMultipleLegend = screen.getByText(
+			'CheckboxMultipleLabel'
+		);
+
+		expect(checkboxMultipleLegend).toHaveAttribute(
+			'aria-describedby',
+			'CheckboxMultiple_fieldFeedback'
+		);
+
+		const fieldFeedback = container.querySelector(
+			'#CheckboxMultiple_fieldFeedback'
 		);
 
 		expect(
-			container.querySelector('#CheckboxMultipleId_fieldFeedback')
+			within(fieldFeedback).getByText('Help Text Content')
 		).toBeInTheDocument();
 	});
 
@@ -176,11 +184,13 @@ describe('Field Checkbox Multiple', () => {
 			/>
 		);
 
-		const labelElements = screen.getAllByText('CheckboxMultipleLabel');
+		const checkboxMultipleFieldset = screen.getByRole('group');
 
-		expect(labelElements.length).toBe(2);
-		expect(labelElements[0]).toBeVisible();
-		expect(labelElements[1]).toHaveClass('sr-only');
+		expect(checkboxMultipleFieldset).toBeInTheDocument();
+
+		expect(
+			within(checkboxMultipleFieldset).getByText('CheckboxMultipleLabel')
+		).toBeInTheDocument();
 	});
 
 	it('does not render field label if showLabel is false', () => {
@@ -191,10 +201,9 @@ describe('Field Checkbox Multiple', () => {
 			/>
 		);
 
-		const labelElements = screen.getAllByText('CheckboxMultipleLabel');
+		const labelElement = screen.queryAllByAltText('CheckboxMultipleLabel');
 
-		expect(labelElements.length).toBe(1);
-		expect(labelElements[0]).toHaveClass('sr-only');
+		expect(labelElement.length).toBe(0);
 	});
 
 	it('has a value', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/__snapshots__/CheckboxMultiple.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/__snapshots__/CheckboxMultiple.es.js.snap
@@ -21,7 +21,8 @@ exports[`Smoke test field Checkbox Multiple renders the expected structure with 
             <input
               class="toggle-switch-check"
               data-option-reference="Option1Reference"
-              name="namePropertyValue_0"
+              id="namePropertyValue_Option1"
+              name="namePropertyValue_Option1"
               role="switch"
               type="checkbox"
               value="Option1Value"
@@ -54,7 +55,8 @@ exports[`Smoke test field Checkbox Multiple renders the expected structure with 
             <input
               class="toggle-switch-check"
               data-option-reference="Option2Reference"
-              name="namePropertyValue_1"
+              id="namePropertyValue_Option2"
+              name="namePropertyValue_Option2"
               role="switch"
               type="checkbox"
               value="Option2Value"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/ColorPicker/__snapshots__/ColorPicker.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/ColorPicker/__snapshots__/ColorPicker.es.js.snap
@@ -40,6 +40,7 @@ exports[`Field Color Picker renders field disabled 1`] = `
             aria-label="color-x-selected"
             class="form-control input-group-inset input-group-inset-before"
             disabled=""
+            id="colorPicker"
             type="text"
             value="000000"
           />
@@ -72,7 +73,6 @@ exports[`Field Color Picker renders field disabled 1`] = `
 exports[`Field Color Picker renders field with helptext 1`] = `
 <div>
   <div
-    aria-labelledby="colorPicker_fieldDetails"
     class="form-group hide"
     data-field-name="colorPicker"
   >
@@ -108,6 +108,7 @@ exports[`Field Color Picker renders field with helptext 1`] = `
           <input
             aria-label="color-x-selected"
             class="form-control input-group-inset input-group-inset-before"
+            id="colorPicker"
             type="text"
             value="000000"
           />
@@ -136,12 +137,6 @@ exports[`Field Color Picker renders field with helptext 1`] = `
         Helptext
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="colorPicker_fieldDetails"
-    >
-      Helptext
-    </span>
   </div>
 </div>
 `;
@@ -153,8 +148,9 @@ exports[`Field Color Picker renders field with label 1`] = `
     data-field-name="colorPicker"
   >
     <label
-      aria-labelledby="colorPicker_fieldDetails"
       class="ddm-label"
+      for="colorPicker"
+      id="colorPicker_fieldLabel"
     >
       label
     </label>
@@ -190,6 +186,7 @@ exports[`Field Color Picker renders field with label 1`] = `
           <input
             aria-label="color-x-selected"
             class="form-control input-group-inset input-group-inset-before"
+            id="colorPicker"
             type="text"
             value="000000"
           />
@@ -218,14 +215,6 @@ exports[`Field Color Picker renders field with label 1`] = `
         Helptext
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="colorPicker_fieldDetails"
-    >
-      label
-      <br />
-      Helptext
-    </span>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -40,9 +40,8 @@ describe('DatePicker', () => {
 		render(<DatePicker label="Date picker" />);
 
 		const allByText = screen.getAllByText('Date picker');
-		expect(allByText).toHaveLength(2);
+		expect(allByText).toHaveLength(1);
 		expect(allByText[0]).toBeInTheDocument();
-		expect(allByText[1]).toBeInTheDocument();
 	});
 
 	it('renders the predefined value', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
@@ -3,7 +3,6 @@
 exports[`Field DocumentLibrary has a helptext 1`] = `
 <div>
   <div
-    aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
   >
@@ -46,6 +45,7 @@ exports[`Field DocumentLibrary has a helptext 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -82,14 +82,6 @@ exports[`Field DocumentLibrary has a helptext 1`] = `
         Type something
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-      Type something
-      <br />
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -101,8 +93,9 @@ exports[`Field DocumentLibrary has a label 1`] = `
     data-field-name="uploadField"
   >
     <label
-      aria-labelledby="uploadField_fieldDetails"
       class="ddm-label"
+      for="uploadField"
+      id="uploadField_fieldLabel"
     >
       label
     </label>
@@ -145,6 +138,7 @@ exports[`Field DocumentLibrary has a label 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -178,14 +172,6 @@ exports[`Field DocumentLibrary has a label 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-      label
-      <br />
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -193,7 +179,6 @@ exports[`Field DocumentLibrary has a label 1`] = `
 exports[`Field DocumentLibrary has a placeholder 1`] = `
 <div>
   <div
-    aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
   >
@@ -236,6 +221,7 @@ exports[`Field DocumentLibrary has a placeholder 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         placeholder="Placeholder"
         type="hidden"
@@ -270,12 +256,6 @@ exports[`Field DocumentLibrary has a placeholder 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -283,7 +263,6 @@ exports[`Field DocumentLibrary has a placeholder 1`] = `
 exports[`Field DocumentLibrary has a spritemap 1`] = `
 <div>
   <div
-    aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
   >
@@ -326,6 +305,7 @@ exports[`Field DocumentLibrary has a spritemap 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -359,12 +339,6 @@ exports[`Field DocumentLibrary has a spritemap 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -372,7 +346,6 @@ exports[`Field DocumentLibrary has a spritemap 1`] = `
 exports[`Field DocumentLibrary has a value 1`] = `
 <div>
   <div
-    aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
   >
@@ -415,6 +388,7 @@ exports[`Field DocumentLibrary has a value 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{\\"id\\":\\"123\\"}"
@@ -448,12 +422,6 @@ exports[`Field DocumentLibrary has a value 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -461,7 +429,6 @@ exports[`Field DocumentLibrary has a value 1`] = `
 exports[`Field DocumentLibrary has an id 1`] = `
 <div>
   <div
-    aria-labelledby="ID_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
   >
@@ -489,7 +456,7 @@ exports[`Field DocumentLibrary has an id 1`] = `
           class="input-group-item input-group-append input-group-item-shrink"
         >
           <button
-            aria-describedby="ID_fieldFeedback"
+            aria-describedby="uploadField_fieldFeedback"
             class="select-button btn btn-secondary"
             disabled=""
             id="uploadField"
@@ -504,7 +471,7 @@ exports[`Field DocumentLibrary has an id 1`] = `
         </div>
       </div>
       <input
-        id="ID"
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -517,7 +484,7 @@ exports[`Field DocumentLibrary has an id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="ID_fieldFeedback"
+      id="uploadField_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -538,12 +505,6 @@ exports[`Field DocumentLibrary has an id 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="ID_fieldDetails"
-    >
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -590,6 +551,7 @@ exports[`Field DocumentLibrary is not readOnly 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -616,7 +578,6 @@ exports[`Field DocumentLibrary is not readOnly 1`] = `
 exports[`Field DocumentLibrary is not required 1`] = `
 <div>
   <div
-    aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
   >
@@ -660,6 +621,7 @@ exports[`Field DocumentLibrary is not required 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -693,12 +655,6 @@ exports[`Field DocumentLibrary is not required 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;
@@ -710,8 +666,9 @@ exports[`Field DocumentLibrary renders Label if showLabel is true 1`] = `
     data-field-name="uploadField"
   >
     <label
-      aria-labelledby="uploadField_fieldDetails"
       class="ddm-label"
+      for="uploadField"
+      id="uploadField_fieldLabel"
     >
       text
     </label>
@@ -754,6 +711,7 @@ exports[`Field DocumentLibrary renders Label if showLabel is true 1`] = `
         </div>
       </div>
       <input
+        id="uploadField"
         name="uploadField"
         type="hidden"
         value="{}"
@@ -787,14 +745,6 @@ exports[`Field DocumentLibrary renders Label if showLabel is true 1`] = `
          you-need-to-be-signed-in-to-edit-this-field
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="uploadField_fieldDetails"
-    >
-      text
-      <br />
-       you-need-to-be-signed-in-to-edit-this-field
-    </span>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/ReactFieldBase.es.js
@@ -261,19 +261,29 @@ describe('ReactFieldBase', () => {
 	});
 
 	it('renders the label with info icon and its corresponding styles when the field is non-localizable', () => {
-		const {getByLabelText, getByTitle} = render(
-			<FieldBaseWithProvider
-				editOnlyInDefaultLanguage
-				label="my-label"
-				readOnly
-			/>
+		const {getByLabelText, getByText, getByTitle} = render(
+			<>
+				<FieldBaseWithProvider
+					editOnlyInDefaultLanguage
+					fieldLabelHtmlFor="field-id"
+					label="my-label"
+					readOnly
+					showLabel
+				/>
+				<input id="field-id" />
+				<FieldBaseWithProvider />
+			</>
 		);
 
 		expect(
 			getByTitle('this-field-cannot-be-localized')
 		).toBeInTheDocument();
 
-		expect(getByLabelText('my-label')).toHaveClass('text-muted');
+		const input = getByLabelText('my-label');
+		const label = getByText('my-label');
+
+		expect(input).toBeInTheDocument();
+		expect(label).toHaveClass('text-muted');
 	});
 
 	describe('Hide Field', () => {
@@ -289,16 +299,14 @@ describe('ReactFieldBase', () => {
 			expect(getByText('hidden')).toBeInTheDocument();
 
 			const allByText = getAllByText('Text');
-			expect(allByText).toHaveLength(2);
+			expect(allByText).toHaveLength(1);
 			expect(allByText[0]).toBeInTheDocument();
-			expect(allByText[1]).toBeInTheDocument();
 
 			expect(getByText('hidden').parentNode).toHaveAttribute(
 				'class',
 				'label ml-1 label-secondary'
 			);
 			expect(allByText[0]).toHaveAttribute('class', 'text-secondary');
-			expect(allByText[1]).toHaveAttribute('class', 'sr-only');
 		});
 
 		it('renders the FieldBase with hideField markup when the label is empty', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
@@ -3,7 +3,9 @@
 exports[`ReactFieldBase does not render the add button when repeatable is true and the maximum limit of repetions is reached 1`] = `
 <div>
   <div
+    aria-labelledby="undefined_fieldLabel"
     class="form-group hide"
+    role="group"
   >
     <div
       class="lfr-ddm-form-field-repeatable-toolbar"
@@ -25,8 +27,8 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
       </button>
     </div>
     <label
-      aria-labelledby="undefined_fieldDetails"
       class="ddm-empty ddm-repeatable"
+      id="undefined_fieldLabel"
     />
     <input
       name="undefined_edited"
@@ -42,12 +44,6 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      Text
-    </span>
   </div>
 </div>
 `;
@@ -55,7 +51,6 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
 exports[`ReactFieldBase does not render the label if showLabel is false 1`] = `
 <div>
   <div
-    aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
   >
     <input
@@ -72,12 +67,6 @@ exports[`ReactFieldBase does not render the label if showLabel is false 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      Text
-    </span>
   </div>
 </div>
 `;
@@ -113,7 +102,6 @@ exports[`ReactFieldBase renders the FieldBase with contentRenderer 1`] = `
 exports[`ReactFieldBase renders the FieldBase with help text 1`] = `
 <div>
   <div
-    aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
   >
     <input
@@ -133,12 +121,6 @@ exports[`ReactFieldBase renders the FieldBase with help text 1`] = `
         Type something!
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      Type something!
-    </span>
   </div>
 </div>
 `;
@@ -155,7 +137,7 @@ exports[`ReactFieldBase renders the FieldBase with id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="Id_fieldFeedback"
+      id="undefined_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -172,8 +154,8 @@ exports[`ReactFieldBase renders the FieldBase with label 1`] = `
     class="form-group hide"
   >
     <label
-      aria-labelledby="undefined_fieldDetails"
       class="ddm-label"
+      id="undefined_fieldLabel"
     >
       Text
     </label>
@@ -191,12 +173,6 @@ exports[`ReactFieldBase renders the FieldBase with label 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      Text
-    </span>
   </div>
 </div>
 `;
@@ -207,8 +183,8 @@ exports[`ReactFieldBase renders the FieldBase with required 1`] = `
     class="form-group hide"
   >
     <label
-      aria-labelledby="undefined_fieldDetails"
       class="ddm-label"
+      id="undefined_fieldLabel"
     >
       <span
         class="ddm-label-required reference-mark"
@@ -237,12 +213,6 @@ exports[`ReactFieldBase renders the FieldBase with required 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      required
-    </span>
   </div>
 </div>
 `;
@@ -250,7 +220,9 @@ exports[`ReactFieldBase renders the FieldBase with required 1`] = `
 exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
 <div>
   <div
+    aria-labelledby="undefined_fieldLabel"
     class="form-group hide"
+    role="group"
   >
     <div
       class="lfr-ddm-form-field-repeatable-toolbar"
@@ -272,8 +244,8 @@ exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
       </button>
     </div>
     <label
-      aria-labelledby="undefined_fieldDetails"
       class="ddm-empty ddm-repeatable"
+      id="undefined_fieldLabel"
     />
     <input
       name="undefined_edited"
@@ -289,12 +261,6 @@ exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      Text
-    </span>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/__snapshots__/Grid.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/__snapshots__/Grid.es.js.snap
@@ -5,76 +5,78 @@ exports[`Grid has a label 1`] = `
   <div
     class="form-group hide"
   >
-    <label
-      aria-labelledby="undefined_fieldDetails"
-      class="ddm-label"
-    >
-      label
-    </label>
-    <div
-      class="table-responsive"
-    >
-      <input
-        type="hidden"
-        value=""
-      />
+    <fieldset>
+      <legend
+        class="lfr-ddm-legend"
+        id="undefined_fieldLabel"
+      >
+        label
+      </legend>
       <div
         class="table-responsive"
       >
-        <table
-          class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+        <input
+          type="hidden"
+          value=""
+        />
+        <div
+          class="table-responsive"
         >
-          <thead>
-            <tr
-              class=""
-            >
-              <th
-                class=""
-              />
-              <th
+          <table
+            class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+          >
+            <thead>
+              <tr
                 class=""
               >
-                col1
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              class=""
-              name="jehf"
-            >
-              <td
-                class=""
-              >
-                row
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="custom-control custom-radio"
+                <th
+                  class=""
+                />
+                <th
+                  class=""
                 >
-                  <label>
-                    <input
-                      aria-label="row: row, column: col1"
-                      class="custom-control-input form-builder-grid-field"
-                      data-name="jehf"
-                      name="undefined_jehf"
-                      role="radio"
-                      type="radio"
-                      value="fieldId"
-                    />
-                    <span
-                      class="custom-control-label"
-                    />
-                  </label>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                  col1
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class=""
+                name="jehf"
+              >
+                <td
+                  class=""
+                >
+                  row
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="custom-control custom-radio"
+                  >
+                    <label>
+                      <input
+                        aria-label="row: row, column: col1"
+                        class="custom-control-input form-builder-grid-field"
+                        data-name="jehf"
+                        name="undefined_jehf"
+                        role="radio"
+                        type="radio"
+                        value="fieldId"
+                      />
+                      <span
+                        class="custom-control-label"
+                      />
+                    </label>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    </fieldset>
     <input
       name="undefined_edited"
       type="hidden"
@@ -89,12 +91,6 @@ exports[`Grid has a label 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      label
-    </span>
   </div>
 </div>
 `;
@@ -102,7 +98,6 @@ exports[`Grid has a label 1`] = `
 exports[`Grid has a tip 1`] = `
 <div>
   <div
-    aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
   >
     <div
@@ -186,12 +181,6 @@ exports[`Grid has a tip 1`] = `
         Type something
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      Type something
-    </span>
   </div>
 </div>
 `;
@@ -272,7 +261,7 @@ exports[`Grid has an id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="Id_fieldFeedback"
+      id="undefined_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -460,76 +449,78 @@ exports[`Grid renders Label if showLabel is true 1`] = `
   <div
     class="form-group hide"
   >
-    <label
-      aria-labelledby="undefined_fieldDetails"
-      class="ddm-label"
-    >
-      text
-    </label>
-    <div
-      class="table-responsive"
-    >
-      <input
-        type="hidden"
-        value=""
-      />
+    <fieldset>
+      <legend
+        class="lfr-ddm-legend"
+        id="undefined_fieldLabel"
+      >
+        text
+      </legend>
       <div
         class="table-responsive"
       >
-        <table
-          class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+        <input
+          type="hidden"
+          value=""
+        />
+        <div
+          class="table-responsive"
         >
-          <thead>
-            <tr
-              class=""
-            >
-              <th
-                class=""
-              />
-              <th
+          <table
+            class="table table-autofit show-quick-actions-on-hover table-hover table-list table-head-bordered table-striped"
+          >
+            <thead>
+              <tr
                 class=""
               >
-                col1
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              class=""
-              name="jehf"
-            >
-              <td
-                class=""
-              >
-                row
-              </td>
-              <td
-                class=""
-              >
-                <div
-                  class="custom-control custom-radio"
+                <th
+                  class=""
+                />
+                <th
+                  class=""
                 >
-                  <label>
-                    <input
-                      aria-label="row: row, column: col1"
-                      class="custom-control-input form-builder-grid-field"
-                      data-name="jehf"
-                      name="undefined_jehf"
-                      role="radio"
-                      type="radio"
-                      value="fieldId"
-                    />
-                    <span
-                      class="custom-control-label"
-                    />
-                  </label>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                  col1
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class=""
+                name="jehf"
+              >
+                <td
+                  class=""
+                >
+                  row
+                </td>
+                <td
+                  class=""
+                >
+                  <div
+                    class="custom-control custom-radio"
+                  >
+                    <label>
+                      <input
+                        aria-label="row: row, column: col1"
+                        class="custom-control-input form-builder-grid-field"
+                        data-name="jehf"
+                        name="undefined_jehf"
+                        role="radio"
+                        type="radio"
+                        value="fieldId"
+                      />
+                      <span
+                        class="custom-control-label"
+                      />
+                    </label>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    </fieldset>
     <input
       name="undefined_edited"
       type="hidden"
@@ -544,12 +535,6 @@ exports[`Grid renders Label if showLabel is true 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="undefined_fieldDetails"
-    >
-      text
-    </span>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/OptionFieldKeyValue.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/OptionFieldKeyValue.js.snap
@@ -56,7 +56,6 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
           display-name
         </label>
         <div
-          aria-labelledby="OptionFieldKeyValue_fieldDetails"
           class="form-group hide"
           data-field-name="OptionFieldKeyValue"
         >
@@ -108,12 +107,6 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
               Type something
             </div>
           </div>
-          <span
-            class="sr-only"
-            id="OptionFieldKeyValue_fieldDetails"
-          >
-            Type something
-          </span>
         </div>
         <label
           class="mt-3"
@@ -122,7 +115,6 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
           option-reference
         </label>
         <div
-          aria-labelledby="undefined_fieldDetails"
           class="form-group hide"
         >
           <div
@@ -173,12 +165,6 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
               Type something
             </div>
           </div>
-          <span
-            class="sr-only"
-            id="undefined_fieldDetails"
-          >
-            Type something
-          </span>
         </div>
       </div>
     </div>
@@ -246,8 +232,8 @@ exports[`OptionFieldKeyValue has a label 1`] = `
           data-field-name="OptionFieldKeyValue"
         >
           <label
-            aria-labelledby="OptionFieldKeyValue_fieldDetails"
             class="ddm-label"
+            id="OptionFieldKeyValue_fieldLabel"
           >
             label
           </label>
@@ -296,12 +282,6 @@ exports[`OptionFieldKeyValue has a label 1`] = `
               class="form-feedback-item"
             />
           </div>
-          <span
-            class="sr-only"
-            id="OptionFieldKeyValue_fieldDetails"
-          >
-            label
-          </span>
         </div>
         <label
           class="mt-3"
@@ -313,8 +293,8 @@ exports[`OptionFieldKeyValue has a label 1`] = `
           class="form-group hide"
         >
           <label
-            aria-labelledby="undefined_fieldDetails"
             class="ddm-label"
+            id="undefined_fieldLabel"
           >
             label
           </label>
@@ -363,12 +343,6 @@ exports[`OptionFieldKeyValue has a label 1`] = `
               class="form-feedback-item"
             />
           </div>
-          <span
-            class="sr-only"
-            id="undefined_fieldDetails"
-          >
-            label
-          </span>
         </div>
       </div>
     </div>
@@ -808,7 +782,7 @@ exports[`OptionFieldKeyValue has an id 1`] = `
           />
           <div
             class="form-feedback-group field-feedback"
-            id="Id_fieldFeedback"
+            id="OptionFieldKeyValue_fieldFeedback"
           >
             <div
               aria-live="assertive"
@@ -863,7 +837,7 @@ exports[`OptionFieldKeyValue has an id 1`] = `
           />
           <div
             class="form-feedback-group field-feedback"
-            id="Id_fieldFeedback"
+            id="undefined_fieldFeedback"
           >
             <div
               aria-live="assertive"
@@ -1271,8 +1245,8 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
           data-field-name="OptionFieldKeyValue"
         >
           <label
-            aria-labelledby="OptionFieldKeyValue_fieldDetails"
             class="ddm-label"
+            id="OptionFieldKeyValue_fieldLabel"
           >
             text
           </label>
@@ -1321,12 +1295,6 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
               class="form-feedback-item"
             />
           </div>
-          <span
-            class="sr-only"
-            id="OptionFieldKeyValue_fieldDetails"
-          >
-            text
-          </span>
         </div>
         <label
           class="mt-3"
@@ -1338,8 +1306,8 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
           class="form-group hide"
         >
           <label
-            aria-labelledby="undefined_fieldDetails"
             class="ddm-label"
+            id="undefined_fieldLabel"
           >
             text
           </label>
@@ -1388,12 +1356,6 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
               class="form-feedback-item"
             />
           </div>
-          <span
-            class="sr-only"
-            id="undefined_fieldDetails"
-          >
-            text
-          </span>
         </div>
       </div>
     </div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/__snapshots__/LocalizableText.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/__snapshots__/LocalizableText.es.js.snap
@@ -22,6 +22,7 @@ exports[`Field LocalizableText adds a new translation for an untranslated item 1
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\",\\"ja_JP\\":\\"Test JP\\"}"
@@ -751,6 +752,7 @@ exports[`Field LocalizableText emits field edit event on field change 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test 2 EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -1478,6 +1480,7 @@ exports[`Field LocalizableText fills with the default language value when the se
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -2206,6 +2209,7 @@ exports[`Field LocalizableText fills with the selected language value when the s
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -2919,8 +2923,8 @@ exports[`Field LocalizableText has a label 1`] = `
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
   >
     <label
-      aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
       class="ddm-label"
+      id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldLabel"
     >
       label
     </label>
@@ -2941,6 +2945,7 @@ exports[`Field LocalizableText has a label 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -3642,12 +3647,6 @@ exports[`Field LocalizableText has a label 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
-    >
-      label
-    </span>
   </div>
 </div>
 `;
@@ -3675,6 +3674,7 @@ exports[`Field LocalizableText has a placeholder 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -4403,6 +4403,7 @@ exports[`Field LocalizableText is not readOnly 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -5131,6 +5132,7 @@ exports[`Field LocalizableText is not required 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -5858,6 +5860,7 @@ exports[`Field LocalizableText removes the translation of an item already transl
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"\\"}"
@@ -6587,6 +6590,7 @@ exports[`Field LocalizableText renders no values when values come empty 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{}"
@@ -7315,6 +7319,7 @@ exports[`Field LocalizableText renders values 1`] = `
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"
@@ -8043,6 +8048,7 @@ exports[`Field LocalizableText shows default language value when no other langua
         />
       </div>
       <input
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
         type="hidden"
         value="{\\"ca_ES\\":\\"Teste ES\\",\\"en_US\\":\\"Test EUA\\",\\"pt_BR\\":\\"Teste BR\\"}"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/Numeric.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/Numeric.js
@@ -77,21 +77,12 @@ describe('Field Numeric', () => {
 		expect(getAllByText('Type something')[0]).toBeInTheDocument();
 	});
 
-	it('has an id', () => {
-		const {container} = render(<Numeric id="ID" />);
-
-		const input = container.querySelector('input');
-
-		expect(input).toHaveAttribute('id', 'ID');
-	});
-
 	it('has a label', () => {
 		const {getAllByText} = render(<Numeric label="label" />);
 
 		const allByText = getAllByText(/label/);
-		expect(allByText).toHaveLength(2);
+		expect(allByText).toHaveLength(1);
 		expect(allByText[0]).toBeInTheDocument();
-		expect(allByText[1]).toBeInTheDocument();
 	});
 
 	it('has a placeholder', () => {
@@ -103,9 +94,12 @@ describe('Field Numeric', () => {
 	});
 
 	it('is required', () => {
-		const {getByText} = render(<Numeric required />);
+		const {getByRole} = render(<Numeric required />);
 
-		expect(getByText(/required/)).toBeInTheDocument();
+		const input = getByRole('textbox');
+
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute('aria-required', 'true');
 	});
 
 	it('renders Label if showLabel is true', () => {
@@ -114,9 +108,8 @@ describe('Field Numeric', () => {
 		);
 
 		const allByText = getAllByText(/Numeric Field/);
-		expect(allByText).toHaveLength(2);
+		expect(allByText).toHaveLength(1);
 		expect(allByText[0]).toHaveClass('ddm-label');
-		expect(allByText[1]).toHaveClass('sr-only');
 	});
 
 	it('has a value', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
@@ -38,20 +38,22 @@ exports[`Field Paragraph has a label 1`] = `
     class="form-group hide"
     data-field-name="textField"
   >
-    <label
-      aria-labelledby="textField_fieldDetails"
-      class="ddm-label"
-    >
-      label
-    </label>
-    <div
-      class="form-group liferay-ddm-form-field-paragraph"
-      data-field-name="textField"
-    >
+    <fieldset>
+      <legend
+        class="lfr-ddm-legend"
+        id="textField_fieldLabel"
+      >
+        label
+      </legend>
       <div
-        class="liferay-ddm-form-field-paragraph-text"
-      />
-    </div>
+        class="form-group liferay-ddm-form-field-paragraph"
+        data-field-name="textField"
+      >
+        <div
+          class="liferay-ddm-form-field-paragraph-text"
+        />
+      </div>
+    </fieldset>
     <input
       name="textField_edited"
       type="hidden"
@@ -66,12 +68,6 @@ exports[`Field Paragraph has a label 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="textField_fieldDetails"
-    >
-      label
-    </span>
   </div>
 </div>
 `;
@@ -161,7 +157,7 @@ exports[`Field Paragraph has an id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="Id_fieldFeedback"
+      id="textField_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -242,20 +238,22 @@ exports[`Field Paragraph renders Label if showLabel is true 1`] = `
     class="form-group hide"
     data-field-name="textField"
   >
-    <label
-      aria-labelledby="textField_fieldDetails"
-      class="ddm-label"
-    >
-      text
-    </label>
-    <div
-      class="form-group liferay-ddm-form-field-paragraph"
-      data-field-name="textField"
-    >
+    <fieldset>
+      <legend
+        class="lfr-ddm-legend"
+        id="textField_fieldLabel"
+      >
+        text
+      </legend>
       <div
-        class="liferay-ddm-form-field-paragraph-text"
-      />
-    </div>
+        class="form-group liferay-ddm-form-field-paragraph"
+        data-field-name="textField"
+      >
+        <div
+          class="liferay-ddm-form-field-paragraph-text"
+        />
+      </div>
+    </fieldset>
     <input
       name="textField_edited"
       type="hidden"
@@ -270,12 +268,6 @@ exports[`Field Paragraph renders Label if showLabel is true 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="textField_fieldDetails"
-    >
-      text
-    </span>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
@@ -3,7 +3,6 @@
 exports[`Field Radio has a helptext 1`] = `
 <div>
   <div
-    aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
   >
@@ -85,12 +84,6 @@ exports[`Field Radio has a helptext 1`] = `
         Type something
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="radioField_fieldDetails"
-    >
-      Type something
-    </span>
   </div>
 </div>
 `;
@@ -101,71 +94,73 @@ exports[`Field Radio has a label 1`] = `
     class="form-group hide"
     data-field-name="radioField"
   >
-    <label
-      aria-labelledby="radioField_fieldDetails"
-      class="ddm-label"
-    >
-      label
-    </label>
-    <div
-      class="ddm__radio"
-    >
+    <fieldset>
+      <legend
+        class="lfr-ddm-legend"
+        id="radioField_fieldLabel"
+      >
+        label
+      </legend>
       <div
-        class=""
+        class="ddm__radio"
       >
         <div
-          class="custom-control custom-radio custom-control-outside"
-          data-checked="false"
+          class=""
         >
-          <label>
-            <input
-              class="custom-control-input"
-              name="radioField"
-              role="radio"
-              type="radio"
-              value="option1"
-            />
-            <span
-              class="custom-control-label"
-            >
+          <div
+            class="custom-control custom-radio custom-control-outside"
+            data-checked="false"
+          >
+            <label>
+              <input
+                class="custom-control-input"
+                name="radioField"
+                role="radio"
+                type="radio"
+                value="option1"
+              />
               <span
-                class="custom-control-label-text"
+                class="custom-control-label"
               >
-                Option 1
+                <span
+                  class="custom-control-label-text"
+                >
+                  Option 1
+                </span>
               </span>
-            </span>
-          </label>
-        </div>
-        <div
-          class="custom-control custom-radio custom-control-outside"
-          data-checked="false"
-        >
-          <label>
-            <input
-              class="custom-control-input"
-              name="radioField"
-              role="radio"
-              type="radio"
-              value="option2"
-            />
-            <span
-              class="custom-control-label"
-            >
+            </label>
+          </div>
+          <div
+            class="custom-control custom-radio custom-control-outside"
+            data-checked="false"
+          >
+            <label>
+              <input
+                class="custom-control-input"
+                name="radioField"
+                role="radio"
+                type="radio"
+                value="option2"
+              />
               <span
-                class="custom-control-label-text"
+                class="custom-control-label"
               >
-                Option 2
+                <span
+                  class="custom-control-label-text"
+                >
+                  Option 2
+                </span>
               </span>
-            </span>
-          </label>
+            </label>
+          </div>
         </div>
       </div>
-    </div>
-    <input
-      name="radioField"
-      type="hidden"
-      value=""
-    />
+      <input
+        name="radioField"
+        type="hidden"
+        value=""
+      />
+    </fieldset>
     <input
       name="radioField_edited"
       type="hidden"
@@ -180,12 +175,6 @@ exports[`Field Radio has a label 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="radioField_fieldDetails"
-    >
-      label
-    </span>
   </div>
 </div>
 `;
@@ -428,7 +417,7 @@ exports[`Field Radio has an id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="Id_fieldFeedback"
+      id="radioField_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -615,71 +604,73 @@ exports[`Field Radio renders Label if showLabel is true 1`] = `
     class="form-group hide"
     data-field-name="radioField"
   >
-    <label
-      aria-labelledby="radioField_fieldDetails"
-      class="ddm-label"
-    >
-      text
-    </label>
-    <div
-      class="ddm__radio"
-    >
+    <fieldset>
+      <legend
+        class="lfr-ddm-legend"
+        id="radioField_fieldLabel"
+      >
+        text
+      </legend>
       <div
-        class=""
+        class="ddm__radio"
       >
         <div
-          class="custom-control custom-radio custom-control-outside"
-          data-checked="false"
+          class=""
         >
-          <label>
-            <input
-              class="custom-control-input"
-              name="radioField"
-              role="radio"
-              type="radio"
-              value="option1"
-            />
-            <span
-              class="custom-control-label"
-            >
+          <div
+            class="custom-control custom-radio custom-control-outside"
+            data-checked="false"
+          >
+            <label>
+              <input
+                class="custom-control-input"
+                name="radioField"
+                role="radio"
+                type="radio"
+                value="option1"
+              />
               <span
-                class="custom-control-label-text"
+                class="custom-control-label"
               >
-                Option 1
+                <span
+                  class="custom-control-label-text"
+                >
+                  Option 1
+                </span>
               </span>
-            </span>
-          </label>
-        </div>
-        <div
-          class="custom-control custom-radio custom-control-outside"
-          data-checked="false"
-        >
-          <label>
-            <input
-              class="custom-control-input"
-              name="radioField"
-              role="radio"
-              type="radio"
-              value="option2"
-            />
-            <span
-              class="custom-control-label"
-            >
+            </label>
+          </div>
+          <div
+            class="custom-control custom-radio custom-control-outside"
+            data-checked="false"
+          >
+            <label>
+              <input
+                class="custom-control-input"
+                name="radioField"
+                role="radio"
+                type="radio"
+                value="option2"
+              />
               <span
-                class="custom-control-label-text"
+                class="custom-control-label"
               >
-                Option 2
+                <span
+                  class="custom-control-label-text"
+                >
+                  Option 2
+                </span>
               </span>
-            </span>
-          </label>
+            </label>
+          </div>
         </div>
       </div>
-    </div>
-    <input
-      name="radioField"
-      type="hidden"
-      value=""
-    />
+      <input
+        name="radioField"
+        type="hidden"
+        value=""
+      />
+    </fieldset>
     <input
       name="radioField_edited"
       type="hidden"
@@ -694,12 +685,6 @@ exports[`Field Radio renders Label if showLabel is true 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="radioField_fieldDetails"
-    >
-      text
-    </span>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
@@ -3,7 +3,6 @@
 exports[`Field Text has a helptext 1`] = `
 <div>
   <div
-    aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
   >
@@ -37,12 +36,6 @@ exports[`Field Text has a helptext 1`] = `
         Type something
       </div>
     </div>
-    <span
-      class="sr-only"
-      id="textField_fieldDetails"
-    >
-      Type something
-    </span>
   </div>
 </div>
 `;
@@ -54,8 +47,9 @@ exports[`Field Text has a label 1`] = `
     data-field-name="textField"
   >
     <label
-      aria-labelledby="textField_fieldDetails"
       class="ddm-label"
+      for="textField"
+      id="textField_fieldLabel"
     >
       label
     </label>
@@ -85,12 +79,6 @@ exports[`Field Text has a label 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="textField_fieldDetails"
-    >
-      label
-    </span>
   </div>
 </div>
 `;
@@ -182,7 +170,7 @@ exports[`Field Text has an id 1`] = `
       <input
         aria-invalid="true"
         class="form-control ddm-field-text"
-        id="Id"
+        id="textField"
         name="textField"
         type="text"
         value=""
@@ -195,7 +183,7 @@ exports[`Field Text has an id 1`] = `
     />
     <div
       class="form-feedback-group field-feedback"
-      id="Id_fieldFeedback"
+      id="textField_fieldFeedback"
     >
       <div
         aria-live="assertive"
@@ -323,8 +311,9 @@ exports[`Field Text renders Label if showLabel is true 1`] = `
     data-field-name="textField"
   >
     <label
-      aria-labelledby="textField_fieldDetails"
       class="ddm-label"
+      for="textField"
+      id="textField_fieldLabel"
     >
       text
     </label>
@@ -354,12 +343,6 @@ exports[`Field Text renders Label if showLabel is true 1`] = `
         class="form-feedback-item"
       />
     </div>
-    <span
-      class="sr-only"
-      id="textField_fieldDetails"
-    >
-      text
-    </span>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Form Field Optimizations Summary

We've focused on improving form field usability and accessibility, leading to cleaner and more maintainable code. Key changes include:

### 1. Simplified Label Association

**Goal:** Reduced complexity by favoring `htmlFor` over dynamic `aria-labelledby`, following W3C recommendations for explicit `<label>` association.

https://www.w3.org/WAI/tutorials/forms/labels/

![image](https://github.com/user-attachments/assets/72e21ba2-6ecb-49f8-b77b-03529633ccad)


### 2. Delegated `htmlFor` Responsibility

**Goal:** Moved `htmlFor` application to individual field components using `reactFieldBase`, introducing `fieldLabelHtmlFor` for flexible label assignments across diverse field types.

### 3. Parameterized `showGroup`

**Goal:** Eliminated the need for `reactFieldBase` to perform internal type checks, making it more generic and reusable.

### 4. Removed `fieldDetails` from `reactFieldBase`

**Goal:** Streamlined `reactFieldBase` by removing `fieldDetails`, as most information was already handled (e.g., `aria-describedby`, `htmlFor`, `aria-required`). The `text` parameter requires further investigation for safe removal.

### 5. Grouped Repeat Buttons

**Goal:** Enhanced user context by visually grouping repeat buttons with their associated fields for better understanding.

### 6. Semantic Grouping with `<fieldset>` and `<legend>`

**Goal:** Corrected the semantic structure of grouped fields (e.g., checkbox multiples, radio groups) by replacing incorrect `<label>` usage with `<fieldset>` and `<legend>` as per W3C guidelines, improving accessibility.

https://www.w3.org/WAI/tutorials/forms/grouping/

![image](https://github.com/user-attachments/assets/c92141cd-7dda-4f0a-b5ac-c9275057a93d)