### PR TITLE
LPD-62682 Add ERC to put method of Liferay Sample Workspace > Spring Boot

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/java/com/liferay/sample/ObjectEntryManager1RestController.java
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/src/main/java/com/liferay/sample/ObjectEntryManager1RestController.java
@@ -178,6 +178,9 @@ public class ObjectEntryManager1RestController extends BaseRestController {
 
 		JSONObject objectEntryJSONObject = _getObjectEntryJSONObject(json);
 
+		objectEntryJSONObject.put(
+			"externalReferenceCode", externalReferenceCode);
+
 		objectEntryJSONObjects.put(
 			externalReferenceCode, objectEntryJSONObject);
 


### PR DESCRIPTION
Related Issue: [LPD-62682](https://liferay.atlassian.net/browse/LPD-62682)

Upon analysing testfix for object-web/main/objectClientExtensions.spec.ts > Can create, read, update, and delete object entries that use the client extension as a storage type for [LPD-57520](https://liferay.atlassian.net/browse/LPD-57520) we've detected the test failures are caused by behavior in the Client Extension used, that is currently returning the ERC as null in the put method

This PR is meant to fix this issue, and I've confirmed that with this change the test should work fine

[LPD-62682]: https://liferay.atlassian.net/browse/LPD-62682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-57520]: https://liferay.atlassian.net/browse/LPD-57520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ