### PR TITLE
LPD-57947

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/java/com/liferay/sample/ObjectEntryManager1RestController.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/java/com/liferay/sample/ObjectEntryManager1RestController.java
@@ -178,6 +178,8 @@ public class ObjectEntryManager1RestController extends BaseRestController {
 
 		JSONObject objectEntryJSONObject = _getObjectEntryJSONObject(json);
 
+		objectEntryJSONObject.put("externalReferenceCode", externalReferenceCode);
+
 		objectEntryJSONObjects.put(
 			externalReferenceCode, objectEntryJSONObject);
 


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-57947

Our [test](https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/tests/object-web/main/objectClientExtensions.spec.ts#L90) in objectClientExtensions.spec.ts creates an object entry (using proxy object) and then updates the entry, however at the moment it is bringing the entry's ERC as null, this PR the current ERC back to the entry, thus making the test to work again