### PR TITLE
LPD-60964 [Test fix] failures in calendar-web/main/calendarEvent.spec.ts > event ending at midnight does not render on the next day

### DIFF
--- a/modules/test/playwright/tests/calendar-web/main/calendarEvent.spec.ts
+++ b/modules/test/playwright/tests/calendar-web/main/calendarEvent.spec.ts
@@ -512,7 +512,7 @@ test('event ending at midnight does not render on the next day', async ({
 	await calendarWidgetPage.closeModalEvent();
 	await calendarWidgetPage.monthViewTab.click();
 
-	await expect(page.getByTitle(title)).toHaveCount(1);
+	await expect(page.getByTitle(title, {exact: true})).toHaveCount(1);
 	await expect(page.locator('.lfr-busy-day')).toHaveCount(1);
 });
 


### PR DESCRIPTION
Related Issue: [LPD-60964](https://liferay.atlassian.net/browse/LPD-60964)

[LPD-60964]: https://liferay.atlassian.net/browse/LPD-60964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ