### PR TITLE
LPD-61566 Cache related object entries on first execution to reduce database calls for one-to-many relationships

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/display/context/CommerceReturnContentDisplayContext.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/display/context/CommerceReturnContentDisplayContext.java
@@ -828,8 +828,8 @@ public class CommerceReturnContentDisplayContext {
 					objectEntry.getGroupId(),
 					commerceReturnToCommerceReturnItems.
 						getObjectRelationshipId(),
-					commerceReturn.getId(), true, null, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS),
+					new Long[] {commerceReturn.getId()}, true, null,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
 				curObjectEntry -> {
 					Map<String, Serializable> values =
 						curObjectEntry.getValues();

--- a/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/display/context/CommerceReturnEditDisplayContext.java
+++ b/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/display/context/CommerceReturnEditDisplayContext.java
@@ -682,8 +682,8 @@ public class CommerceReturnEditDisplayContext {
 		return _objectEntryLocalService.getOneToManyObjectEntries(
 			objectEntry.getGroupId(),
 			objectRelationship.getObjectRelationshipId(),
-			objectEntry.getObjectEntryId(), true, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			new Long[] {objectEntry.getObjectEntryId()}, true, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 	}
 
 	private boolean _hasStatusCompleted() throws Exception {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/contributor/CommerceReturnObjectEntryValuesContributor.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/contributor/CommerceReturnObjectEntryValuesContributor.java
@@ -134,7 +134,7 @@ public class CommerceReturnObjectEntryValuesContributor
 					originalObjectEntry.getObjectDefinitionId(),
 					"commerceReturnToCommerceReturnItems"
 				).getObjectRelationshipId(),
-				originalObjectEntry.getObjectEntryId(), true, null,
+				new Long[] {originalObjectEntry.getObjectEntryId()}, true, null,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Map<String, List<ObjectEntry>> returnItemStatusObjectEntriesMap =

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/related/models/DeleteOnDisassociateObjectRelatedModelsProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/related/models/DeleteOnDisassociateObjectRelatedModelsProvider.java
@@ -89,22 +89,22 @@ public class DeleteOnDisassociateObjectRelatedModelsProvider
 
 	@Override
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
 		return _objectRelatedModelsProvider.getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, search, start, end);
+			groupId, objectRelationshipId, primaryKeys, search, start, end);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException {
 
 		return _objectRelatedModelsProvider.getRelatedModelsCount(
-			groupId, objectRelationshipId, primaryKey, search);
+			groupId, objectRelationshipId, primaryKeys, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsProvider.java
@@ -42,12 +42,12 @@ public interface ObjectRelatedModelsProvider<T extends BaseModel<T>> {
 	public String getObjectRelationshipType();
 
 	public List<T> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException;
 
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -289,13 +289,13 @@ public interface ObjectEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException;
 
@@ -410,13 +410,13 @@ public interface ObjectEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -362,22 +362,22 @@ public class ObjectEntryLocalServiceUtil {
 	}
 
 	public static List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
 		return getService().getManyToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, reverse, search,
-			start, end);
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
 	}
 
 	public static int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		return getService().getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -529,22 +529,22 @@ public class ObjectEntryLocalServiceUtil {
 	}
 
 	public static List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
 			end);
 	}
 
 	public static int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	public static ObjectEntry getOrAddEmptyObjectEntry(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -409,24 +409,24 @@ public class ObjectEntryLocalServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getManyToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
 				boolean related, boolean reverse, String search, int start,
 				int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getManyToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, reverse, search,
-			start, end);
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
 	}
 
 	@Override
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -606,23 +606,23 @@ public class ObjectEntryLocalServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
 				boolean related, String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
 			end);
 	}
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -83,13 +83,13 @@ public interface ObjectEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException;
 
@@ -109,13 +109,13 @@ public interface ObjectEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -93,22 +93,22 @@ public class ObjectEntryServiceUtil {
 	}
 
 	public static List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
 		return getService().getManyToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, reverse, search,
-			start, end);
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
 	}
 
 	public static int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		return getService().getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -135,22 +135,22 @@ public class ObjectEntryServiceUtil {
 	}
 
 	public static List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
 			end);
 	}
 
 	public static int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -98,24 +98,24 @@ public class ObjectEntryServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getManyToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
 				boolean related, boolean reverse, String search, int start,
 				int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getManyToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, reverse, search,
-			start, end);
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
 	}
 
 	@Override
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -149,23 +149,23 @@ public class ObjectEntryServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
 				boolean related, String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
 			end);
 	}
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	/**

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectEntryTreeFactory.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectEntryTreeFactory.java
@@ -49,8 +49,9 @@ public class ObjectEntryTreeFactory extends BaseTreeFactory {
 							_objectEntryLocalService.getOneToManyObjectEntries(
 								parentObjectEntry.getGroupId(),
 								objectRelationship.getObjectRelationshipId(),
-								parentObjectEntry.getPrimaryKey(), true, null,
-								QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+								new Long[] {parentObjectEntry.getPrimaryKey()},
+								true, null, QueryUtil.ALL_POS,
+								QueryUtil.ALL_POS),
 							objectEntry -> new Node(
 								new Edge(
 									objectRelationship.

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -882,6 +882,14 @@ public class ObjectEntryDTOConverter
 				ObjectDefinition objectDefinition, long primaryKey)
 		throws Exception {
 
+		Map<String, Map<Long, List<com.liferay.object.model.ObjectEntry>>>
+			objectRelationshipRelatedObjectEntriesMap =
+				(Map
+					<String,
+					 Map<Long, List<com.liferay.object.model.ObjectEntry>>>)
+						 dtoConverterContext.getAttribute(
+							 "objectRelationshipRelatedObjectEntriesMap");
+
 		return NestedFieldsSupplier.supplyUnsafeSupplier(
 			nestedFieldName -> {
 				ObjectRelationship objectRelationship =
@@ -921,11 +929,27 @@ public class ObjectEntryDTOConverter
 					relatedObjectDefinitionGroupId = 0;
 				}
 
-				List<?> relatedModels =
-					objectRelatedModelsProvider.getRelatedModels(
-						relatedObjectDefinitionGroupId,
-						objectRelationship.getObjectRelationshipId(),
-						primaryKey, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				List<?> relatedModels;
+
+				if ((objectRelationshipRelatedObjectEntriesMap != null) &&
+					objectRelationshipRelatedObjectEntriesMap.containsKey(
+						objectRelationship.getName())) {
+
+					Map<Long, List<com.liferay.object.model.ObjectEntry>>
+						relatedObjectEntriesMap =
+							objectRelationshipRelatedObjectEntriesMap.get(
+								objectRelationship.getName());
+
+					relatedModels = relatedObjectEntriesMap.get(primaryKey);
+				}
+				else {
+					relatedModels =
+						objectRelatedModelsProvider.getRelatedModels(
+							relatedObjectDefinitionGroupId,
+							objectRelationship.getObjectRelationshipId(),
+							new Long[] {primaryKey}, null, QueryUtil.ALL_POS,
+							QueryUtil.ALL_POS);
+				}
 
 				if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 					SystemObjectDefinitionManager

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -634,6 +634,22 @@ public class DefaultObjectEntryManagerImpl
 			groupIds = new Long[] {groupId};
 		}
 
+		List<Long> primaryKeys = objectEntryLocalService.getPrimaryKeys(
+			groupIds, companyId, dtoConverterContext.getUserId(),
+			objectDefinition.getObjectDefinitionId(), predicate, search, start,
+			end, sorts);
+
+		Map<String, Map<Long, List<com.liferay.object.model.ObjectEntry>>>
+			objectRelationshipRelatedObjectEntriesMap = new HashMap<>();
+
+		_populateObjectRelationshipRelatedObjectEntriesMap(
+			groupId, objectDefinition,
+			objectRelationshipRelatedObjectEntriesMap, primaryKeys);
+
+		dtoConverterContext.setAttribute(
+			"objectRelationshipRelatedObjectEntriesMap",
+			objectRelationshipRelatedObjectEntriesMap);
+
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -674,10 +690,7 @@ public class DefaultObjectEntryManagerImpl
 			).build(),
 			facets,
 			TransformUtil.transform(
-				objectEntryLocalService.getPrimaryKeys(
-					groupIds, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(), predicate, search,
-					start, end, sorts),
+				primaryKeys,
 				primaryKey -> _getObjectEntry(
 					dtoConverterContext, objectDefinition, primaryKey)),
 			pagination,
@@ -2235,6 +2248,101 @@ public class DefaultObjectEntryManagerImpl
 		return false;
 	}
 
+	private void _populateObjectRelationshipRelatedObjectEntriesMap(
+			long groupId, ObjectDefinition objectDefinition,
+			Map<String, Map<Long, List<com.liferay.object.model.ObjectEntry>>>
+				objectRelationshipRelatedObjectEntriesMap,
+			List<Long> primaryKeys)
+		throws Exception {
+
+		if (primaryKeys.isEmpty()) {
+			return;
+		}
+
+		NestedFieldsSupplier.supplyUnsafeSupplier(
+			nestedFieldName -> {
+				ObjectRelationship objectRelationship =
+					_objectRelationshipLocalService.
+						fetchObjectRelationshipByObjectDefinitionId1(
+							objectDefinition.getObjectDefinitionId(),
+							nestedFieldName);
+
+				if ((objectRelationship == null) ||
+					!objectRelationship.isAllowedObjectRelationshipType(
+						objectRelationship.getType())) {
+
+					return null;
+				}
+
+				ObjectDefinition relatedObjectDefinition =
+					_objectDefinitionLocalService.getObjectDefinition(
+						objectRelationship.getObjectDefinitionId2());
+
+				if (!relatedObjectDefinition.isActive() ||
+					!Objects.equals(
+						objectRelationship.getType(),
+						ObjectRelationshipConstants.TYPE_ONE_TO_MANY) ||
+					relatedObjectDefinition.isUnmodifiableSystemObject()) {
+
+					return null;
+				}
+
+				ObjectRelatedModelsProvider objectRelatedModelsProvider =
+					_objectRelatedModelsProviderRegistry.
+						getObjectRelatedModelsProvider(
+							relatedObjectDefinition.getClassName(),
+							relatedObjectDefinition.getCompanyId(),
+							objectRelationship.getType());
+
+				long relatedObjectDefinitionGroupId = groupId;
+
+				if (Objects.equals(
+						relatedObjectDefinition.getScope(),
+						ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+					relatedObjectDefinitionGroupId = 0;
+				}
+
+				List<com.liferay.object.model.ObjectEntry> objectEntries =
+					objectRelatedModelsProvider.getRelatedModels(
+						relatedObjectDefinitionGroupId,
+						objectRelationship.getObjectRelationshipId(),
+						primaryKeys.toArray(new Long[0]), null,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+				ObjectField relationshipObjectField =
+					_objectFieldLocalService.fetchObjectField(
+						objectRelationship.getObjectFieldId2());
+
+				Map<Long, List<com.liferay.object.model.ObjectEntry>>
+					relatedObjectEntriesMap = new HashMap<>();
+
+				primaryKeys.forEach(
+					primaryKey -> relatedObjectEntriesMap.put(
+						primaryKey, new ArrayList<>()));
+
+				for (com.liferay.object.model.ObjectEntry objectEntry :
+						objectEntries) {
+
+					Map<String, Serializable> values = objectEntry.getValues();
+
+					Long parentObjectEntryId = GetterUtil.getLong(
+						values.get(relationshipObjectField.getName()));
+
+					List<com.liferay.object.model.ObjectEntry>
+						relatedObjectEntries = relatedObjectEntriesMap.get(
+							parentObjectEntryId);
+
+					relatedObjectEntries.add(objectEntry);
+				}
+
+				objectRelationshipRelatedObjectEntriesMap.put(
+					objectRelationship.getName(), relatedObjectEntriesMap);
+
+				return null;
+			});
+	}
+
 	private long _processAttachment(
 			ObjectDefinition objectDefinition, ObjectField objectField,
 			Object propertyValue, String scopeKey,
@@ -2720,6 +2828,10 @@ public class DefaultObjectEntryManagerImpl
 
 		defaultDTOConverterContext.setAttribute(
 			"objectDefinition", objectDefinition);
+		defaultDTOConverterContext.setAttribute(
+			"objectRelationshipRelatedObjectEntriesMap",
+			dtoConverterContext.getAttribute(
+				"objectRelationshipRelatedObjectEntriesMap"));
 
 		return _objectEntryDTOConverter.toDTO(
 			defaultDTOConverterContext, serviceBuilderObjectEntry);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -896,13 +896,13 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext,
 				objectRelatedModelsProvider.getRelatedModels(
 					groupId, objectRelationship.getObjectRelationshipId(),
-					serviceBuilderObjectEntry.getPrimaryKey(), null,
-					_getStartPosition(pagination),
+					new Long[] {serviceBuilderObjectEntry.getPrimaryKey()},
+					null, _getStartPosition(pagination),
 					_getEndPosition(pagination))),
 			pagination,
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				groupId, objectRelationship.getObjectRelationshipId(),
-				serviceBuilderObjectEntry.getPrimaryKey(), null));
+				new Long[] {serviceBuilderObjectEntry.getPrimaryKey()}, null));
 	}
 
 	@Override
@@ -934,8 +934,8 @@ public class DefaultObjectEntryManagerImpl
 					objectRelatedModelsProvider.getRelatedModels(
 						serviceBuilderObjectEntry.getGroupId(),
 						objectRelationship.getObjectRelationshipId(),
-						serviceBuilderObjectEntry.getPrimaryKey(), null,
-						_getStartPosition(pagination),
+						new Long[] {serviceBuilderObjectEntry.getPrimaryKey()},
+						null, _getStartPosition(pagination),
 						_getEndPosition(pagination)),
 				baseModel -> _toDTO(
 					baseModel, serviceBuilderObjectEntry,
@@ -946,7 +946,7 @@ public class DefaultObjectEntryManagerImpl
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				serviceBuilderObjectEntry.getGroupId(),
 				objectRelationship.getObjectRelationshipId(),
-				serviceBuilderObjectEntry.getPrimaryKey(), null));
+				new Long[] {serviceBuilderObjectEntry.getPrimaryKey()}, null));
 	}
 
 	@Override
@@ -2058,8 +2058,8 @@ public class DefaultObjectEntryManagerImpl
 
 		return objectRelatedModelsProvider.getRelatedModels(
 			GroupThreadLocal.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), primaryKey, null, -1,
-			-1);
+			objectRelationship.getObjectRelationshipId(),
+			new Long[] {primaryKey}, null, -1, -1);
 	}
 
 	private ObjectDefinition _getRelatedObjectDefinition(
@@ -2185,12 +2185,13 @@ public class DefaultObjectEntryManagerImpl
 				dtoConverterContext,
 				objectRelatedModelsProvider.getRelatedModels(
 					groupId, objectRelationship.getObjectRelationshipId(),
-					objectEntryId, null, _getStartPosition(pagination),
+					new Long[] {objectEntryId}, null,
+					_getStartPosition(pagination),
 					_getEndPosition(pagination))),
 			pagination,
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				groupId, objectRelationship.getObjectRelationshipId(),
-				objectEntryId, null));
+				new Long[] {objectEntryId}, null));
 	}
 
 	private Serializable _getValue(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -40,14 +40,14 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 			objectEntryLocalService.getManyToManyObjectEntries(
 				objectEntry.getGroupId(),
 				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
+				new Long[] {objectEntry.getObjectEntryId()}, true,
 				objectRelationship.isReverse(), null, pagination.getStart(),
 				pagination.getEnd()),
 			pagination,
 			objectEntryLocalService.getManyToManyObjectEntriesCount(
 				objectEntry.getGroupId(),
 				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
+				new Long[] {objectEntry.getObjectEntryId()}, true,
 				objectRelationship.isReverse(), null));
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -40,13 +40,13 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 			objectEntryLocalService.getOneToManyObjectEntries(
 				objectEntry.getGroupId(),
 				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true, null,
+				new Long[] {objectEntry.getObjectEntryId()}, true, null,
 				pagination.getStart(), pagination.getEnd()),
 			pagination,
 			objectEntryLocalService.getOneToManyObjectEntriesCount(
 				objectEntry.getGroupId(),
 				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true, null));
+				new Long[] {objectEntry.getObjectEntryId()}, true, null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
@@ -56,7 +56,7 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, 0, 1);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null, 0, 1);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -139,22 +139,22 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, true, search, 0, 1);
+			groupId, objectRelationshipId, primaryKeys, true, search, 0, 1);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException {
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, search, 0, 1);
+			groupId, objectRelationshipId, primaryKeys, search, 0, 1);
 
 		return relatedModels.size();
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
@@ -57,8 +57,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -148,23 +148,23 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, true, search, start,
+			groupId, objectRelationshipId, primaryKeys, true, search, start,
 			end);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, true, search);
+			groupId, objectRelationshipId, primaryKeys, true, search);
 	}
 
 	@Override
@@ -175,8 +175,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, objectEntryId, false, search, start,
-			end);
+			groupId, objectRelationshipId, new Long[] {objectEntryId}, false,
+			search, start, end);
 	}
 
 	@Override
@@ -186,7 +186,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, objectEntryId, false, search);
+			groupId, objectRelationshipId, new Long[] {objectEntryId}, false,
+			search);
 	}
 
 	private final String _className;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsProviderImpl.java
@@ -45,8 +45,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -107,7 +107,7 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 	}
 
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
@@ -116,13 +116,13 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		return _objectEntryService.getManyToManyObjectEntries(
-			groupId, objectRelationship.getObjectRelationshipId(), primaryKey,
+			groupId, objectRelationship.getObjectRelationshipId(), primaryKeys,
 			true, objectRelationship.isReverse(), search, start, end);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException {
 
@@ -131,7 +131,7 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		return _objectEntryService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationship.getObjectRelationshipId(), primaryKey,
+			groupId, objectRelationship.getObjectRelationshipId(), primaryKeys,
 			true, objectRelationship.isReverse(), search);
 	}
 
@@ -148,8 +148,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 
 		return _objectEntryService.getManyToManyObjectEntries(
 			groupId, objectRelationship.getObjectRelationshipId(),
-			objectEntryId, false, objectRelationship.isReverse(), search, start,
-			end);
+			new Long[] {objectEntryId}, false, objectRelationship.isReverse(),
+			search, start, end);
 	}
 
 	@Override
@@ -164,7 +164,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 
 		return _objectEntryService.getManyToManyObjectEntriesCount(
 			groupId, objectRelationship.getObjectRelationshipId(),
-			objectEntryId, false, objectRelationship.isReverse(), search);
+			new Long[] {objectEntryId}, false, objectRelationship.isReverse(),
+			search);
 	}
 
 	private final String _className;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
@@ -85,8 +85,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<T> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -249,7 +249,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<T> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
@@ -261,7 +261,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 		DSLQuery dslQuery = _getGroupByStep(
 			_getDynamicObjectDefinitionTable(),
 			DSLQueryFactoryUtil.selectDistinct(_table), groupId,
-			objectRelationshipId, primaryKey, search
+			objectRelationshipId, primaryKeys, search
 		).orderBy(
 			_systemObjectDefinitionManager.getPrimaryKeyColumn(
 			).ascending()
@@ -274,7 +274,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException {
 
@@ -291,7 +291,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 				dynamicObjectDefinitionTable,
 				DSLQueryFactoryUtil.countDistinct(
 					dynamicObjectDefinitionTable.getPrimaryKeyColumn()),
-				groupId, objectRelationshipId, primaryKey, search));
+				groupId, objectRelationshipId, primaryKeys, search));
 	}
 
 	@Override
@@ -388,7 +388,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 	private GroupByStep _getGroupByStep(
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, String search)
+			Long[] primaryKeys, String search)
 		throws PortalException {
 
 		Column<?, Long> primaryKeyColumn = null;
@@ -445,8 +445,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 		}
 
 		return joinStep.where(
-			primaryKeyColumn.eq(
-				primaryKey
+			primaryKeyColumn.in(
+				primaryKeys
 			).and(
 				() -> {
 					Column<?, Long> groupIdColumn = _table.getColumn("groupId");

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
@@ -71,8 +71,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<T> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -138,7 +138,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<T> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
@@ -150,7 +150,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		return persistedModelLocalService.dslQuery(
 			_getGroupByStep(
 				DSLQueryFactoryUtil.selectDistinct(_table), groupId,
-				objectRelationshipId, primaryKey, search
+				objectRelationshipId, primaryKeys, search
 			).orderBy(
 				_systemObjectDefinitionManager.getPrimaryKeyColumn(
 				).ascending()
@@ -161,7 +161,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException {
 
@@ -175,7 +175,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 				DSLQueryFactoryUtil.countDistinct(
 					_table.getColumn(
 						_objectDefinition.getPKObjectFieldDBColumnName())),
-				groupId, objectRelationshipId, primaryKey, search));
+				groupId, objectRelationshipId, primaryKeys, search));
 	}
 
 	@Override
@@ -223,7 +223,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 
 	private GroupByStep _getGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, String search)
+			Long[] primaryKeys, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -284,8 +284,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		}
 
 		return joinStep.where(
-			primaryKeyColumn1.eq(
-				primaryKey
+			primaryKeyColumn1.in(
+				primaryKeys
 			).and(
 				() -> {
 					Column<?, Long> groupIdColumn = _table.getColumn("groupId");

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -332,7 +332,7 @@ public class ObjectEntryServiceHttp {
 	public static java.util.List<com.liferay.object.model.ObjectEntry>
 			getManyToManyObjectEntries(
 				HttpPrincipal httpPrincipal, long groupId,
-				long objectRelationshipId, long primaryKey, boolean related,
+				long objectRelationshipId, Long[] primaryKeys, boolean related,
 				boolean reverse, String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -342,7 +342,7 @@ public class ObjectEntryServiceHttp {
 				_getManyToManyObjectEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				reverse, search, start, end);
 
 			Object returnObj = null;
@@ -376,7 +376,7 @@ public class ObjectEntryServiceHttp {
 
 	public static int getManyToManyObjectEntriesCount(
 			HttpPrincipal httpPrincipal, long groupId,
-			long objectRelationshipId, long primaryKey, boolean related,
+			long objectRelationshipId, Long[] primaryKeys, boolean related,
 			boolean reverse, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -386,7 +386,7 @@ public class ObjectEntryServiceHttp {
 				_getManyToManyObjectEntriesCountParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				reverse, search);
 
 			Object returnObj = null;
@@ -545,7 +545,7 @@ public class ObjectEntryServiceHttp {
 	public static java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
 				HttpPrincipal httpPrincipal, long groupId,
-				long objectRelationshipId, long primaryKey, boolean related,
+				long objectRelationshipId, Long[] primaryKeys, boolean related,
 				String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -555,7 +555,7 @@ public class ObjectEntryServiceHttp {
 				_getOneToManyObjectEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				search, start, end);
 
 			Object returnObj = null;
@@ -589,7 +589,7 @@ public class ObjectEntryServiceHttp {
 
 	public static int getOneToManyObjectEntriesCount(
 			HttpPrincipal httpPrincipal, long groupId,
-			long objectRelationshipId, long primaryKey, boolean related,
+			long objectRelationshipId, Long[] primaryKeys, boolean related,
 			String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -599,7 +599,7 @@ public class ObjectEntryServiceHttp {
 				_getOneToManyObjectEntriesCountParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				search);
 
 			Object returnObj = null;
@@ -1066,12 +1066,12 @@ public class ObjectEntryServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getManyToManyObjectEntriesParameterTypes7 =
 		new Class[] {
-			long.class, long.class, long.class, boolean.class, boolean.class,
+			long.class, long.class, Long[].class, boolean.class, boolean.class,
 			String.class, int.class, int.class
 		};
 	private static final Class<?>[]
 		_getManyToManyObjectEntriesCountParameterTypes8 = new Class[] {
-			long.class, long.class, long.class, boolean.class, boolean.class,
+			long.class, long.class, Long[].class, boolean.class, boolean.class,
 			String.class
 		};
 	private static final Class<?>[] _getModelResourcePermissionParameterTypes9 =
@@ -1082,12 +1082,12 @@ public class ObjectEntryServiceHttp {
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes12 =
 		new Class[] {
-			long.class, long.class, long.class, boolean.class, String.class,
+			long.class, long.class, Long[].class, boolean.class, String.class,
 			int.class, int.class
 		};
 	private static final Class<?>[]
 		_getOneToManyObjectEntriesCountParameterTypes13 = new Class[] {
-			long.class, long.class, long.class, boolean.class, String.class
+			long.class, long.class, Long[].class, boolean.class, String.class
 		};
 	private static final Class<?>[]
 		_hasModelResourcePermissionParameterTypes14 = new Class[] {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1061,13 +1061,13 @@ public class ObjectEntryLocalServiceImpl
 
 	@Override
 	public List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
 		DSLQuery dslQuery = _getManyToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
-			groupId, objectRelationshipId, primaryKey, related, reverse, search
+			groupId, objectRelationshipId, primaryKeys, related, reverse, search
 		).orderBy(
 			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
 		).limit(
@@ -1083,14 +1083,14 @@ public class ObjectEntryLocalServiceImpl
 
 	@Override
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		DSLQuery dslQuery = _getManyToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.countDistinct(
 				ObjectEntryTable.INSTANCE.objectEntryId),
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 
 		if (_log.isDebugEnabled()) {
@@ -1210,13 +1210,13 @@ public class ObjectEntryLocalServiceImpl
 
 	@Override
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
-			groupId, objectRelationshipId, primaryKey, related, search
+			groupId, objectRelationshipId, primaryKeys, related, search
 		).orderBy(
 			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
 		).limit(
@@ -1232,14 +1232,14 @@ public class ObjectEntryLocalServiceImpl
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException {
 
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.countDistinct(
 				ObjectEntryTable.INSTANCE.objectEntryId),
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
@@ -3774,7 +3774,7 @@ public class ObjectEntryLocalServiceImpl
 
 	private GroupByStep _getManyToManyObjectEntriesGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, boolean related, boolean reverse, String search)
+			Long[] primaryKeys, boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -3877,7 +3877,7 @@ public class ObjectEntryLocalServiceImpl
 			).and(
 				() -> {
 					if (related) {
-						return primaryKeyColumn1.eq(primaryKey);
+						return primaryKeyColumn1.in(primaryKeys);
 					}
 
 					return dynamicObjectDefinitionTablePrimaryKeyColumn.notIn(
@@ -3886,19 +3886,17 @@ public class ObjectEntryLocalServiceImpl
 						).from(
 							dynamicObjectRelationshipMappingTable
 						).where(
-							primaryKeyColumn1.eq(primaryKey)
+							primaryKeyColumn1.in(primaryKeys)
 						));
 				}
 			).and(
 				() -> {
-					if (objectDefinition1.getObjectDefinitionId() !=
-							objectDefinition2.getObjectDefinitionId()) {
-
-						return null;
+					if (objectRelationship.isSelf()) {
+						return dynamicObjectDefinitionTablePrimaryKeyColumn.
+							notIn(primaryKeys);
 					}
 
-					return dynamicObjectDefinitionTablePrimaryKeyColumn.neq(
-						primaryKey);
+					return null;
 				}
 			).and(
 				ObjectEntrySearchUtil.getRelatedModelsPredicate(
@@ -3924,7 +3922,7 @@ public class ObjectEntryLocalServiceImpl
 
 	private GroupByStep _getOneToManyObjectEntriesGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, boolean related, String search)
+			Long[] primaryKeys, boolean related, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -4008,12 +4006,11 @@ public class ObjectEntryLocalServiceImpl
 									objectField.getDBColumnName());
 					}
 
-					return column.eq(related ? primaryKey : 0L);
+					return column.in(primaryKeys);
 				}
 			).and(
-				() ->
-					objectRelationship.isSelf() ?
-						primaryKeyColumn.neq(primaryKey) : null
+				() -> objectRelationship.isSelf() ?
+					primaryKeyColumn.notIn(primaryKeys) : null
 			).and(
 				() -> {
 					if (ObjectEntryThreadLocal.

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3944,13 +3944,19 @@ public class ObjectEntryLocalServiceImpl
 		ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
 			objectRelationship.getObjectFieldId2());
 
-		ObjectEntry objectEntry = fetchObjectEntry(primaryKey);
+		ObjectEntry objectEntry = null;
+
+		if (primaryKeys.length == 1) {
+			objectEntry = fetchObjectEntry(primaryKeys[0]);
+		}
 
 		DynamicObjectDefinitionTable rootDynamicObjectDefinitionTable =
 			_getRootDynamicObjectDefinitionTable(objectEntry);
 
 		Column<DynamicObjectDefinitionTable, Long> primaryKeyColumn =
 			dynamicObjectDefinitionTable.getPrimaryKeyColumn();
+
+		ObjectEntry finalObjectEntry = objectEntry;
 
 		return fromStep.from(
 			dynamicObjectDefinitionTable
@@ -4027,11 +4033,11 @@ public class ObjectEntryLocalServiceImpl
 
 					long rootObjectDefinitionId = 0L;
 
-					if ((objectEntry != null) &&
-						(objectEntry.getRootObjectEntryId() != 0)) {
+					if ((finalObjectEntry != null) &&
+						(finalObjectEntry.getRootObjectEntryId() != 0)) {
 
 						ObjectEntry rootObjectEntry = fetchObjectEntry(
-							objectEntry.getRootObjectEntryId());
+							finalObjectEntry.getRootObjectEntryId());
 
 						rootObjectDefinitionId =
 							rootObjectEntry.getObjectDefinitionId();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4006,7 +4006,11 @@ public class ObjectEntryLocalServiceImpl
 									objectField.getDBColumnName());
 					}
 
-					return column.in(primaryKeys);
+					if (related) {
+						return column.in(primaryKeys);
+					}
+
+					return column.notIn(primaryKeys);
 				}
 			).and(
 				() -> objectRelationship.isSelf() ?

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -222,13 +222,13 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
 		List<ObjectEntry> objectEntries =
 			objectEntryLocalService.getManyToManyObjectEntries(
-				groupId, objectRelationshipId, primaryKey, related, reverse,
+				groupId, objectRelationshipId, primaryKeys, related, reverse,
 				search, start, end);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
@@ -244,12 +244,12 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		return objectEntryLocalService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -305,13 +305,13 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
 		List<ObjectEntry> objectEntries =
 			objectEntryLocalService.getOneToManyObjectEntries(
-				groupId, objectRelationshipId, primaryKey, related, search,
+				groupId, objectRelationshipId, primaryKeys, related, search,
 				start, end);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
@@ -327,12 +327,12 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException {
 
 		return objectEntryLocalService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1674,7 +1674,7 @@ public class ObjectRelationshipLocalServiceImpl
 				int relatedObjectEntriesCount =
 					_objectEntryLocalService.getOneToManyObjectEntriesCount(
 						0, objectRelationship.getObjectRelationshipId(),
-						new Long[] {0L}, false, null);
+						new Long[] {0L}, true, null);
 
 				if (relatedObjectEntriesCount > 0) {
 					throw new ObjectRelationshipEdgeException(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1673,8 +1673,8 @@ public class ObjectRelationshipLocalServiceImpl
 
 				int relatedObjectEntriesCount =
 					_objectEntryLocalService.getOneToManyObjectEntriesCount(
-						0, objectRelationship.getObjectRelationshipId(), 0L,
-						false, null);
+						0, objectRelationship.getObjectRelationshipId(),
+						new Long[] {0L}, false, null);
 
 				if (relatedObjectEntriesCount > 0) {
 					throw new ObjectRelationshipEdgeException(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/BaseSystemObjectRelatedModelsProviderTestCase.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/BaseSystemObjectRelatedModelsProviderTestCase.java
@@ -178,7 +178,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		insertIntoOrUpdateExtensionTable(
 			objectEntry1.getObjectEntryId(), primaryKeys[0],
@@ -193,23 +193,25 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			3, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		// Get related models with search
 
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(),
+			new Long[] {objectEntry1.getObjectEntryId()},
 			String.valueOf(RandomTestUtil.randomInt()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), String.valueOf(primaryKeys[1]));
+			new Long[] {objectEntry1.getObjectEntryId()},
+			String.valueOf(primaryKeys[1]));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), getName(primaryKeys[1]));
+			new Long[] {objectEntry1.getObjectEntryId()},
+			getName(primaryKeys[1]));
 
 		// Disassociate related models
 
@@ -221,7 +223,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		// Object relationship deletion type cascade
 
@@ -255,14 +257,14 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			new Long[] {objectEntry2.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			new Long[] {objectEntry2.getObjectEntryId()});
 
 		Assert.assertNotNull(fetchBaseModel(primaryKeys[0]));
 
@@ -293,7 +295,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry3.getObjectEntryId());
+			new Long[] {objectEntry3.getObjectEntryId()});
 
 		objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -316,7 +318,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
@@ -328,23 +330,25 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		// Get related models with search
 
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(),
+			new Long[] {objectEntry1.getObjectEntryId()},
 			String.valueOf(RandomTestUtil.randomInt()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), String.valueOf(primaryKeys[0]));
+			new Long[] {objectEntry1.getObjectEntryId()},
+			String.valueOf(primaryKeys[0]));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), getName(primaryKeys[1]));
+			new Long[] {objectEntry1.getObjectEntryId()},
+			getName(primaryKeys[1]));
 
 		// Object relationship deletion type cascade
 
@@ -389,14 +393,14 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			new Long[] {objectEntry2.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			new Long[] {objectEntry2.getObjectEntryId()});
 
 		Assert.assertNotNull(fetchBaseModel(primaryKeys[2]));
 
@@ -452,26 +456,28 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, objectRelatedModelsProvider,
-			_objectRelationship.getObjectRelationshipId(), primaryKeys[2]);
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {primaryKeys[2]});
 
 		// Get related models with search
 
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			0, objectRelatedModelsProvider,
-			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
-			StringUtil.randomString());
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {primaryKeys[2]}, StringUtil.randomString());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
-			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {primaryKeys[2]},
 			String.valueOf(objectEntry3.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
-			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
-			"New");
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {primaryKeys[2]}, "New");
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			2, objectRelatedModelsProvider,
-			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
-			"Entry");
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {primaryKeys[2]}, "Entry");
 
 		objectRelationshipLocalService.deleteObjectRelationships(
 			_objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/BaseSystemObjectRelatedModelsProviderTestCase.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/BaseSystemObjectRelatedModelsProviderTestCase.java
@@ -164,7 +164,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 	private void _testSystemObjectEntry1toMObjectRelatedModels(long groupId)
 		throws Exception {
 
-		long[] primaryKeys = addBaseModels(3);
+		long[] primaryKeys = addBaseModels(4);
 
 		addObjectRelationship(
 			_objectDefinition, _systemObjectDefinition,
@@ -194,6 +194,28 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			3, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()});
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			groupId, _objectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			3, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		insertIntoOrUpdateExtensionTable(
+			objectEntry2.getObjectEntryId(), primaryKeys[3],
+			_systemObjectDefinition.getObjectDefinitionId());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			4, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
 
 		// Get related models with search
 
@@ -246,25 +268,25 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			Collections.emptyMap());
 
 		insertIntoOrUpdateExtensionTable(
-			objectEntry2.getObjectEntryId(), primaryKeys[0],
+			objectEntry3.getObjectEntryId(), primaryKeys[0],
 			_systemObjectDefinition.getObjectDefinitionId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry2.getObjectEntryId()});
+			new Long[] {objectEntry3.getObjectEntryId()});
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry2.getObjectEntryId()});
+			new Long[] {objectEntry3.getObjectEntryId()});
 
 		Assert.assertNotNull(fetchBaseModel(primaryKeys[0]));
 
@@ -276,12 +298,12 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			Collections.emptyMap());
 
 		insertIntoOrUpdateExtensionTable(
-			objectEntry3.getObjectEntryId(), primaryKeys[0],
+			objectEntry4.getObjectEntryId(), primaryKeys[0],
 			_systemObjectDefinition.getObjectDefinitionId());
 
 		AssertUtils.assertFailure(
@@ -290,12 +312,12 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry3));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry4));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry3.getObjectEntryId()});
+			new Long[] {objectEntry4.getObjectEntryId()});
 
 		objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -304,7 +326,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 	private void _testSystemObjectEntryMtoMObjectRelatedModels(long groupId)
 		throws Exception {
 
-		long[] primaryKeys = addBaseModels(3);
+		long[] primaryKeys = addBaseModels(4);
 
 		addObjectRelationship(
 			_objectDefinition, _systemObjectDefinition,
@@ -331,6 +353,39 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			2, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()});
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			groupId, _objectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			2, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry2.getObjectEntryId(), primaryKeys[0]);
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			2, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry2.getObjectEntryId(), primaryKeys[3]);
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			3, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
 
 		// Get related models with search
 
@@ -382,25 +437,25 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId(), primaryKeys[2]);
+			objectEntry3.getObjectEntryId(), primaryKeys[2]);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry2.getObjectEntryId()});
+			new Long[] {objectEntry3.getObjectEntryId()});
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry2.getObjectEntryId()});
+			new Long[] {objectEntry3.getObjectEntryId()});
 
 		Assert.assertNotNull(fetchBaseModel(primaryKeys[2]));
 
@@ -412,7 +467,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				"able", "Entry"
@@ -420,7 +475,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry3.getObjectEntryId(), primaryKeys[2]);
+			objectEntry4.getObjectEntryId(), primaryKeys[2]);
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -428,7 +483,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry3));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry4));
 
 		// Reverse object relationship
 
@@ -444,7 +499,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 				_objectDefinition.getCompanyId(),
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry5 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				"able", "New Entry"
@@ -452,7 +507,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
-			objectEntry4.getObjectEntryId());
+			objectEntry5.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, objectRelatedModelsProvider,
@@ -469,7 +524,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {primaryKeys[2]},
-			String.valueOf(objectEntry3.getObjectEntryId()));
+			String.valueOf(objectEntry4.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/CPDefinitionSystemObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/CPDefinitionSystemObjectRelatedModelsProviderTest.java
@@ -204,15 +204,16 @@ public class CPDefinitionSystemObjectRelatedModelsProviderTest
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			0, objectRelatedModelsProvider,
 			objectRelationship.getObjectRelationshipId(),
-			objectEntry.getPrimaryKey(), StringUtil.randomString());
+			new Long[] {objectEntry.getPrimaryKey()},
+			StringUtil.randomString());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			objectRelationship.getObjectRelationshipId(),
-			objectEntry.getPrimaryKey(), cpDefinition.getName());
+			new Long[] {objectEntry.getPrimaryKey()}, cpDefinition.getName());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			2, objectRelatedModelsProvider,
 			objectRelationship.getObjectRelationshipId(),
-			objectEntry.getPrimaryKey(), "CP");
+			new Long[] {objectEntry.getPrimaryKey()}, "CP");
 
 		objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship.getObjectRelationshipId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -250,6 +250,8 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry2 = _addObjectEntry(
+			_objectDefinition1, Collections.emptyMap());
+		ObjectEntry objectEntry3 = _addObjectEntry(
 			_objectDefinition2, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
@@ -257,7 +259,7 @@ public class ObjectRelatedModelsProviderTest {
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()});
 
-		ObjectEntry objectEntry3 = _addObjectEntry(
+		ObjectEntry objectEntry4 = _addObjectEntry(
 			_objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				"able", "First Entry"
@@ -270,6 +272,27 @@ public class ObjectRelatedModelsProviderTest {
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()});
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			1, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		_addObjectEntry(
+			_objectDefinition2,
+			HashMapBuilder.<String, Serializable>put(
+				_relationshipObjectField.getName(),
+				objectEntry2.getObjectEntryId()
+			).build());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			2, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
 
 		_addObjectEntry(
 			_objectDefinition2,
@@ -286,7 +309,7 @@ public class ObjectRelatedModelsProviderTest {
 			new Long[] {objectEntry1.getObjectEntryId()});
 
 		_updateObjectEntry(
-			objectEntry2.getObjectEntryId(),
+			objectEntry3.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"able", "Third Entry"
 			).put(
@@ -373,7 +396,7 @@ public class ObjectRelatedModelsProviderTest {
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()},
-			String.valueOf(objectEntry2.getObjectEntryId()));
+			String.valueOf(objectEntry3.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
@@ -388,7 +411,7 @@ public class ObjectRelatedModelsProviderTest {
 			new Long[] {objectEntry1.getObjectEntryId()}, "Entry");
 
 		_updateObjectEntry(
-			objectEntry3.getObjectEntryId(),
+			objectEntry4.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(), 0
 			).build());
@@ -403,7 +426,7 @@ public class ObjectRelatedModelsProviderTest {
 		_setUser(_user);
 
 		_assertViewPermission(
-			_objectDefinition2, objectEntry1, objectEntry2.getObjectEntryId());
+			_objectDefinition2, objectEntry1, objectEntry3.getObjectEntryId());
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -439,34 +462,34 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		ObjectEntry objectEntry4 = _addObjectEntry(
+		ObjectEntry objectEntry6 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry4.getObjectEntryId()});
+			new Long[] {objectEntry6.getObjectEntryId()});
 
 		Group group = GroupTestUtil.addGroup();
 
-		ObjectEntry objectEntry6 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry7 = ObjectEntryTestUtil.addObjectEntry(
 			group.getGroupId(),
 			scopeSiteObjectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(),
-				objectEntry4.getObjectEntryId()
+				objectEntry6.getObjectEntryId()
 			).build());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry4.getObjectEntryId()});
+			new Long[] {objectEntry6.getObjectEntryId()});
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry6);
 
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry6.getObjectEntryId()));
+				objectEntry7.getObjectEntryId()));
 
 		// Object relationship deletion type disassociate
 
@@ -476,32 +499,32 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry7 = _addObjectEntry(
+		ObjectEntry objectEntry8 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 
-		ObjectEntry objectEntry8 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry9 = ObjectEntryTestUtil.addObjectEntry(
 			group.getGroupId(),
 			scopeSiteObjectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(),
-				objectEntry7.getObjectEntryId()
+				objectEntry8.getObjectEntryId()
 			).build());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry7.getObjectEntryId()});
+			new Long[] {objectEntry8.getObjectEntryId()});
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry7);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry8);
 
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry8.getObjectEntryId()));
+				objectEntry9.getObjectEntryId()));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry7.getObjectEntryId()});
+			new Long[] {objectEntry8.getObjectEntryId()});
 
 		// Object relationship deletion type prevent
 
@@ -511,20 +534,20 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry9 = _addObjectEntry(
+		ObjectEntry objectEntry10 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 
 		_updateObjectEntry(
-			objectEntry8.getObjectEntryId(),
+			objectEntry9.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(),
-				objectEntry9.getObjectEntryId()
+				objectEntry10.getObjectEntryId()
 			).build());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry9.getObjectEntryId()});
+			new Long[] {objectEntry10.getObjectEntryId()});
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -532,12 +555,12 @@ public class ObjectRelatedModelsProviderTest {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry9));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry10));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry9.getObjectEntryId()});
+			new Long[] {objectEntry10.getObjectEntryId()});
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -873,6 +896,8 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry2 = _addObjectEntry(
+			objectDefinition1, Collections.emptyMap());
+		ObjectEntry objectEntry3 = _addObjectEntry(
 			objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				"able", "First Entry"
@@ -885,14 +910,32 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId());
+			objectEntry1.getObjectEntryId(), objectEntry3.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()});
 
-		ObjectEntry objectEntry3 = _addObjectEntry(
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			1, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry2.getObjectEntryId(), objectEntry3.getObjectEntryId());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			1, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectEntry objectEntry4 = _addObjectEntry(
 			objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				"able", "Second Entry"
@@ -900,7 +943,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), objectEntry3.getObjectEntryId());
+			objectEntry1.getObjectEntryId(), objectEntry4.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
@@ -910,21 +953,21 @@ public class ObjectRelatedModelsProviderTest {
 		// Get related models with search
 
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			0, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			0, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()},
 			StringUtil.randomString());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			1, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			1, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()},
-			String.valueOf(objectEntry2.getObjectEntryId()));
+			String.valueOf(objectEntry3.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			1, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			1, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()}, "First ");
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			2, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			2, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			new Long[] {objectEntry1.getObjectEntryId()}, " Entry");
 
@@ -933,7 +976,7 @@ public class ObjectRelatedModelsProviderTest {
 		_setUser(_user);
 
 		_assertViewPermission(
-			objectDefinition2, objectEntry1, objectEntry2.getObjectEntryId());
+			objectDefinition2, objectEntry1, objectEntry3.getObjectEntryId());
 
 		_setUser(TestPropsValues.getUser());
 
@@ -945,14 +988,14 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 			_objectRelationship.getLabelMap());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
 
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
 				objectEntry1.getObjectEntryId()));
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry3.getObjectEntryId()));
+				objectEntry4.getObjectEntryId()));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
@@ -966,7 +1009,7 @@ public class ObjectRelatedModelsProviderTest {
 				objectEntry1.getObjectEntryId()));
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry2.getObjectEntryId()));
+				objectEntry3.getObjectEntryId()));
 
 		// Object relationship deletion type disassociate
 
@@ -976,31 +1019,31 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry4 = _addObjectEntry(
-			objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry5 = _addObjectEntry(
-			objectDefinition2, Collections.emptyMap());
+			objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry6 = _addObjectEntry(
+			objectDefinition2, Collections.emptyMap());
+		ObjectEntry objectEntry7 = _addObjectEntry(
 			objectDefinition2, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId(), objectEntry5.getObjectEntryId());
+			objectEntry5.getObjectEntryId(), objectEntry6.getObjectEntryId());
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId(), objectEntry6.getObjectEntryId());
+			objectEntry5.getObjectEntryId(), objectEntry7.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry4.getObjectEntryId()});
+			new Long[] {objectEntry5.getObjectEntryId()});
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry5);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry4.getObjectEntryId()});
+			new Long[] {objectEntry5.getObjectEntryId()});
 
 		// Object relationship deletion type prevent
 
@@ -1010,20 +1053,20 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry7 = _addObjectEntry(
+		ObjectEntry objectEntry8 = _addObjectEntry(
 			objectDefinition1, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId(), objectEntry5.getObjectEntryId());
+			objectEntry8.getObjectEntryId(), objectEntry6.getObjectEntryId());
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId(), objectEntry6.getObjectEntryId());
+			objectEntry8.getObjectEntryId(), objectEntry7.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry7.getObjectEntryId()});
+			new Long[] {objectEntry8.getObjectEntryId()});
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -1031,23 +1074,23 @@ public class ObjectRelatedModelsProviderTest {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry7));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry8));
 
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry7.getObjectEntryId()));
+				objectEntry8.getObjectEntryId()));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry7.getObjectEntryId()});
+			new Long[] {objectEntry8.getObjectEntryId()});
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry6);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry7);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			new Long[] {objectEntry7.getObjectEntryId()});
+			new Long[] {objectEntry8.getObjectEntryId()});
 
 		// Reverse object relationship
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -168,7 +168,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		ObjectEntry objectEntry3 = _addObjectEntry(
 			_objectDefinition2,
@@ -180,7 +180,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		AssertUtils.assertFailure(
 			ObjectEntryValuesException.OneToOneConstraintViolation.class,
@@ -219,7 +219,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		_updateObjectEntry(
 			objectEntry3.getObjectEntryId(),
@@ -230,7 +230,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -255,7 +255,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		ObjectEntry objectEntry3 = _addObjectEntry(
 			_objectDefinition2,
@@ -269,7 +269,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		_addObjectEntry(
 			_objectDefinition2,
@@ -283,7 +283,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		_updateObjectEntry(
 			objectEntry2.getObjectEntryId(),
@@ -297,7 +297,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			3, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		// Get related models with localized object field
 
@@ -367,24 +367,25 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), StringUtil.randomString());
+			new Long[] {objectEntry1.getObjectEntryId()},
+			StringUtil.randomString());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(),
+			new Long[] {objectEntry1.getObjectEntryId()},
 			String.valueOf(objectEntry2.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), "First ");
+			new Long[] {objectEntry1.getObjectEntryId()}, "First ");
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), "d Entry");
+			new Long[] {objectEntry1.getObjectEntryId()}, "d Entry");
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			3, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), "Entry");
+			new Long[] {objectEntry1.getObjectEntryId()}, "Entry");
 
 		_updateObjectEntry(
 			objectEntry3.getObjectEntryId(),
@@ -395,7 +396,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		// Get related models with view permission
 
@@ -444,7 +445,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			new Long[] {objectEntry4.getObjectEntryId()});
 
 		Group group = GroupTestUtil.addGroup();
 
@@ -459,7 +460,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			new Long[] {objectEntry4.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
 
@@ -489,7 +490,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			new Long[] {objectEntry7.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry7);
 
@@ -500,7 +501,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			new Long[] {objectEntry7.getObjectEntryId()});
 
 		// Object relationship deletion type prevent
 
@@ -523,7 +524,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry9.getObjectEntryId());
+			new Long[] {objectEntry9.getObjectEntryId()});
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -536,7 +537,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry9.getObjectEntryId());
+			new Long[] {objectEntry9.getObjectEntryId()});
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -709,7 +710,7 @@ public class ObjectRelatedModelsProviderTest {
 			0,
 			_objectRelatedModelsProvider.getRelatedModelsCount(
 				0, _objectRelationship.getObjectRelationshipId(),
-				parentObjectEntry.getObjectEntryId(), null));
+				new Long[] {parentObjectEntry.getObjectEntryId()}, null));
 
 		_resourcePermissionLocalService.setResourcePermissions(
 			TestPropsValues.getCompanyId(), objectDefinition.getClassName(),
@@ -720,7 +721,7 @@ public class ObjectRelatedModelsProviderTest {
 			expectedRelatedModelsCount,
 			_objectRelatedModelsProvider.getRelatedModelsCount(
 				0, _objectRelationship.getObjectRelationshipId(),
-				parentObjectEntry.getObjectEntryId(), null));
+				new Long[] {parentObjectEntry.getObjectEntryId()}, null));
 
 		_resourcePermissionLocalService.removeResourcePermission(
 			TestPropsValues.getCompanyId(), objectDefinition.getClassName(),
@@ -880,7 +881,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
@@ -889,7 +890,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		ObjectEntry objectEntry3 = _addObjectEntry(
 			objectDefinition2,
@@ -904,27 +905,28 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		// Get related models with search
 
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			0, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), StringUtil.randomString());
+			new Long[] {objectEntry1.getObjectEntryId()},
+			StringUtil.randomString());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(),
+			new Long[] {objectEntry1.getObjectEntryId()},
 			String.valueOf(objectEntry2.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), "First ");
+			new Long[] {objectEntry1.getObjectEntryId()}, "First ");
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			2, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), " Entry");
+			new Long[] {objectEntry1.getObjectEntryId()}, " Entry");
 
 		// View permission
 
@@ -955,7 +957,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId());
+			new Long[] {objectEntry1.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry1);
 
@@ -991,14 +993,14 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			new Long[] {objectEntry4.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			new Long[] {objectEntry4.getObjectEntryId()});
 
 		// Object relationship deletion type prevent
 
@@ -1021,7 +1023,7 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			new Long[] {objectEntry7.getObjectEntryId()});
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -1038,14 +1040,14 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			new Long[] {objectEntry7.getObjectEntryId()});
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry6);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			new Long[] {objectEntry7.getObjectEntryId()});
 
 		// Reverse object relationship
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/util/ObjectRelationshipTestUtil.java
@@ -37,12 +37,12 @@ public class ObjectRelationshipTestUtil {
 	public static void assertGetRelatedModels(
 			int expectedSize,
 			ObjectRelatedModelsProvider objectRelatedModelsProvider,
-			long objectRelationshipId, long primaryKey)
+			long objectRelationshipId, Long[] primaryKeys)
 		throws Exception {
 
 		List<ObjectEntry> objectEntries =
 			objectRelatedModelsProvider.getRelatedModels(
-				0, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
+				0, objectRelationshipId, primaryKeys, null, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS);
 
 		Assert.assertEquals(
@@ -52,12 +52,12 @@ public class ObjectRelationshipTestUtil {
 	public static void assertSearchRelatedModels(
 			int expectedSize, long groupId,
 			ObjectRelatedModelsProvider objectRelatedModelsProvider,
-			long objectRelationshipId, long primaryKey, String search)
+			long objectRelationshipId, Long[] primaryKeys, String search)
 		throws Exception {
 
 		List<ObjectEntry> objectEntries =
 			objectRelatedModelsProvider.getRelatedModels(
-				groupId, objectRelationshipId, primaryKey, search,
+				groupId, objectRelationshipId, primaryKeys, search,
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(
@@ -67,12 +67,12 @@ public class ObjectRelationshipTestUtil {
 	public static void assertSearchRelatedModels(
 			int expectedSize,
 			ObjectRelatedModelsProvider objectRelatedModelsProvider,
-			long objectRelationshipId, long primaryKey, String search)
+			long objectRelationshipId, Long[] primaryKeys, String search)
 		throws Exception {
 
 		assertSearchRelatedModels(
 			expectedSize, 0, objectRelatedModelsProvider, objectRelationshipId,
-			primaryKey, search);
+			primaryKeys, search);
 	}
 
 	public static ObjectRelationship updateObjectRelationship(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/data/provider/RelatedModelsFDSDataProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/data/provider/RelatedModelsFDSDataProvider.java
@@ -78,7 +78,7 @@ public class RelatedModelsFDSDataProvider
 
 		return TransformUtil.transform(
 			(List<ObjectEntry>)objectRelatedModelsProvider.getRelatedModels(
-				groupId, objectRelationshipId, objectEntryId,
+				groupId, objectRelationshipId, new Long[] {objectEntryId},
 				fdsKeywords.getKeywords(), fdsPagination.getStartPosition(),
 				fdsPagination.getEndPosition()),
 			objectEntry -> new RelatedModel(
@@ -116,7 +116,8 @@ public class RelatedModelsFDSDataProvider
 
 		return objectRelatedModelsProvider.getRelatedModelsCount(
 			objectScopeProvider.getGroupId(httpServletRequest),
-			objectRelationshipId, objectEntryId, fdsKeywords.getKeywords());
+			objectRelationshipId, new Long[] {objectEntryId},
+			fdsKeywords.getKeywords());
 	}
 
 	@Reference

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/provider/SystemRelatedModelsFDSDataProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/provider/SystemRelatedModelsFDSDataProvider.java
@@ -85,8 +85,8 @@ public class SystemRelatedModelsFDSDataProvider
 		return TransformUtil.transform(
 			(List<BaseModel<?>>)objectRelatedModelsProvider.getRelatedModels(
 				objectScopeProvider.getGroupId(httpServletRequest),
-				objectRelationshipId, objectEntryId, fdsKeywords.getKeywords(),
-				fdsPagination.getStartPosition(),
+				objectRelationshipId, new Long[] {objectEntryId},
+				fdsKeywords.getKeywords(), fdsPagination.getStartPosition(),
 				fdsPagination.getEndPosition()),
 			relatedModel -> {
 				ObjectField titleObjectField =
@@ -155,7 +155,8 @@ public class SystemRelatedModelsFDSDataProvider
 
 		return objectRelatedModelsProvider.getRelatedModelsCount(
 			objectScopeProvider.getGroupId(httpServletRequest),
-			objectRelationshipId, objectEntryId, fdsKeywords.getKeywords());
+			objectRelationshipId, new Long[] {objectEntryId},
+			fdsKeywords.getKeywords());
 	}
 
 	@Reference


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-61566