### PR TITLE
LPD-61891DatePicker is not localised part 2

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingConflictsView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingConflictsView.js
@@ -215,6 +215,23 @@ class ChangeTrackingConflictsView extends ChangeTrackingBaseScheduleView {
 							<div className={this.getDateClassName()}>
 								<div>
 									<ClayDatePicker
+										ariaLabels={{
+											buttonChooseDate: `${Liferay.Language.get(
+												'select-date'
+											)}`,
+											buttonDot: `${Liferay.Language.get(
+												'select-current-date'
+											)}`,
+											buttonNextMonth: `${Liferay.Language.get(
+												'select-next-month'
+											)}`,
+											buttonPreviousMonth: `${Liferay.Language.get(
+												'select-previous-month'
+											)}`,
+											dialog: `${Liferay.Language.get('select-date')}`,
+											selectMonth: `${Liferay.Language.get('select-a-month')}`,
+											selectYear: `${Liferay.Language.get('select-a-year')}`,
+										}}
 										disabled={
 											!!this.unresolvedConflicts.length
 										}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRescheduleView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRescheduleView.js
@@ -56,6 +56,23 @@ class ChangeTrackingRescheduleView extends ChangeTrackingBaseScheduleView {
 						<div className={this.getDateClassName()}>
 							<div>
 								<ClayDatePicker
+									ariaLabels={{
+										buttonChooseDate: `${Liferay.Language.get(
+											'select-date'
+										)}`,
+										buttonDot: `${Liferay.Language.get(
+											'select-current-date'
+										)}`,
+										buttonNextMonth: `${Liferay.Language.get(
+											'select-next-month'
+										)}`,
+										buttonPreviousMonth: `${Liferay.Language.get(
+											'select-previous-month'
+										)}`,
+										dialog: `${Liferay.Language.get('select-date')}`,
+										selectMonth: `${Liferay.Language.get('select-a-month')}`,
+										selectYear: `${Liferay.Language.get('select-a-year')}`,
+									}}
 									firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 									months={[
 										`${Liferay.Language.get('january')}`,

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/utils/openCustomDateModal.tsx
@@ -10,7 +10,7 @@ import ClayModal, {useModal} from '@clayui/modal';
 import {render} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import {useId} from 'frontend-js-components-web';
-import {navigate} from 'frontend-js-web';
+import {dateUtils, navigate} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 const NOT_SELECTED_OPTION = {
@@ -114,6 +114,38 @@ export function CustomDateModal({
 						</label>
 
 						<ClayDatePicker
+							ariaLabels={{
+								buttonChooseDate: `${Liferay.Language.get(
+									'select-date'
+								)}`,
+								buttonDot: `${Liferay.Language.get(
+									'select-current-date'
+								)}`,
+								buttonNextMonth: `${Liferay.Language.get(
+									'select-next-month'
+								)}`,
+								buttonPreviousMonth: `${Liferay.Language.get(
+									'select-previous-month'
+								)}`,
+								dialog: `${Liferay.Language.get('select-date')}`,
+								selectMonth: `${Liferay.Language.get('select-a-month')}`,
+								selectYear: `${Liferay.Language.get('select-a-year')}`,
+							}}
+							firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+							months={[
+								`${Liferay.Language.get('january')}`,
+								`${Liferay.Language.get('february')}`,
+								`${Liferay.Language.get('march')}`,
+								`${Liferay.Language.get('april')}`,
+								`${Liferay.Language.get('may')}`,
+								`${Liferay.Language.get('june')}`,
+								`${Liferay.Language.get('july')}`,
+								`${Liferay.Language.get('august')}`,
+								`${Liferay.Language.get('september')}`,
+								`${Liferay.Language.get('october')}`,
+								`${Liferay.Language.get('november')}`,
+								`${Liferay.Language.get('december')}`,
+							]}
 							onChange={(range: string) => {
 								const [start, end] = range!.split(' - ');
 
@@ -125,6 +157,7 @@ export function CustomDateModal({
 							placeholder="YYYY-MM-DD - YYYY-MM-DD"
 							range
 							value={getDateRange(startDate, endDate)}
+							weekdaysShort={dateUtils.getWeekdaysShort()}
 							years={{
 								end: new Date().getFullYear() + 10,
 								start: new Date().getFullYear() - 10,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePickerBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DatePicker/DatePickerBase.tsx
@@ -9,6 +9,7 @@ import {
 	createAutoCorrectedDatePipe,
 	datetimeUtils,
 } from '@liferay/object-js-components-web';
+import {dateUtils} from 'frontend-js-web';
 
 // @ts-ignore
 
@@ -36,7 +37,6 @@ export interface DatePickerBaseProps {
 	localizable: boolean;
 	localizedObjectField: boolean;
 	localizedValue?: LocalizedValue<string>;
-	months: string[];
 	name: string;
 	onBlur: any;
 	onChange: any;
@@ -55,7 +55,6 @@ export interface DatePickerBaseProps {
 	type: 'date' | 'date_time';
 	valid: boolean;
 	value: string | LocalizedValue<string>;
-	weekdaysShort: string[];
 }
 
 type MaskRef = {
@@ -76,7 +75,6 @@ export default function DatePickerBase({
 	htmlAutocompleteAttribute,
 	id,
 	locale,
-	months,
 	name,
 	onBlur,
 	onChange,
@@ -87,14 +85,12 @@ export default function DatePickerBase({
 	setValidField,
 	tip,
 	valid,
-	weekdaysShort,
 }: DatePickerBaseProps) {
 	const inputRef = useRef(null);
 	const maskRef = useRef<null | MaskRef>(null);
 
 	const {
 		clayFormat,
-		firstDayOfWeek,
 		isDateTime = false,
 		momentFormat = '',
 		placeholder = '',
@@ -292,9 +288,22 @@ export default function DatePickerBase({
 					dir={dir}
 					disabled={readOnly}
 					expanded={expanded}
-					firstDayOfWeek={firstDayOfWeek}
+					firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 					id={name}
-					months={months}
+					months={[
+						`${Liferay.Language.get('january')}`,
+						`${Liferay.Language.get('february')}`,
+						`${Liferay.Language.get('march')}`,
+						`${Liferay.Language.get('april')}`,
+						`${Liferay.Language.get('may')}`,
+						`${Liferay.Language.get('june')}`,
+						`${Liferay.Language.get('july')}`,
+						`${Liferay.Language.get('august')}`,
+						`${Liferay.Language.get('september')}`,
+						`${Liferay.Language.get('october')}`,
+						`${Liferay.Language.get('november')}`,
+						`${Liferay.Language.get('december')}`,
+					]}
 					onBlur={handleBlur}
 					onChange={handleValueChange}
 					onExpandedChange={handleExpandedChange}
@@ -305,7 +314,7 @@ export default function DatePickerBase({
 					time={isDateTime}
 					use12Hours={use12Hours}
 					value={formattedDate}
-					weekdaysShort={weekdaysShort}
+					weekdaysShort={dateUtils.getWeekdaysShort()}
 					years={years}
 					yearsCheck={false}
 				/>

--- a/modules/apps/fragment/fragment-collection-filter-date/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/fragment/fragment-collection-filter-date/src/main/resources/META-INF/resources/js/index.js
@@ -21,6 +21,17 @@ export function FragmentCollectionFilterDate({
 
 	return (
 		<ClayDatePicker
+			ariaLabels={{
+				buttonChooseDate: `${Liferay.Language.get('select-date')}`,
+				buttonDot: `${Liferay.Language.get('select-current-date')}`,
+				buttonNextMonth: `${Liferay.Language.get('select-next-month')}`,
+				buttonPreviousMonth: `${Liferay.Language.get(
+					'select-previous-month'
+				)}`,
+				dialog: `${Liferay.Language.get('select-date')}`,
+				selectMonth: `${Liferay.Language.get('select-a-month')}`,
+				selectYear: `${Liferay.Language.get('select-a-year')}`,
+			}}
 			disabled={isDisabled}
 			firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 			months={[

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
@@ -7,6 +7,7 @@ import ClayDatePicker from '@clayui/date-picker';
 import ClayForm from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
+import {dateUtils} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {IDateFilter, IField, IFilter} from '../../../utils/types';
@@ -209,13 +210,46 @@ function Body({
 							</label>
 
 							<ClayDatePicker
+								ariaLabels={{
+									buttonChooseDate: `${Liferay.Language.get(
+										'select-date'
+									)}`,
+									buttonDot: `${Liferay.Language.get(
+										'select-current-date'
+									)}`,
+									buttonNextMonth: `${Liferay.Language.get(
+										'select-next-month'
+									)}`,
+									buttonPreviousMonth: `${Liferay.Language.get(
+										'select-previous-month'
+									)}`,
+									dialog: `${Liferay.Language.get('select-date')}`,
+									selectMonth: `${Liferay.Language.get('select-a-month')}`,
+									selectYear: `${Liferay.Language.get('select-a-year')}`,
+								}}
 								dateFormat="yyyy-MM-dd"
+								firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 								inputName={fromFormElementId}
+								months={[
+									`${Liferay.Language.get('january')}`,
+									`${Liferay.Language.get('february')}`,
+									`${Liferay.Language.get('march')}`,
+									`${Liferay.Language.get('april')}`,
+									`${Liferay.Language.get('may')}`,
+									`${Liferay.Language.get('june')}`,
+									`${Liferay.Language.get('july')}`,
+									`${Liferay.Language.get('august')}`,
+									`${Liferay.Language.get('september')}`,
+									`${Liferay.Language.get('october')}`,
+									`${Liferay.Language.get('november')}`,
+									`${Liferay.Language.get('december')}`,
+								]}
 								onChange={(value: any) => {
 									setFrom(value);
 								}}
 								placeholder="YYYY-MM-DD"
 								value={from}
+								weekdaysShort={dateUtils.getWeekdaysShort()}
 								years={{
 									end: new Date().getFullYear() + 25,
 									start: new Date().getFullYear() - 50,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ScheduleOptions.js
@@ -52,6 +52,23 @@ export default function ScheduleOptions({
 				</label>
 
 				<ClayDatePicker
+					ariaLabels={{
+						buttonChooseDate: `${Liferay.Language.get(
+							'select-date'
+						)}`,
+						buttonDot: `${Liferay.Language.get(
+							'select-current-date'
+						)}`,
+						buttonNextMonth: `${Liferay.Language.get(
+							'select-next-month'
+						)}`,
+						buttonPreviousMonth: `${Liferay.Language.get(
+							'select-previous-month'
+						)}`,
+						dialog: `${Liferay.Language.get('select-date')}`,
+						selectMonth: `${Liferay.Language.get('select-a-month')}`,
+						selectYear: `${Liferay.Language.get('select-a-year')}`,
+					}}
 					firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 					id={`${portletNamespace}displayDatePicker`}
 					months={[

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/ScheduleModal.js
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/js/admin/components/ScheduleModal.js
@@ -104,6 +104,23 @@ export default function ScheduleModal({
 					<label>{Liferay.Language.get('date-and-time')}</label>
 
 					<ClayDatePicker
+						ariaLabels={{
+							buttonChooseDate: `${Liferay.Language.get(
+								'select-date'
+							)}`,
+							buttonDot: `${Liferay.Language.get(
+								'select-current-date'
+							)}`,
+							buttonNextMonth: `${Liferay.Language.get(
+								'select-next-month'
+							)}`,
+							buttonPreviousMonth: `${Liferay.Language.get(
+								'select-previous-month'
+							)}`,
+							dialog: `${Liferay.Language.get('select-date')}`,
+							selectMonth: `${Liferay.Language.get('select-a-month')}`,
+							selectYear: `${Liferay.Language.get('select-a-year')}`,
+						}}
 						dateFormat="yyyy-MM-dd"
 						firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 						months={[

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/DatePicker.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/DatePicker.tsx
@@ -5,6 +5,7 @@
 
 import ClayDatePicker from '@clayui/date-picker';
 import {FieldBase} from 'frontend-js-components-web';
+import {dateUtils} from 'frontend-js-web';
 
 // @ts-ignore
 
@@ -90,15 +91,10 @@ export function DatePicker({
 }: DatePickerProps) {
 	const [expanded, setExpanded] = useState(false);
 
-	const momentLocale = moment().locale(locale ?? defaultLanguageId);
-	const months = momentLocale.localeData().months();
-	const weekdaysShort = momentLocale.localeData().weekdaysShort();
-
 	const inputRef = useRef(null);
 	const maskRef = useRef<null | MaskRef>(null);
 	const {
 		clayFormat,
-		firstDayOfWeek,
 		isDateTime = false,
 		momentFormat = '',
 		placeholder,
@@ -207,12 +203,38 @@ export function DatePicker({
 			required={required}
 		>
 			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: `${Liferay.Language.get('select-date')}`,
+					buttonDot: `${Liferay.Language.get('select-current-date')}`,
+					buttonNextMonth: `${Liferay.Language.get(
+						'select-next-month'
+					)}`,
+					buttonPreviousMonth: `${Liferay.Language.get(
+						'select-previous-month'
+					)}`,
+					dialog: `${Liferay.Language.get('select-date')}`,
+					selectMonth: `${Liferay.Language.get('select-a-month')}`,
+					selectYear: `${Liferay.Language.get('select-a-year')}`,
+				}}
 				dateFormat={clayFormat}
 				disabled={disabled}
 				expanded={expanded}
-				firstDayOfWeek={firstDayOfWeek}
+				firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 				id={id}
-				months={months}
+				months={[
+					`${Liferay.Language.get('january')}`,
+					`${Liferay.Language.get('february')}`,
+					`${Liferay.Language.get('march')}`,
+					`${Liferay.Language.get('april')}`,
+					`${Liferay.Language.get('may')}`,
+					`${Liferay.Language.get('june')}`,
+					`${Liferay.Language.get('july')}`,
+					`${Liferay.Language.get('august')}`,
+					`${Liferay.Language.get('september')}`,
+					`${Liferay.Language.get('october')}`,
+					`${Liferay.Language.get('november')}`,
+					`${Liferay.Language.get('december')}`,
+				]}
 				onBlur={onBlur}
 				onChange={handleValueChange}
 				onExpandedChange={() => {
@@ -225,7 +247,7 @@ export function DatePicker({
 				time={isDateTime}
 				use12Hours={use12Hours}
 				value={formattedDate}
-				weekdaysShort={weekdaysShort}
+				weekdaysShort={dateUtils.getWeekdaysShort()}
 				years={years}
 				yearsCheck={false}
 			/>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/DateTimeInput.tsx
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/inputs/DateTimeInput.tsx
@@ -103,6 +103,7 @@ function DateTimeInput({
 				dateFormat="yyyy/MM/dd"
 				disabled={disabled}
 				expanded={expanded}
+				firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 				months={[
 					`${Liferay.Language.get('january')}`,
 					`${Liferay.Language.get('february')}`,
@@ -121,6 +122,7 @@ function DateTimeInput({
 				onChange={setDisplayDate}
 				onExpandedChange={onExpandedChange}
 				value={displayDate}
+				weekdaysShort={dateUtils.getWeekdaysShort()}
 				years={{
 					end: new Date().getFullYear(),
 					start: 1900,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/RangeSelectorsDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/RangeSelectorsDropdown.test.tsx
@@ -13,6 +13,21 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+jest.mock('frontend-js-web', () => ({
+	dateUtils: {
+		getFirstDayOfWeek: jest.fn(() => 0),
+		getWeekdaysShort: jest.fn(() => [
+			'Sun',
+			'Mon',
+			'Tue',
+			'Wed',
+			'Thu',
+			'Fri',
+			'Sat',
+		]),
+	},
+}));
+
 describe('[CMS Dashboard] Components: RangeSelectorsDropdown', () => {
 	const mockedOnChange = jest.fn();
 	const mockedProps: IRangeSelectorsDropdown = {

--- a/modules/dxp/apps/analytics/analytics-reports-js-components-web/src/main/resources/META-INF/resources/js/components/RangeSelectorsDropdown.tsx
+++ b/modules/dxp/apps/analytics/analytics-reports-js-components-web/src/main/resources/META-INF/resources/js/components/RangeSelectorsDropdown.tsx
@@ -9,6 +9,7 @@ import ClayDatePicker from '@clayui/date-picker';
 import ClayDropdown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
+import {dateUtils} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 type Item = {
@@ -154,11 +155,44 @@ const CustomRangeView: React.FC<Omit<IView, 'availableRangeSelectors'>> = ({
 					</label>
 
 					<ClayDatePicker
+						ariaLabels={{
+							buttonChooseDate: `${Liferay.Language.get(
+								'select-date'
+							)}`,
+							buttonDot: `${Liferay.Language.get(
+								'select-current-date'
+							)}`,
+							buttonNextMonth: `${Liferay.Language.get(
+								'select-next-month'
+							)}`,
+							buttonPreviousMonth: `${Liferay.Language.get(
+								'select-previous-month'
+							)}`,
+							dialog: `${Liferay.Language.get('select-date')}`,
+							selectMonth: `${Liferay.Language.get('select-a-month')}`,
+							selectYear: `${Liferay.Language.get('select-a-year')}`,
+						}}
 						dateFormat="yyyy-MM-dd"
+						firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 						inputName="rangeStartId"
+						months={[
+							`${Liferay.Language.get('january')}`,
+							`${Liferay.Language.get('february')}`,
+							`${Liferay.Language.get('march')}`,
+							`${Liferay.Language.get('april')}`,
+							`${Liferay.Language.get('may')}`,
+							`${Liferay.Language.get('june')}`,
+							`${Liferay.Language.get('july')}`,
+							`${Liferay.Language.get('august')}`,
+							`${Liferay.Language.get('september')}`,
+							`${Liferay.Language.get('october')}`,
+							`${Liferay.Language.get('november')}`,
+							`${Liferay.Language.get('december')}`,
+						]}
 						onChange={setRangeStart}
 						placeholder="YYYY-MM-DD"
 						value={rangeStart}
+						weekdaysShort={dateUtils.getWeekdaysShort()}
 						years={{
 							end: new Date().getFullYear() + 25,
 							start: new Date().getFullYear() - 50,

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/objects/fields/DateField.tsx
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/objects/fields/DateField.tsx
@@ -99,11 +99,40 @@ const DateField = ({
 			</label>
 
 			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: `${Liferay.Language.get('select-date')}`,
+					buttonDot: `${Liferay.Language.get('select-current-date')}`,
+					buttonNextMonth: `${Liferay.Language.get(
+						'select-next-month'
+					)}`,
+					buttonPreviousMonth: `${Liferay.Language.get(
+						'select-previous-month'
+					)}`,
+					dialog: `${Liferay.Language.get('select-date')}`,
+					selectMonth: `${Liferay.Language.get('select-a-month')}`,
+					selectYear: `${Liferay.Language.get('select-a-year')}`,
+				}}
 				disabled={disabled || readOnly}
+				firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
 				id={`${namespace}${id}`}
 				inputName={`${namespace}${name}`}
+				months={[
+					`${Liferay.Language.get('january')}`,
+					`${Liferay.Language.get('february')}`,
+					`${Liferay.Language.get('march')}`,
+					`${Liferay.Language.get('april')}`,
+					`${Liferay.Language.get('may')}`,
+					`${Liferay.Language.get('june')}`,
+					`${Liferay.Language.get('july')}`,
+					`${Liferay.Language.get('august')}`,
+					`${Liferay.Language.get('september')}`,
+					`${Liferay.Language.get('october')}`,
+					`${Liferay.Language.get('november')}`,
+					`${Liferay.Language.get('december')}`,
+				]}
 				onChange={onChangeHandler}
 				value={internalValue}
+				weekdaysShort={dateUtils.getWeekdaysShort()}
 				years={{
 					end: new Date().getFullYear() + 100,
 					start: new Date().getFullYear() - 100,

--- a/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/panels/EditUserInfoPanel.js
+++ b/modules/dxp/apps/commerce/commerce-organization-web/src/main/resources/META-INF/resources/js/panels/EditUserInfoPanel.js
@@ -643,6 +643,23 @@ function EditUserInfoPanel({
 						</label>
 
 						<ClayDatePicker
+							ariaLabels={{
+								buttonChooseDate: `${Liferay.Language.get(
+									'select-date'
+								)}`,
+								buttonDot: `${Liferay.Language.get(
+									'select-current-date'
+								)}`,
+								buttonNextMonth: `${Liferay.Language.get(
+									'select-next-month'
+								)}`,
+								buttonPreviousMonth: `${Liferay.Language.get(
+									'select-previous-month'
+								)}`,
+								dialog: `${Liferay.Language.get('select-date')}`,
+								selectMonth: `${Liferay.Language.get('select-a-month')}`,
+								selectYear: `${Liferay.Language.get('select-a-year')}`,
+							}}
 							dateFormat="P"
 							disabled={isLoading}
 							firstDayOfWeek={dateUtils.getFirstDayOfWeek()}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/DateInput.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/sxp_element/DateInput.js
@@ -20,6 +20,19 @@ function DateInput({disabled, name, setFieldTouched, setFieldValue, value}) {
 	return (
 		<div className="date-picker-input" onBlur={() => setFieldTouched(name)}>
 			<ClayDatePicker
+				ariaLabels={{
+					buttonChooseDate: `${Liferay.Language.get('select-date')}`,
+					buttonDot: `${Liferay.Language.get('select-current-date')}`,
+					buttonNextMonth: `${Liferay.Language.get(
+						'select-next-month'
+					)}`,
+					buttonPreviousMonth: `${Liferay.Language.get(
+						'select-previous-month'
+					)}`,
+					dialog: `${Liferay.Language.get('select-date')}`,
+					selectMonth: `${Liferay.Language.get('select-a-month')}`,
+					selectYear: `${Liferay.Language.get('select-a-year')}`,
+				}}
 				dateFormat="MM/dd/yyyy"
 				disabled={disabled}
 				firstDayOfWeek={dateUtils.getFirstDayOfWeek()}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/pages/data_set/tabs/FiltersPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/pages/data_set/tabs/FiltersPage.ts
@@ -116,7 +116,7 @@ export class FiltersPage {
 		};
 		this.newDateRangeFilterForm = {
 			...this.newFilterForm,
-			datePicker: page.getByRole('dialog', {name: 'Choose date'}),
+			datePicker: page.getByRole('dialog', {name: 'Select date'}),
 			fromDatePickerTrigger: page
 				.locator('div')
 				.filter({hasText: /^From$/})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61891

Hey BPM team! Could you please review in this PR the changes related to your components? This was requested by [slack](https://liferay.slack.com/archives/C026NQPV6TV/p1753863832116769) some days ago, but I guess this would have more visibility for your team. 
It has been reviewed and approved by [Frontend Infra](https://github.com/liferay-frontend/liferay-portal/pull/5027) team and by Cloud (Adriano), so if you think it is ok, feel free to forward it.  

Comment from @balazssk: 

> Adds ariaLabels usages and firstDayOfWeek, months and weekdaysShort (where [part 1](https://liferay.atlassian.net/browse/LPD-60402) missed out) to ClayDatePicker
> 
> Separated DDM https://github.com/liferay-frontend/liferay-portal/commit/12862d60218b01d88a06c716f1b2f5823a5f320b and Objects https://github.com/liferay-frontend/liferay-portal/commit/5ad1d0bd6d0f1b5b551444cca49fab3965f4469a changes because in those cases some api changes were needed and I'm not 100% sure if I covered all changes needed.