### PR TITLE
LPD-60826 Improve performance when creating the selected array in ViewBuilderScreen

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ViewBuilderScreen/ViewBuilderScreen.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectView/ViewBuilderScreen/ViewBuilderScreen.tsx
@@ -33,11 +33,16 @@ const ViewBuilderScreen: React.FC<
 		dispatch,
 	] = useViewContext();
 
-	const selected = objectViewColumns.map((objectViewColumn) => {
-		return objectFields.find(
-			(objectField) =>
-				objectViewColumn.objectFieldName === objectField.name
-		);
+	const objectFieldsMap = new Map();
+
+	objectFields.forEach((field) => {
+		objectFieldsMap.set(field.name, field);
+	});
+
+	const selected = objectViewColumns.map((column) => {
+		if (objectFieldsMap.has(column.objectFieldName)) {
+			return objectFieldsMap.get(column.objectFieldName);
+		}
 	});
 
 	const handleAddColumns = () => {


### PR DESCRIPTION
related ticket: https://liferay.atlassian.net/browse/LPD-60826

hi reviewer! :cherry_blossom: 

this is a follow-up from this previous PR (https://github.com/liferay-bpm/liferay-portal/pull/4765)  to improve the performance when creating the selected array.

the change i'm proposing is to change this code:

```
const selected = objectViewColumns.map((objectViewColumn) => {
		return objectFields.find(
			(objectField) =>
				objectViewColumn.objectFieldName === objectField.name
		);
	});
```
into this:

```
const objectFieldsMap = new Map();

	objectFields.forEach((field) => {
		objectFieldsMap.set(field.name, field);
	});

	const selected = objectViewColumns.map((column) => {
		if (objectFieldsMap.has(column.objectFieldName)) {
			return objectFieldsMap.get(column.objectFieldName);
		}
	});
```

on the new approach, we would be calling the `forEach` function `n` times (the size of `objectFields`) and the `map` function `m` times (the size of `objectViewColumns`), so the time complexity would be `O(n + m)`.

on the previous approach, the time complexity is `O(n * m)` since the `find` function is inside the map.

imagine that the client has 50 fields and 20 columns:

- old approach: 50 * 20: 1000 calls at the worst case
- new approach: 50 + 20: 70 calls at the worst case

this is why i'm suggesting this change, let me know if you have any concerns about this; thanks a lot!