### PR TITLE
LPD-62319 Ensure that all disabled settings of a child object definition based on root logic should not be applied

### DIFF
--- a/modules/apps/object/object-web/package.json
+++ b/modules/apps/object/object-web/package.json
@@ -22,6 +22,7 @@
 		"@liferay/frontend-js-codemirror-web": "*",
 		"@liferay/object-js-components-web": "*",
 		"classnames": "2.3.1",
+		"fetch-mock": "5.13.1",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"moment": "2.29.4",

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.tsx
@@ -82,11 +82,6 @@ export function RightSidebarObjectDefinitionDetails({
 			onSubmit: () => {},
 		});
 
-	const isRootDescendantNode =
-		!!values.rootObjectDefinitionExternalReferenceCode &&
-		values.externalReferenceCode !==
-			values.rootObjectDefinitionExternalReferenceCode;
-
 	useEffect(() => {
 		const makeFetch = async () => {
 			if (selectedObjectDefinitionNode) {
@@ -270,7 +265,6 @@ export function RightSidebarObjectDefinitionDetails({
 						selectedObjectDefinitionNode?.data
 							?.linkedObjectDefinition ?? false
 					}
-					isRootDescendantNode={isRootDescendantNode}
 					onSubmit={onSubmit}
 					setValues={setValues}
 					sites={sites}
@@ -286,7 +280,6 @@ export function RightSidebarObjectDefinitionDetails({
 							selectedObjectDefinitionNode?.data
 								?.linkedObjectDefinition ?? false
 						}
-						isRootDescendantNode={isRootDescendantNode}
 						objectFields={
 							(values?.objectFields as ObjectField[]) ?? []
 						}
@@ -308,7 +301,6 @@ export function RightSidebarObjectDefinitionDetails({
 						selectedObjectDefinitionNode?.data
 							?.linkedObjectDefinition ?? false
 					}
-					isRootDescendantNode={isRootDescendantNode}
 					onSubmit={onSubmit}
 					setValues={setValues}
 					values={values as ObjectDefinition}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/AccountRestrictionContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/AccountRestrictionContainer.tsx
@@ -18,7 +18,6 @@ interface AccountRestrictionContainerProps {
 	errors: FormError<ObjectDefinition>;
 	isApproved: boolean;
 	isLinkedObjectDefinition?: boolean;
-	isRootDescendantNode: boolean;
 	objectFields: ObjectField[];
 	onSubmit?: (editedObjectDefinition?: Partial<ObjectDefinition>) => void;
 	setValues: (values: Partial<ObjectDefinition>) => void;
@@ -29,7 +28,6 @@ export function AccountRestrictionContainer({
 	errors,
 	isApproved,
 	isLinkedObjectDefinition,
-	isRootDescendantNode,
 	objectFields,
 	onSubmit,
 	setValues,
@@ -97,8 +95,7 @@ export function AccountRestrictionContainer({
 					disabled={
 						!accountRelationshipFields.length ||
 						disableAccountToggle ||
-						isLinkedObjectDefinition ||
-						isRootDescendantNode
+						isLinkedObjectDefinition
 					}
 					label={sub(
 						Liferay.Language.get('enable-x'),
@@ -131,8 +128,7 @@ export function AccountRestrictionContainer({
 					!accountRelationshipFields.length ||
 					!values.accountEntryRestricted ||
 					disableAccountSelect ||
-					isLinkedObjectDefinition ||
-					isRootDescendantNode
+					isLinkedObjectDefinition
 				}
 				error={errors.accountEntryRestrictedObjectFieldName}
 				items={accountRelationshipFields}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
@@ -12,7 +12,6 @@ interface ConfigurationContainerProps {
 	hasUpdateObjectDefinitionPermission: boolean;
 	isEnableObjectEntrySchedule: boolean;
 	isLinkedObjectDefinition?: boolean;
-	isRootDescendantNode: boolean;
 	onSubmit?: (editedObjectDefinition?: Partial<ObjectDefinition>) => void;
 	setValues: (values: Partial<ObjectDefinition>) => void;
 	values: Partial<ObjectDefinition>;
@@ -22,7 +21,6 @@ export function ConfigurationContainer({
 	hasUpdateObjectDefinitionPermission,
 	isEnableObjectEntrySchedule,
 	isLinkedObjectDefinition,
-	isRootDescendantNode,
 	onSubmit,
 	setValues,
 	values,
@@ -38,7 +36,7 @@ export function ConfigurationContainer({
 		<div className="lfr-objects__object-definition-details-configuration">
 			<ClayForm.Group>
 				<Toggle
-					disabled={disabled || isRootDescendantNode}
+					disabled={disabled}
 					label={sub(
 						Liferay.Language.get('show-widget-in-x'),
 						Liferay.Language.get('page-builder')

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/EditObjectDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/EditObjectDetails.tsx
@@ -325,7 +325,6 @@ export default function EditObjectDetails({
 									hasUpdateObjectDefinitionPermission
 								}
 								isApproved={isApproved}
-								isRootDescendantNode={isRootDescendantNode}
 								setValues={setValues}
 								sites={sites}
 								values={values}
@@ -346,7 +345,6 @@ export default function EditObjectDetails({
 								<AccountRestrictionContainer
 									errors={errors}
 									isApproved={isApproved}
-									isRootDescendantNode={isRootDescendantNode}
 									objectFields={objectFields}
 									setValues={setValues}
 									values={values}
@@ -369,7 +367,6 @@ export default function EditObjectDetails({
 								isEnableObjectEntrySchedule={
 									isEnableObjectEntrySchedule
 								}
-								isRootDescendantNode={isRootDescendantNode}
 								setValues={setValues}
 								values={values}
 							/>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ScopeContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ScopeContainer.tsx
@@ -28,7 +28,6 @@ interface ScopeContainerProps {
 	hasUpdateObjectDefinitionPermission: boolean;
 	isApproved: boolean;
 	isLinkedObjectDefinition?: boolean;
-	isRootDescendantNode: boolean;
 	onSubmit?: (editedObjectDefinition?: Partial<ObjectDefinition>) => void;
 	setValues: (values: Partial<ObjectDefinition>) => void;
 	sites: Scope[];
@@ -42,7 +41,6 @@ export function ScopeContainer({
 	hasUpdateObjectDefinitionPermission,
 	isApproved,
 	isLinkedObjectDefinition,
-	isRootDescendantNode,
 	onSubmit,
 	setValues,
 	sites,
@@ -87,7 +85,6 @@ export function ScopeContainer({
 					isApproved ||
 					!hasUpdateObjectDefinitionPermission ||
 					values.storageType === 'salesforce' ||
-					isRootDescendantNode ||
 					isLinkedObjectDefinition
 				}
 				error={errors.titleObjectFieldId}
@@ -118,7 +115,6 @@ export function ScopeContainer({
 				disabled={
 					(!values.modifiable && values.system) ||
 					!hasUpdateObjectDefinitionPermission ||
-					isRootDescendantNode ||
 					isLinkedObjectDefinition
 				}
 				error={errors.titleObjectFieldId}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.spec.tsx
@@ -1,0 +1,282 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {render, screen} from '@testing-library/react';
+
+// @ts-ignore
+
+import fetchMock from 'fetch-mock';
+import React from 'react';
+
+import {RightSidebarObjectDefinitionDetails} from '../../../components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails';
+import {objectDefinition} from './__mock__/objectDefinition';
+
+const OBJECT_DEFINITION_URL_REGEX =
+	/\/o\/object-admin\/v1\.0\/object-definitions\/by-external-reference-code\/.+/;
+
+let mockUseObjectFolderContextReturnValue = [
+	{
+		selectedObjectDefinitionNode: {
+			data: {externalReferenceCode: '1'},
+		},
+	},
+	jest.fn(),
+];
+
+const rightSidebarObjectDefinitionDetailsProps = {
+	companies: [],
+	sites: [],
+};
+
+const renderComponent = (customProps = {}) => {
+	fetchMock.get(OBJECT_DEFINITION_URL_REGEX, {
+		body: {...objectDefinition, ...customProps},
+	});
+
+	render(
+		<RightSidebarObjectDefinitionDetails
+			{...rightSidebarObjectDefinitionDetailsProps}
+		/>
+	);
+};
+
+jest.mock('frontend-js-web', () => ({
+	...(jest.requireActual('frontend-js-web') as object),
+	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
+}));
+
+jest.mock(
+	'../../../components/ModelBuilder/ModelBuilderContext/objectFolderContext',
+	() => ({
+		useObjectFolderContext: () => mockUseObjectFolderContextReturnValue,
+	})
+);
+
+jest.mock('react-flow-renderer', () => {
+	return {
+		useStore() {
+			return {
+				edges: [],
+				nodes: [],
+			};
+		},
+	};
+});
+
+afterAll(() => {
+	jest.restoreAllMocks();
+});
+
+afterEach(() => {
+	fetchMock.restore();
+	mockUseObjectFolderContextReturnValue = [
+		{
+			selectedObjectDefinitionNode: {
+				data: {externalReferenceCode: '1'},
+			},
+		},
+		jest.fn(),
+	];
+});
+
+describe('object definition configuration', () => {
+	it('enable account restriction is enabled by default', async () => {
+		renderComponent({storageType: 'salesforce'});
+
+		const accountRestrictionToggle = await screen.findByRole('switch', {
+			name: 'enable-account-restriction',
+		});
+
+		expect(accountRestrictionToggle).toBeEnabled();
+	});
+
+	it('panel link is enabled by default', async () => {
+		renderComponent();
+
+		const panelLink = await screen.findByRole('combobox', {
+			name: 'panel-link',
+		});
+
+		expect(panelLink).toBeEnabled();
+	});
+
+	it('scope is enabled by default', async () => {
+		renderComponent();
+
+		const scope = await screen.findByRole('combobox', {
+			name: 'scope',
+		});
+
+		expect(scope).toBeEnabled();
+	});
+
+	it('show widget in page builder is enabled by default', async () => {
+		renderComponent();
+
+		const showWidgetToggle = await screen.findByRole('switch', {
+			name: 'show-widget-in-page-builder',
+		});
+
+		expect(showWidgetToggle).toBeEnabled();
+	});
+});
+
+describe('when the object definition is approved', () => {
+	it('enable account restriction is disabled', async () => {
+		renderComponent({
+			accountEntryRestricted: true,
+			status: {label: 'approved'},
+		});
+
+		const accountRestrictionToggle = await screen.findByRole('switch', {
+			name: 'enable-account-restriction',
+		});
+
+		expect(accountRestrictionToggle).toBeDisabled();
+	});
+
+	it('panel link is enabled', async () => {
+		renderComponent({status: {label: 'approved'}});
+
+		const panelLink = await screen.findByRole('combobox', {
+			name: 'panel-link',
+		});
+
+		expect(panelLink).toBeEnabled();
+	});
+
+	it('scope is disabled', async () => {
+		renderComponent({status: {label: 'approved'}});
+
+		const scope = await screen.findByRole('combobox', {
+			name: 'scope',
+		});
+
+		expect(scope).toBeDisabled();
+	});
+
+	it('show widget in page builder is enabled', async () => {
+		renderComponent({status: {label: 'approved'}});
+
+		const showWidgetToggle = await screen.findByRole('switch', {
+			name: 'show-widget-in-page-builder',
+		});
+
+		expect(showWidgetToggle).toBeEnabled();
+	});
+});
+
+describe('when the object definition is a system object', () => {
+	it('enable account restriction is enabled', async () => {
+		renderComponent({system: true});
+
+		const accountRestrictionToggle = await screen.findByRole('switch', {
+			name: 'enable-account-restriction',
+		});
+
+		expect(accountRestrictionToggle).toBeDisabled();
+	});
+
+	it('panel link is disabled', async () => {
+		renderComponent({modifiable: false, system: true});
+
+		const panelLink = await screen.findByRole('combobox', {
+			name: 'panel-link',
+		});
+
+		expect(panelLink).toBeDisabled();
+	});
+
+	it('scope is enabled', async () => {
+		renderComponent({system: true});
+
+		const scope = await screen.findByRole('combobox', {
+			name: 'scope',
+		});
+
+		expect(scope).toBeEnabled();
+	});
+
+	it('show widget in page builder is disabled', async () => {
+		renderComponent({modifiable: false, system: true});
+
+		const showWidgetToggle = await screen.findByRole('switch', {
+			name: 'show-widget-in-page-builder',
+		});
+
+		expect(showWidgetToggle).toBeDisabled();
+	});
+});
+
+describe('when the object definition has a root object definition', () => {
+	it('configurations are enabled', async () => {
+		renderComponent({
+			rootObjectDefinitionExternalReferenceCode: '1',
+			storageType: 'sugarcrm',
+		});
+
+		const accountRestriction = await screen.findByRole('switch', {
+			name: 'enable-account-restriction',
+		});
+
+		const panelLink = await screen.findByRole('combobox', {
+			name: 'panel-link',
+		});
+
+		const scope = await screen.findByRole('combobox', {name: 'scope'});
+
+		const showWidget = await screen.findByRole('switch', {
+			name: 'show-widget-in-page-builder',
+		});
+
+		expect(accountRestriction).toBeEnabled();
+		expect(panelLink).toBeEnabled();
+		expect(scope).toBeEnabled();
+		expect(showWidget).toBeEnabled();
+	});
+});
+
+describe('when the object definition has storageType salesforce', () => {
+	it('enable account restriction is enabled', async () => {
+		renderComponent({storageType: 'salesforce'});
+
+		const accountRestrictionToggle = await screen.findByRole('switch', {
+			name: 'enable-account-restriction',
+		});
+
+		expect(accountRestrictionToggle).toBeEnabled();
+	});
+
+	it('panel link is enabled', async () => {
+		renderComponent({storageType: 'salesforce'});
+
+		const panelLink = await screen.findByRole('combobox', {
+			name: 'panel-link',
+		});
+
+		expect(panelLink).toBeEnabled();
+	});
+
+	it('scope is disabled', async () => {
+		renderComponent({storageType: 'salesforce'});
+
+		const scope = await screen.findByRole('combobox', {
+			name: 'scope',
+		});
+
+		expect(scope).toBeDisabled();
+	});
+
+	it('show widget in page builder is enabled', async () => {
+		renderComponent({storageType: 'salesforce'});
+
+		const showWidgetToggle = await screen.findByRole('switch', {
+			name: 'show-widget-in-page-builder',
+		});
+
+		expect(showWidgetToggle).toBeEnabled();
+	});
+});

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ModelBuilder/RightSidebar/__mock__/objectDefinition.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ModelBuilder/RightSidebar/__mock__/objectDefinition.ts
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const objectDefinition = {
+	accountEntryRestricted: false,
+	accountEntryRestrictedObjectFieldId: '',
+	accountEntryRestrictedObjectFieldName: '',
+	actions: {
+		delete: {
+			href: '',
+			method: 'DELETE',
+		},
+		get: {
+			href: '',
+			method: 'GET',
+		},
+		update: {
+			href: '',
+			method: 'PATCH',
+		},
+	},
+	active: true,
+	dateCreated: '',
+	dateModified: '',
+	defaultLanguageId: 'en-US',
+	enableCategorization: true,
+	enableComments: true,
+	enableFriendlyURLCustomization: true,
+	enableIndexSearch: true,
+	enableLocalization: true,
+	enableObjectEntryDraft: true,
+	enableObjectEntryHistory: true,
+	enableObjectEntrySchedule: true,
+	enableObjectEntrySubscription: true,
+	externalReferenceCode: '',
+	friendlyURLSeparator: '',
+	id: 1,
+	label: {
+		'en-US': 'Object Definition',
+	},
+	modifiable: true,
+	name: 'Object Definition',
+	objectActions: [],
+	objectFields: [
+		{
+			businessType: 'Text',
+			defaultValue: '',
+			externalReferenceCode: '',
+			id: 1,
+			indexed: true,
+			indexedAsKeyword: false,
+			label: {en_US: 'Field'},
+			listTypeDefinitionId: 0,
+			name: 'field',
+			objectFieldSettings: [],
+			required: false,
+			system: false,
+			type: 'String',
+		},
+	],
+	objectFolderExternalReferenceCode: '',
+	objectLayouts: [],
+	objectRelationships: [],
+	objectViews: [],
+	panelCategoryKey: '',
+	pluralLabel: {
+		'en-US': '',
+	},
+	portlet: true,
+	restContextPath: '',
+	rootObjectDefinitionExternalReferenceCode: '',
+	scope: 'company',
+	status: {
+		code: 0,
+		label: 'active',
+		label_i18n: 'Active',
+	},
+	storageType: 'default',
+	system: false,
+	titleObjectFieldId: '',
+	titleObjectFieldName: '',
+};

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectDetails/ConfigurationContainer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectDetails/ConfigurationContainer.spec.tsx
@@ -44,7 +44,6 @@ describe('The ConfigurationContainer component', () => {
 				<ConfigurationContainer
 					hasUpdateObjectDefinitionPermission
 					isEnableObjectEntrySchedule={isEnableObjectEntrySchedule}
-					isRootDescendantNode={false}
 					setValues={result.current.setValues}
 					values={result.current.values}
 				/>


### PR DESCRIPTION
## What is the goal of this [task](https://liferay.atlassian.net/browse/LPD-62319)?

Ensure that the association of an object definition in a tree should no longer be among the set of information that defines when scope, panel link, account restriction, and widget display in page builder settings will be disabled.