### PR TITLE
LPD-61464 | Create a mapper for ObjectDefinitionEnableObjectEntryScheduleException

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectDefinitionEnableObjectEntryScheduleExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectDefinitionEnableObjectEntryScheduleExceptionMapper.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectDefinitionEnableObjectEntryScheduleException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import jakarta.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.ObjectDefinitionEnableObjectEntryScheduleExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectDefinitionEnableObjectEntryScheduleExceptionMapper
+	extends BaseExceptionMapper
+		<ObjectDefinitionEnableObjectEntryScheduleException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectDefinitionEnableObjectEntryScheduleException
+			objectDefinitionEnableObjectEntryScheduleException) {
+
+		return new Problem(objectDefinitionEnableObjectEntryScheduleException);
+	}
+
+}


### PR DESCRIPTION
related [LPD-61464](https://liferay.atlassian.net/browse/LPD-61464)

[LPD-61464]: https://liferay.atlassian.net/browse/LPD-61464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ