### PR TITLE
LPD-61566 Performance test when getting object entries with nested fields object relationship names

### DIFF
--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/related/models/DeleteOnDisassociateObjectRelatedModelsProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/related/models/DeleteOnDisassociateObjectRelatedModelsProvider.java
@@ -93,8 +93,19 @@ public class DeleteOnDisassociateObjectRelatedModelsProvider
 			String search, int start, int end)
 		throws PortalException {
 
+		return getRelatedModels(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search,
+			start, end);
+	}
+
+	@Override
+	public List<ObjectEntry> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search, int start, int end)
+		throws PortalException {
+
 		return _objectRelatedModelsProvider.getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, search, start, end);
+			groupId, objectRelationshipId, primaryKeys, search, start, end);
 	}
 
 	@Override
@@ -103,8 +114,18 @@ public class DeleteOnDisassociateObjectRelatedModelsProvider
 			String search)
 		throws PortalException {
 
+		return getRelatedModelsCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search);
+	}
+
+	@Override
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search)
+		throws PortalException {
+
 		return _objectRelatedModelsProvider.getRelatedModelsCount(
-			groupId, objectRelationshipId, primaryKey, search);
+			groupId, objectRelationshipId, primaryKeys, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 110.0.1
+Bundle-Version: 111.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsProvider.java
@@ -46,8 +46,18 @@ public interface ObjectRelatedModelsProvider<T extends BaseModel<T>> {
 			String search, int start, int end)
 		throws PortalException;
 
+	public List<T> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search, int start, int end)
+		throws PortalException;
+
 	public int getRelatedModelsCount(
 			long groupId, long objectRelationshipId, long primaryKey,
+			String search)
+		throws PortalException;
+
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search)
 		throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -294,8 +294,20 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectEntry> getManyToManyObjectEntries(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, boolean reverse, String search, int start, int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getManyToManyObjectEntriesCount(
 			long groupId, long objectRelationshipId, long primaryKey,
+			boolean related, boolean reverse, String search)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getManyToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException;
 
@@ -415,8 +427,20 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectEntry> getOneToManyObjectEntries(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, String search, int start, int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getOneToManyObjectEntriesCount(
 			long groupId, long objectRelationshipId, long primaryKey,
+			boolean related, String search)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getOneToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -371,6 +371,16 @@ public class ObjectEntryLocalServiceUtil {
 			start, end);
 	}
 
+	public static List<ObjectEntry> getManyToManyObjectEntries(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, boolean reverse, String search, int start, int end)
+		throws PortalException {
+
+		return getService().getManyToManyObjectEntries(
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
+	}
+
 	public static int getManyToManyObjectEntriesCount(
 			long groupId, long objectRelationshipId, long primaryKey,
 			boolean related, boolean reverse, String search)
@@ -378,6 +388,16 @@ public class ObjectEntryLocalServiceUtil {
 
 		return getService().getManyToManyObjectEntriesCount(
 			groupId, objectRelationshipId, primaryKey, related, reverse,
+			search);
+	}
+
+	public static int getManyToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, boolean reverse, String search)
+		throws PortalException {
+
+		return getService().getManyToManyObjectEntriesCount(
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -538,6 +558,16 @@ public class ObjectEntryLocalServiceUtil {
 			end);
 	}
 
+	public static List<ObjectEntry> getOneToManyObjectEntries(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, String search, int start, int end)
+		throws PortalException {
+
+		return getService().getOneToManyObjectEntries(
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
+			end);
+	}
+
 	public static int getOneToManyObjectEntriesCount(
 			long groupId, long objectRelationshipId, long primaryKey,
 			boolean related, String search)
@@ -545,6 +575,15 @@ public class ObjectEntryLocalServiceUtil {
 
 		return getService().getOneToManyObjectEntriesCount(
 			groupId, objectRelationshipId, primaryKey, related, search);
+	}
+
+	public static int getOneToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, String search)
+		throws PortalException {
+
+		return getService().getOneToManyObjectEntriesCount(
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	public static ObjectEntry getOrAddEmptyObjectEntry(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -420,6 +420,19 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<com.liferay.object.model.ObjectEntry>
+			getManyToManyObjectEntries(
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
+				boolean related, boolean reverse, String search, int start,
+				int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getManyToManyObjectEntries(
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
+	}
+
+	@Override
 	public int getManyToManyObjectEntriesCount(
 			long groupId, long objectRelationshipId, long primaryKey,
 			boolean related, boolean reverse, String search)
@@ -427,6 +440,17 @@ public class ObjectEntryLocalServiceWrapper
 
 		return _objectEntryLocalService.getManyToManyObjectEntriesCount(
 			groupId, objectRelationshipId, primaryKey, related, reverse,
+			search);
+	}
+
+	@Override
+	public int getManyToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, boolean reverse, String search)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getManyToManyObjectEntriesCount(
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -616,6 +640,18 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<com.liferay.object.model.ObjectEntry>
+			getOneToManyObjectEntries(
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
+				boolean related, String search, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getOneToManyObjectEntries(
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
+			end);
+	}
+
+	@Override
 	public int getOneToManyObjectEntriesCount(
 			long groupId, long objectRelationshipId, long primaryKey,
 			boolean related, String search)
@@ -623,6 +659,16 @@ public class ObjectEntryLocalServiceWrapper
 
 		return _objectEntryLocalService.getOneToManyObjectEntriesCount(
 			groupId, objectRelationshipId, primaryKey, related, search);
+	}
+
+	@Override
+	public int getOneToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, String search)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getOneToManyObjectEntriesCount(
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -88,13 +88,13 @@ public interface ObjectEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException;
 
@@ -114,13 +114,13 @@ public interface ObjectEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException;
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -101,22 +101,22 @@ public class ObjectEntryServiceUtil {
 	}
 
 	public static List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
 		return getService().getManyToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, reverse, search,
-			start, end);
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
 	}
 
 	public static int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		return getService().getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -143,22 +143,22 @@ public class ObjectEntryServiceUtil {
 	}
 
 	public static List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
 			end);
 	}
 
 	public static int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	public static ObjectEntry getOrAddEmptyObjectEntry(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -107,24 +107,24 @@ public class ObjectEntryServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getManyToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
 				boolean related, boolean reverse, String search, int start,
 				int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getManyToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, reverse, search,
-			start, end);
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
+			search, start, end);
 	}
 
 	@Override
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -158,23 +158,23 @@ public class ObjectEntryServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
+				long groupId, long objectRelationshipId, Long[] primaryKeys,
 				boolean related, String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
+			groupId, objectRelationshipId, primaryKeys, related, search, start,
 			end);
 	}
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
@@ -1,1 +1,1 @@
-version 9.1.0
+version 9.2.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 76.0.0
+version 77.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -882,6 +882,14 @@ public class ObjectEntryDTOConverter
 				ObjectDefinition objectDefinition, long primaryKey)
 		throws Exception {
 
+		Map<String, Map<Long, List<com.liferay.object.model.ObjectEntry>>>
+			objectRelationshipRelatedObjectEntriesMap =
+				(Map
+					<String,
+					 Map<Long, List<com.liferay.object.model.ObjectEntry>>>)
+						 dtoConverterContext.getAttribute(
+							 "objectRelationshipRelatedObjectEntriesMap");
+
 		return NestedFieldsSupplier.supplyUnsafeSupplier(
 			nestedFieldName -> {
 				ObjectRelationship objectRelationship =
@@ -921,11 +929,27 @@ public class ObjectEntryDTOConverter
 					relatedObjectDefinitionGroupId = 0;
 				}
 
-				List<?> relatedModels =
-					objectRelatedModelsProvider.getRelatedModels(
-						relatedObjectDefinitionGroupId,
-						objectRelationship.getObjectRelationshipId(),
-						primaryKey, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				List<?> relatedModels;
+
+				if ((objectRelationshipRelatedObjectEntriesMap != null) &&
+					objectRelationshipRelatedObjectEntriesMap.containsKey(
+						objectRelationship.getName())) {
+
+					Map<Long, List<com.liferay.object.model.ObjectEntry>>
+						relatedObjectEntriesMap =
+							objectRelationshipRelatedObjectEntriesMap.get(
+								objectRelationship.getName());
+
+					relatedModels = relatedObjectEntriesMap.get(primaryKey);
+				}
+				else {
+					relatedModels =
+						objectRelatedModelsProvider.getRelatedModels(
+							relatedObjectDefinitionGroupId,
+							objectRelationship.getObjectRelationshipId(),
+							new Long[] {primaryKey}, null, QueryUtil.ALL_POS,
+							QueryUtil.ALL_POS);
+				}
 
 				if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 					SystemObjectDefinitionManager

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -663,6 +663,22 @@ public class DefaultObjectEntryManagerImpl
 			groupIds = new Long[] {groupId};
 		}
 
+		List<Long> primaryKeys = objectEntryLocalService.getPrimaryKeys(
+			groupIds, companyId, dtoConverterContext.getUserId(),
+			objectDefinition.getObjectDefinitionId(), predicate, search, start,
+			end, sorts);
+
+		Map<String, Map<Long, List<com.liferay.object.model.ObjectEntry>>>
+			objectRelationshipRelatedObjectEntriesMap = new HashMap<>();
+
+		_populateObjectRelationshipRelatedObjectEntriesMap(
+			groupId, objectDefinition,
+			objectRelationshipRelatedObjectEntriesMap, primaryKeys);
+
+		dtoConverterContext.setAttribute(
+			"objectRelationshipRelatedObjectEntriesMap",
+			objectRelationshipRelatedObjectEntriesMap);
+
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -703,10 +719,7 @@ public class DefaultObjectEntryManagerImpl
 			).build(),
 			facets,
 			TransformUtil.transform(
-				objectEntryLocalService.getPrimaryKeys(
-					groupIds, companyId, dtoConverterContext.getUserId(),
-					objectDefinition.getObjectDefinitionId(), predicate, search,
-					start, end, sorts),
+				primaryKeys,
 				primaryKey -> _getObjectEntry(
 					dtoConverterContext, objectDefinition, primaryKey)),
 			pagination,
@@ -2395,6 +2408,102 @@ public class DefaultObjectEntryManagerImpl
 		return false;
 	}
 
+	private void _populateObjectRelationshipRelatedObjectEntriesMap(
+			long groupId, ObjectDefinition objectDefinition,
+			Map<String, Map<Long, List<com.liferay.object.model.ObjectEntry>>>
+				objectRelationshipRelatedObjectEntriesMap,
+			List<Long> primaryKeys)
+		throws Exception {
+
+		if (primaryKeys.isEmpty()) {
+			return;
+		}
+
+		NestedFieldsSupplier.supplyUnsafeSupplier(
+			nestedFieldName -> {
+				ObjectRelationship objectRelationship =
+					_objectRelationshipLocalService.
+						fetchObjectRelationshipByObjectDefinitionId1(
+							objectDefinition.getObjectDefinitionId(),
+							nestedFieldName);
+
+				if ((objectRelationship == null) ||
+					!objectRelationship.isAllowedObjectRelationshipType(
+						objectRelationship.getType()) ||
+					objectRelationship.isSelf()) {
+
+					return null;
+				}
+
+				ObjectDefinition relatedObjectDefinition =
+					_objectDefinitionLocalService.getObjectDefinition(
+						objectRelationship.getObjectDefinitionId2());
+
+				if (!relatedObjectDefinition.isActive() ||
+					!Objects.equals(
+						objectRelationship.getType(),
+						ObjectRelationshipConstants.TYPE_ONE_TO_MANY) ||
+					relatedObjectDefinition.isUnmodifiableSystemObject()) {
+
+					return null;
+				}
+
+				ObjectRelatedModelsProvider objectRelatedModelsProvider =
+					_objectRelatedModelsProviderRegistry.
+						getObjectRelatedModelsProvider(
+							relatedObjectDefinition.getClassName(),
+							relatedObjectDefinition.getCompanyId(),
+							objectRelationship.getType());
+
+				long relatedObjectDefinitionGroupId = groupId;
+
+				if (Objects.equals(
+						relatedObjectDefinition.getScope(),
+						ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+					relatedObjectDefinitionGroupId = 0;
+				}
+
+				List<com.liferay.object.model.ObjectEntry> objectEntries =
+					objectRelatedModelsProvider.getRelatedModels(
+						relatedObjectDefinitionGroupId,
+						objectRelationship.getObjectRelationshipId(),
+						primaryKeys.toArray(new Long[0]), null,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+				ObjectField relationshipObjectField =
+					_objectFieldLocalService.fetchObjectField(
+						objectRelationship.getObjectFieldId2());
+
+				Map<Long, List<com.liferay.object.model.ObjectEntry>>
+					relatedObjectEntriesMap = new HashMap<>();
+
+				primaryKeys.forEach(
+					primaryKey -> relatedObjectEntriesMap.put(
+						primaryKey, new ArrayList<>()));
+
+				for (com.liferay.object.model.ObjectEntry objectEntry :
+						objectEntries) {
+
+					Map<String, Serializable> values = objectEntry.getValues();
+
+					Long parentObjectEntryId = GetterUtil.getLong(
+						values.get(relationshipObjectField.getName()));
+
+					List<com.liferay.object.model.ObjectEntry>
+						relatedObjectEntries = relatedObjectEntriesMap.get(
+							parentObjectEntryId);
+
+					relatedObjectEntries.add(objectEntry);
+				}
+
+				objectRelationshipRelatedObjectEntriesMap.put(
+					objectRelationship.getName(), relatedObjectEntriesMap);
+
+				return null;
+			});
+	}
+
 	private long _processAttachment(
 			ObjectDefinition objectDefinition, ObjectField objectField,
 			Object propertyValue, String scopeKey,
@@ -2880,6 +2989,10 @@ public class DefaultObjectEntryManagerImpl
 
 		defaultDTOConverterContext.setAttribute(
 			"objectDefinition", objectDefinition);
+		defaultDTOConverterContext.setAttribute(
+			"objectRelationshipRelatedObjectEntriesMap",
+			dtoConverterContext.getAttribute(
+				"objectRelationshipRelatedObjectEntriesMap"));
 
 		return _objectEntryDTOConverter.toDTO(
 			defaultDTOConverterContext, serviceBuilderObjectEntry);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
@@ -56,7 +56,7 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, 0, 1);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null, 0, 1);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -143,8 +143,19 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 			String search, int start, int end)
 		throws PortalException {
 
+		return getRelatedModels(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search,
+			start, end);
+	}
+
+	@Override
+	public List<ObjectEntry> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search, int start, int end)
+		throws PortalException {
+
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, true, search, 0, 1);
+			groupId, objectRelationshipId, primaryKeys, true, search, 0, 1);
 	}
 
 	@Override
@@ -153,8 +164,18 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 			String search)
 		throws PortalException {
 
+		return getRelatedModelsCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search);
+	}
+
+	@Override
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search)
+		throws PortalException {
+
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, search, 0, 1);
+			groupId, objectRelationshipId, primaryKeys, search, 0, 1);
 
 		return relatedModels.size();
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
@@ -57,8 +57,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -152,8 +152,19 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 			String search, int start, int end)
 		throws PortalException {
 
+		return getRelatedModels(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search,
+			start, end);
+	}
+
+	@Override
+	public List<ObjectEntry> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search, int start, int end)
+		throws PortalException {
+
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, true, search, start,
+			groupId, objectRelationshipId, primaryKeys, true, search, start,
 			end);
 	}
 
@@ -163,8 +174,18 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 			String search)
 		throws PortalException {
 
+		return getRelatedModelsCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search);
+	}
+
+	@Override
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search)
+		throws PortalException {
+
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, true, search);
+			groupId, objectRelationshipId, primaryKeys, true, search);
 	}
 
 	@Override
@@ -175,8 +196,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, objectEntryId, false, search, start,
-			end);
+			groupId, objectRelationshipId, new Long[] {objectEntryId}, false,
+			search, start, end);
 	}
 
 	@Override
@@ -186,7 +207,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, objectEntryId, false, search);
+			groupId, objectRelationshipId, new Long[] {objectEntryId}, false,
+			search);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsProviderImpl.java
@@ -46,8 +46,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -107,8 +107,19 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 		return ObjectRelationshipConstants.TYPE_MANY_TO_MANY;
 	}
 
+	@Override
 	public List<ObjectEntry> getRelatedModels(
 			long groupId, long objectRelationshipId, long primaryKey,
+			String search, int start, int end)
+		throws PortalException {
+
+		return getRelatedModels(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search,
+			start, end);
+	}
+
+	public List<ObjectEntry> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			String search, int start, int end)
 		throws PortalException {
 
@@ -117,7 +128,7 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		return _objectEntryService.getManyToManyObjectEntries(
-			groupId, objectRelationship.getObjectRelationshipId(), primaryKey,
+			groupId, objectRelationship.getObjectRelationshipId(), primaryKeys,
 			true, objectRelationship.isReverse(), search, start, end);
 	}
 
@@ -127,12 +138,22 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 			String search)
 		throws PortalException {
 
+		return getRelatedModelsCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search);
+	}
+
+	@Override
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search)
+		throws PortalException {
+
 		ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.getObjectRelationship(
 				objectRelationshipId);
 
 		return _objectEntryService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationship.getObjectRelationshipId(), primaryKey,
+			groupId, objectRelationship.getObjectRelationshipId(), primaryKeys,
 			true, objectRelationship.isReverse(), search);
 	}
 
@@ -149,8 +170,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 
 		return _objectEntryService.getManyToManyObjectEntries(
 			groupId, objectRelationship.getObjectRelationshipId(),
-			objectEntryId, false, objectRelationship.isReverse(), search, start,
-			end);
+			new Long[] {objectEntryId}, false, objectRelationship.isReverse(),
+			search, start, end);
 	}
 
 	@Override
@@ -165,7 +186,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 
 		return _objectEntryService.getManyToManyObjectEntriesCount(
 			groupId, objectRelationship.getObjectRelationshipId(),
-			objectEntryId, false, objectRelationship.isReverse(), search);
+			new Long[] {objectEntryId}, false, objectRelationship.isReverse(),
+			search);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
@@ -85,8 +85,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<T> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -253,6 +253,17 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 			String search, int start, int end)
 		throws PortalException {
 
+		return getRelatedModels(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search,
+			start, end);
+	}
+
+	@Override
+	public List<T> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search, int start, int end)
+		throws PortalException {
+
 		PersistedModelLocalService persistedModelLocalService =
 			PersistedModelLocalServiceRegistryUtil.
 				getPersistedModelLocalService(
@@ -261,7 +272,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 		DSLQuery dslQuery = _getGroupByStep(
 			_getDynamicObjectDefinitionTable(),
 			DSLQueryFactoryUtil.selectDistinct(_table), groupId,
-			objectRelationshipId, primaryKey, search
+			objectRelationshipId, primaryKeys, search
 		).orderBy(
 			_systemObjectDefinitionManager.getPrimaryKeyColumn(
 			).ascending()
@@ -278,6 +289,16 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 			String search)
 		throws PortalException {
 
+		return getRelatedModelsCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search);
+	}
+
+	@Override
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search)
+		throws PortalException {
+
 		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
 			_getDynamicObjectDefinitionTable();
 
@@ -291,7 +312,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 				dynamicObjectDefinitionTable,
 				DSLQueryFactoryUtil.countDistinct(
 					dynamicObjectDefinitionTable.getPrimaryKeyColumn()),
-				groupId, objectRelationshipId, primaryKey, search));
+				groupId, objectRelationshipId, primaryKeys, search));
 	}
 
 	@Override
@@ -388,7 +409,7 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 	private GroupByStep _getGroupByStep(
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, String search)
+			Long[] primaryKeys, String search)
 		throws PortalException {
 
 		Column<?, Long> primaryKeyColumn = null;
@@ -445,8 +466,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 		}
 
 		return joinStep.where(
-			primaryKeyColumn.eq(
-				primaryKey
+			primaryKeyColumn.in(
+				primaryKeys
 			).and(
 				() -> {
 					Column<?, Long> groupIdColumn = _table.getColumn("groupId");

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
@@ -71,8 +71,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<T> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, new Long[] {primaryKey}, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -142,6 +142,17 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 			String search, int start, int end)
 		throws PortalException {
 
+		return getRelatedModels(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search,
+			start, end);
+	}
+
+	@Override
+	public List<T> getRelatedModels(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search, int start, int end)
+		throws PortalException {
+
 		PersistedModelLocalService persistedModelLocalService =
 			PersistedModelLocalServiceRegistryUtil.
 				getPersistedModelLocalService(
@@ -150,7 +161,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		return persistedModelLocalService.dslQuery(
 			_getGroupByStep(
 				DSLQueryFactoryUtil.selectDistinct(_table), groupId,
-				objectRelationshipId, primaryKey, search
+				objectRelationshipId, primaryKeys, search
 			).orderBy(
 				_systemObjectDefinitionManager.getPrimaryKeyColumn(
 				).ascending()
@@ -165,6 +176,16 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 			String search)
 		throws PortalException {
 
+		return getRelatedModelsCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, search);
+	}
+
+	@Override
+	public int getRelatedModelsCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			String search)
+		throws PortalException {
+
 		PersistedModelLocalService persistedModelLocalService =
 			PersistedModelLocalServiceRegistryUtil.
 				getPersistedModelLocalService(
@@ -175,7 +196,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 				DSLQueryFactoryUtil.countDistinct(
 					_table.getColumn(
 						_objectDefinition.getPKObjectFieldDBColumnName())),
-				groupId, objectRelationshipId, primaryKey, search));
+				groupId, objectRelationshipId, primaryKeys, search));
 	}
 
 	@Override
@@ -223,7 +244,7 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 
 	private GroupByStep _getGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, String search)
+			Long[] primaryKeys, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -284,8 +305,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		}
 
 		return joinStep.where(
-			primaryKeyColumn1.eq(
-				primaryKey
+			primaryKeyColumn1.in(
+				primaryKeys
 			).and(
 				() -> {
 					Column<?, Long> groupIdColumn = _table.getColumn("groupId");

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -373,7 +373,7 @@ public class ObjectEntryServiceHttp {
 	public static java.util.List<com.liferay.object.model.ObjectEntry>
 			getManyToManyObjectEntries(
 				HttpPrincipal httpPrincipal, long groupId,
-				long objectRelationshipId, long primaryKey, boolean related,
+				long objectRelationshipId, Long[] primaryKeys, boolean related,
 				boolean reverse, String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -383,7 +383,7 @@ public class ObjectEntryServiceHttp {
 				_getManyToManyObjectEntriesParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				reverse, search, start, end);
 
 			Object returnObj = null;
@@ -417,7 +417,7 @@ public class ObjectEntryServiceHttp {
 
 	public static int getManyToManyObjectEntriesCount(
 			HttpPrincipal httpPrincipal, long groupId,
-			long objectRelationshipId, long primaryKey, boolean related,
+			long objectRelationshipId, Long[] primaryKeys, boolean related,
 			boolean reverse, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -427,7 +427,7 @@ public class ObjectEntryServiceHttp {
 				_getManyToManyObjectEntriesCountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				reverse, search);
 
 			Object returnObj = null;
@@ -586,7 +586,7 @@ public class ObjectEntryServiceHttp {
 	public static java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
 				HttpPrincipal httpPrincipal, long groupId,
-				long objectRelationshipId, long primaryKey, boolean related,
+				long objectRelationshipId, Long[] primaryKeys, boolean related,
 				String search, int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -596,7 +596,7 @@ public class ObjectEntryServiceHttp {
 				_getOneToManyObjectEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				search, start, end);
 
 			Object returnObj = null;
@@ -630,7 +630,7 @@ public class ObjectEntryServiceHttp {
 
 	public static int getOneToManyObjectEntriesCount(
 			HttpPrincipal httpPrincipal, long groupId,
-			long objectRelationshipId, long primaryKey, boolean related,
+			long objectRelationshipId, Long[] primaryKeys, boolean related,
 			String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -640,7 +640,7 @@ public class ObjectEntryServiceHttp {
 				_getOneToManyObjectEntriesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
+				methodKey, groupId, objectRelationshipId, primaryKeys, related,
 				search);
 
 			Object returnObj = null;
@@ -1151,12 +1151,12 @@ public class ObjectEntryServiceHttp {
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[] _getManyToManyObjectEntriesParameterTypes8 =
 		new Class[] {
-			long.class, long.class, long.class, boolean.class, boolean.class,
+			long.class, long.class, Long[].class, boolean.class, boolean.class,
 			String.class, int.class, int.class
 		};
 	private static final Class<?>[]
 		_getManyToManyObjectEntriesCountParameterTypes9 = new Class[] {
-			long.class, long.class, long.class, boolean.class, boolean.class,
+			long.class, long.class, Long[].class, boolean.class, boolean.class,
 			String.class
 		};
 	private static final Class<?>[]
@@ -1167,12 +1167,12 @@ public class ObjectEntryServiceHttp {
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes13 =
 		new Class[] {
-			long.class, long.class, long.class, boolean.class, String.class,
+			long.class, long.class, Long[].class, boolean.class, String.class,
 			int.class, int.class
 		};
 	private static final Class<?>[]
 		_getOneToManyObjectEntriesCountParameterTypes14 = new Class[] {
-			long.class, long.class, long.class, boolean.class, String.class
+			long.class, long.class, Long[].class, boolean.class, String.class
 		};
 	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes15 =
 		new Class[] {String.class, long.class, long.class, long.class};

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4022,13 +4022,19 @@ public class ObjectEntryLocalServiceImpl
 		ObjectField objectField = _objectFieldPersistence.fetchByPrimaryKey(
 			objectRelationship.getObjectFieldId2());
 
-		ObjectEntry objectEntry = fetchObjectEntry(primaryKey);
+		ObjectEntry objectEntry = null;
+
+		if (primaryKeys.length == 1) {
+			objectEntry = fetchObjectEntry(primaryKeys[0]);
+		}
 
 		DynamicObjectDefinitionTable rootDynamicObjectDefinitionTable =
 			_getRootDynamicObjectDefinitionTable(objectEntry);
 
 		Column<DynamicObjectDefinitionTable, Long> primaryKeyColumn =
 			dynamicObjectDefinitionTable.getPrimaryKeyColumn();
+
+		ObjectEntry finalObjectEntry = objectEntry;
 
 		return fromStep.from(
 			dynamicObjectDefinitionTable
@@ -4101,11 +4107,11 @@ public class ObjectEntryLocalServiceImpl
 
 					long rootObjectDefinitionId = 0L;
 
-					if ((objectEntry != null) &&
-						(objectEntry.getRootObjectEntryId() != 0)) {
+					if ((finalObjectEntry != null) &&
+						(finalObjectEntry.getRootObjectEntryId() != 0)) {
 
 						ObjectEntry rootObjectEntry = fetchObjectEntry(
-							objectEntry.getRootObjectEntryId());
+							finalObjectEntry.getRootObjectEntryId());
 
 						rootObjectDefinitionId =
 							rootObjectEntry.getObjectDefinitionId();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1021,9 +1021,20 @@ public class ObjectEntryLocalServiceImpl
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
+		return getManyToManyObjectEntries(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, related,
+			reverse, search, start, end);
+	}
+
+	@Override
+	public List<ObjectEntry> getManyToManyObjectEntries(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, boolean reverse, String search, int start, int end)
+		throws PortalException {
+
 		DSLQuery dslQuery = _getManyToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
-			groupId, objectRelationshipId, primaryKey, related, reverse, search
+			groupId, objectRelationshipId, primaryKeys, related, reverse, search
 		).orderBy(
 			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
 		).limit(
@@ -1043,10 +1054,21 @@ public class ObjectEntryLocalServiceImpl
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
+		return getManyToManyObjectEntriesCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, related,
+			reverse, search);
+	}
+
+	@Override
+	public int getManyToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, boolean reverse, String search)
+		throws PortalException {
+
 		DSLQuery dslQuery = _getManyToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.countDistinct(
 				ObjectEntryTable.INSTANCE.objectEntryId),
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 
 		if (_log.isDebugEnabled()) {
@@ -1170,9 +1192,20 @@ public class ObjectEntryLocalServiceImpl
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
+		return getOneToManyObjectEntries(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, related,
+			search, start, end);
+	}
+
+	@Override
+	public List<ObjectEntry> getOneToManyObjectEntries(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, String search, int start, int end)
+		throws PortalException {
+
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
-			groupId, objectRelationshipId, primaryKey, related, search
+			groupId, objectRelationshipId, primaryKeys, related, search
 		).orderBy(
 			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
 		).limit(
@@ -1192,10 +1225,21 @@ public class ObjectEntryLocalServiceImpl
 			boolean related, String search)
 		throws PortalException {
 
+		return getOneToManyObjectEntriesCount(
+			groupId, objectRelationshipId, new Long[] {primaryKey}, related,
+			search);
+	}
+
+	@Override
+	public int getOneToManyObjectEntriesCount(
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
+			boolean related, String search)
+		throws PortalException {
+
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.countDistinct(
 				ObjectEntryTable.INSTANCE.objectEntryId),
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
@@ -3808,7 +3852,7 @@ public class ObjectEntryLocalServiceImpl
 
 	private GroupByStep _getManyToManyObjectEntriesGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, boolean related, boolean reverse, String search)
+			Long[] primaryKeys, boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -3911,7 +3955,7 @@ public class ObjectEntryLocalServiceImpl
 			).and(
 				() -> {
 					if (related) {
-						return primaryKeyColumn1.eq(primaryKey);
+						return primaryKeyColumn1.in(primaryKeys);
 					}
 
 					return dynamicObjectDefinitionTablePrimaryKeyColumn.notIn(
@@ -3920,19 +3964,17 @@ public class ObjectEntryLocalServiceImpl
 						).from(
 							dynamicObjectRelationshipMappingTable
 						).where(
-							primaryKeyColumn1.eq(primaryKey)
+							primaryKeyColumn1.in(primaryKeys)
 						));
 				}
 			).and(
 				() -> {
-					if (objectDefinition1.getObjectDefinitionId() !=
-							objectDefinition2.getObjectDefinitionId()) {
-
-						return null;
+					if (objectRelationship.isSelf()) {
+						return dynamicObjectDefinitionTablePrimaryKeyColumn.
+							notIn(primaryKeys);
 					}
 
-					return dynamicObjectDefinitionTablePrimaryKeyColumn.neq(
-						primaryKey);
+					return null;
 				}
 			).and(
 				ObjectEntrySearchUtil.getRelatedModelsPredicate(
@@ -3958,7 +4000,7 @@ public class ObjectEntryLocalServiceImpl
 
 	private GroupByStep _getOneToManyObjectEntriesGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, boolean related, String search)
+			Long[] primaryKeys, boolean related, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -4042,12 +4084,11 @@ public class ObjectEntryLocalServiceImpl
 									objectField.getDBColumnName());
 					}
 
-					return column.eq(related ? primaryKey : 0L);
+					return column.in(primaryKeys);
 				}
 			).and(
-				() ->
-					objectRelationship.isSelf() ?
-						primaryKeyColumn.neq(primaryKey) : null
+				() -> objectRelationship.isSelf() ?
+					primaryKeyColumn.notIn(primaryKeys) : null
 			).and(
 				() -> {
 					if (ObjectEntryThreadLocal.

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4090,7 +4090,11 @@ public class ObjectEntryLocalServiceImpl
 									objectField.getDBColumnName());
 					}
 
-					return column.in(primaryKeys);
+					if (related) {
+						return column.in(primaryKeys);
+					}
+
+					return column.notIn(primaryKeys);
 				}
 			).and(
 				() -> objectRelationship.isSelf() ?

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -243,13 +243,13 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public List<ObjectEntry> getManyToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search, int start, int end)
 		throws PortalException {
 
 		List<ObjectEntry> objectEntries =
 			objectEntryLocalService.getManyToManyObjectEntries(
-				groupId, objectRelationshipId, primaryKey, related, reverse,
+				groupId, objectRelationshipId, primaryKeys, related, reverse,
 				search, start, end);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
@@ -265,12 +265,12 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public int getManyToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, boolean reverse, String search)
 		throws PortalException {
 
 		return objectEntryLocalService.getManyToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, reverse,
+			groupId, objectRelationshipId, primaryKeys, related, reverse,
 			search);
 	}
 
@@ -326,13 +326,13 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
 		List<ObjectEntry> objectEntries =
 			objectEntryLocalService.getOneToManyObjectEntries(
-				groupId, objectRelationshipId, primaryKey, related, search,
+				groupId, objectRelationshipId, primaryKeys, related, search,
 				start, end);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
@@ -348,12 +348,12 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
+			long groupId, long objectRelationshipId, Long[] primaryKeys,
 			boolean related, String search)
 		throws PortalException {
 
 		return objectEntryLocalService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, primaryKeys, related, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1701,7 +1701,7 @@ public class ObjectRelationshipLocalServiceImpl
 				int relatedObjectEntriesCount =
 					_objectEntryLocalService.getOneToManyObjectEntriesCount(
 						0, objectRelationship.getObjectRelationshipId(), 0L,
-						false, null);
+						true, null);
 
 				if (relatedObjectEntriesCount > 0) {
 					throw new ObjectRelationshipEdgeException(

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	testIntegrationImplementation group: "com.liferay", name: "org.apache.cxf.core", version: "3.5.11.JAKARTA-LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation group: "org.apache.commons", name: "commons-lang3", version: "3.18.0"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/BaseSystemObjectRelatedModelsProviderTestCase.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/BaseSystemObjectRelatedModelsProviderTestCase.java
@@ -164,7 +164,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 	private void _testSystemObjectEntry1toMObjectRelatedModels(long groupId)
 		throws Exception {
 
-		long[] primaryKeys = addBaseModels(3);
+		long[] primaryKeys = addBaseModels(4);
 
 		addObjectRelationship(
 			_objectDefinition, _systemObjectDefinition,
@@ -194,6 +194,28 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			3, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId());
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			groupId, _objectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			3, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		insertIntoOrUpdateExtensionTable(
+			objectEntry2.getObjectEntryId(), primaryKeys[3],
+			_systemObjectDefinition.getObjectDefinitionId());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			4, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
 
 		// Get related models with search
 
@@ -244,25 +266,25 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			Collections.emptyMap());
 
 		insertIntoOrUpdateExtensionTable(
-			objectEntry2.getObjectEntryId(), primaryKeys[0],
+			objectEntry3.getObjectEntryId(), primaryKeys[0],
 			_systemObjectDefinition.getObjectDefinitionId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			objectEntry3.getObjectEntryId());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			objectEntry3.getObjectEntryId());
 
 		Assert.assertNotNull(fetchBaseModel(primaryKeys[0]));
 
@@ -274,12 +296,12 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			Collections.emptyMap());
 
 		insertIntoOrUpdateExtensionTable(
-			objectEntry3.getObjectEntryId(), primaryKeys[0],
+			objectEntry4.getObjectEntryId(), primaryKeys[0],
 			_systemObjectDefinition.getObjectDefinitionId());
 
 		AssertUtils.assertFailure(
@@ -288,12 +310,12 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry3));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry4));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry3.getObjectEntryId());
+			objectEntry4.getObjectEntryId());
 
 		objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -302,7 +324,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 	private void _testSystemObjectEntryMtoMObjectRelatedModels(long groupId)
 		throws Exception {
 
-		long[] primaryKeys = addBaseModels(3);
+		long[] primaryKeys = addBaseModels(4);
 
 		addObjectRelationship(
 			_objectDefinition, _systemObjectDefinition,
@@ -329,6 +351,39 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			2, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId());
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			groupId, _objectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			2, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry2.getObjectEntryId(), primaryKeys[0]);
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			2, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry2.getObjectEntryId(), primaryKeys[3]);
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			3, objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
 
 		// Get related models with search
 
@@ -378,25 +433,25 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId(), primaryKeys[2]);
+			objectEntry3.getObjectEntryId(), primaryKeys[2]);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			objectEntry3.getObjectEntryId());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry2.getObjectEntryId());
+			objectEntry3.getObjectEntryId());
 
 		Assert.assertNotNull(fetchBaseModel(primaryKeys[2]));
 
@@ -408,7 +463,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				"able", "Entry"
@@ -416,7 +471,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry3.getObjectEntryId(), primaryKeys[2]);
+			objectEntry4.getObjectEntryId(), primaryKeys[2]);
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -424,7 +479,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry3));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry4));
 
 		// Reverse object relationship
 
@@ -440,7 +495,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 				_objectDefinition.getCompanyId(),
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
-		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry5 = ObjectEntryTestUtil.addObjectEntry(
 			groupId, _objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				"able", "New Entry"
@@ -448,7 +503,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
-			objectEntry4.getObjectEntryId());
+			objectEntry5.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, objectRelatedModelsProvider,
@@ -463,7 +518,7 @@ public abstract class BaseSystemObjectRelatedModelsProviderTestCase {
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],
-			String.valueOf(objectEntry3.getObjectEntryId()));
+			String.valueOf(objectEntry4.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(), primaryKeys[2],

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -260,6 +260,8 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry2 = _addObjectEntry(
+			_objectDefinition1, Collections.emptyMap());
+		ObjectEntry objectEntry3 = _addObjectEntry(
 			_objectDefinition2, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
@@ -267,7 +269,7 @@ public class ObjectRelatedModelsProviderTest {
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId());
 
-		ObjectEntry objectEntry3 = _addObjectEntry(
+		ObjectEntry objectEntry4 = _addObjectEntry(
 			_objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				"able", "First Entry"
@@ -280,6 +282,27 @@ public class ObjectRelatedModelsProviderTest {
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			1, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		_addObjectEntry(
+			_objectDefinition2,
+			HashMapBuilder.<String, Serializable>put(
+				_relationshipObjectField.getName(),
+				objectEntry2.getObjectEntryId()
+			).build());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			2, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
 
 		_addObjectEntry(
 			_objectDefinition2,
@@ -296,7 +319,7 @@ public class ObjectRelatedModelsProviderTest {
 			objectEntry1.getObjectEntryId());
 
 		_updateObjectEntry(
-			objectEntry2.getObjectEntryId(),
+			objectEntry3.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"able", "Third Entry"
 			).put(
@@ -382,7 +405,7 @@ public class ObjectRelatedModelsProviderTest {
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId(),
-			String.valueOf(objectEntry2.getObjectEntryId()));
+			String.valueOf(objectEntry3.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
@@ -397,7 +420,7 @@ public class ObjectRelatedModelsProviderTest {
 			objectEntry1.getObjectEntryId(), "Entry");
 
 		_updateObjectEntry(
-			objectEntry3.getObjectEntryId(),
+			objectEntry4.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(), 0
 			).build());
@@ -412,7 +435,7 @@ public class ObjectRelatedModelsProviderTest {
 		_setUser(_user);
 
 		_assertViewPermission(
-			_objectDefinition2, objectEntry1, objectEntry2.getObjectEntryId());
+			_objectDefinition2, objectEntry1, objectEntry3.getObjectEntryId());
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -448,34 +471,34 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		ObjectEntry objectEntry4 = _addObjectEntry(
+		ObjectEntry objectEntry6 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			objectEntry6.getObjectEntryId());
 
 		Group group = GroupTestUtil.addGroup();
 
-		ObjectEntry objectEntry6 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry7 = ObjectEntryTestUtil.addObjectEntry(
 			group.getGroupId(),
 			scopeSiteObjectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(),
-				objectEntry4.getObjectEntryId()
+				objectEntry6.getObjectEntryId()
 			).build());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			objectEntry6.getObjectEntryId());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry6);
 
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry6.getObjectEntryId()));
+				objectEntry7.getObjectEntryId()));
 
 		// Object relationship deletion type disassociate
 
@@ -485,32 +508,32 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry7 = _addObjectEntry(
+		ObjectEntry objectEntry8 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 
-		ObjectEntry objectEntry8 = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry9 = ObjectEntryTestUtil.addObjectEntry(
 			group.getGroupId(),
 			scopeSiteObjectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(),
-				objectEntry7.getObjectEntryId()
+				objectEntry8.getObjectEntryId()
 			).build());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			objectEntry8.getObjectEntryId());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry7);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry8);
 
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry8.getObjectEntryId()));
+				objectEntry9.getObjectEntryId()));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			objectEntry8.getObjectEntryId());
 
 		// Object relationship deletion type prevent
 
@@ -520,20 +543,20 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry9 = _addObjectEntry(
+		ObjectEntry objectEntry10 = _addObjectEntry(
 			_objectDefinition1, Collections.emptyMap());
 
 		_updateObjectEntry(
-			objectEntry8.getObjectEntryId(),
+			objectEntry9.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				_relationshipObjectField.getName(),
-				objectEntry9.getObjectEntryId()
+				objectEntry10.getObjectEntryId()
 			).build());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry9.getObjectEntryId());
+			objectEntry10.getObjectEntryId());
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -541,12 +564,12 @@ public class ObjectRelatedModelsProviderTest {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry9));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry10));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry9.getObjectEntryId());
+			objectEntry10.getObjectEntryId());
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			_objectRelationship);
@@ -1023,6 +1046,8 @@ public class ObjectRelatedModelsProviderTest {
 		ObjectEntry objectEntry1 = _addObjectEntry(
 			objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry2 = _addObjectEntry(
+			objectDefinition1, Collections.emptyMap());
+		ObjectEntry objectEntry3 = _addObjectEntry(
 			objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				"able", "First Entry"
@@ -1035,14 +1060,32 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId());
+			objectEntry1.getObjectEntryId(), objectEntry3.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId());
 
-		ObjectEntry objectEntry3 = _addObjectEntry(
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			1, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry2.getObjectEntryId(), objectEntry3.getObjectEntryId());
+
+		ObjectRelationshipTestUtil.assertGetRelatedModels(
+			1, _objectRelatedModelsProvider,
+			_objectRelationship.getObjectRelationshipId(),
+			new Long[] {
+				objectEntry1.getObjectEntryId(), objectEntry2.getObjectEntryId()
+			});
+
+		ObjectEntry objectEntry4 = _addObjectEntry(
 			objectDefinition2,
 			HashMapBuilder.<String, Serializable>put(
 				"able", "Second Entry"
@@ -1050,7 +1093,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry1.getObjectEntryId(), objectEntry3.getObjectEntryId());
+			objectEntry1.getObjectEntryId(), objectEntry4.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
@@ -1060,20 +1103,20 @@ public class ObjectRelatedModelsProviderTest {
 		// Get related models with search
 
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			0, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			0, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId(), StringUtil.randomString());
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			1, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			1, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId(),
-			String.valueOf(objectEntry2.getObjectEntryId()));
+			String.valueOf(objectEntry3.getObjectEntryId()));
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			1, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			1, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId(), "First ");
 		ObjectRelationshipTestUtil.assertSearchRelatedModels(
-			2, objectEntry2.getGroupId(), _objectRelatedModelsProvider,
+			2, objectEntry3.getGroupId(), _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
 			objectEntry1.getObjectEntryId(), " Entry");
 
@@ -1082,7 +1125,7 @@ public class ObjectRelatedModelsProviderTest {
 		_setUser(_user);
 
 		_assertViewPermission(
-			objectDefinition2, objectEntry1, objectEntry2.getObjectEntryId());
+			objectDefinition2, objectEntry1, objectEntry3.getObjectEntryId());
 
 		_setUser(TestPropsValues.getUser());
 
@@ -1094,14 +1137,14 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 			_objectRelationship.getLabelMap());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
 
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
 				objectEntry1.getObjectEntryId()));
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry3.getObjectEntryId()));
+				objectEntry4.getObjectEntryId()));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
@@ -1115,7 +1158,7 @@ public class ObjectRelatedModelsProviderTest {
 				objectEntry1.getObjectEntryId()));
 		Assert.assertNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry2.getObjectEntryId()));
+				objectEntry3.getObjectEntryId()));
 
 		// Object relationship deletion type disassociate
 
@@ -1125,31 +1168,31 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry4 = _addObjectEntry(
-			objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry5 = _addObjectEntry(
-			objectDefinition2, Collections.emptyMap());
+			objectDefinition1, Collections.emptyMap());
 		ObjectEntry objectEntry6 = _addObjectEntry(
+			objectDefinition2, Collections.emptyMap());
+		ObjectEntry objectEntry7 = _addObjectEntry(
 			objectDefinition2, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId(), objectEntry5.getObjectEntryId());
+			objectEntry5.getObjectEntryId(), objectEntry6.getObjectEntryId());
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId(), objectEntry6.getObjectEntryId());
+			objectEntry5.getObjectEntryId(), objectEntry7.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			objectEntry5.getObjectEntryId());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry4);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry5);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			0, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry4.getObjectEntryId());
+			objectEntry5.getObjectEntryId());
 
 		// Object relationship deletion type prevent
 
@@ -1159,20 +1202,20 @@ public class ObjectRelatedModelsProviderTest {
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_objectRelationship.getLabelMap());
 
-		ObjectEntry objectEntry7 = _addObjectEntry(
+		ObjectEntry objectEntry8 = _addObjectEntry(
 			objectDefinition1, Collections.emptyMap());
 
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId(), objectEntry5.getObjectEntryId());
+			objectEntry8.getObjectEntryId(), objectEntry6.getObjectEntryId());
 		ObjectRelationshipTestUtil.addObjectRelationshipMappingTableValues(
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId(), objectEntry6.getObjectEntryId());
+			objectEntry8.getObjectEntryId(), objectEntry7.getObjectEntryId());
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			objectEntry8.getObjectEntryId());
 
 		AssertUtils.assertFailure(
 			RequiredObjectRelationshipException.class,
@@ -1180,23 +1223,23 @@ public class ObjectRelatedModelsProviderTest {
 				"Object relationship ",
 				_objectRelationship.getObjectRelationshipId(),
 				" does not allow deletes"),
-			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry7));
+			() -> _objectEntryLocalService.deleteObjectEntry(objectEntry8));
 
 		Assert.assertNotNull(
 			_objectEntryLocalService.fetchObjectEntry(
-				objectEntry7.getObjectEntryId()));
+				objectEntry8.getObjectEntryId()));
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			2, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			objectEntry8.getObjectEntryId());
 
-		_objectEntryLocalService.deleteObjectEntry(objectEntry6);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry7);
 
 		ObjectRelationshipTestUtil.assertGetRelatedModels(
 			1, _objectRelatedModelsProvider,
 			_objectRelationship.getObjectRelationshipId(),
-			objectEntry7.getObjectEntryId());
+			objectEntry8.getObjectEntryId());
 
 		// Reverse object relationship
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/util/ObjectRelationshipTestUtil.java
@@ -49,6 +49,21 @@ public class ObjectRelationshipTestUtil {
 			objectEntries.toString(), expectedSize, objectEntries.size());
 	}
 
+	public static void assertGetRelatedModels(
+			int expectedSize,
+			ObjectRelatedModelsProvider objectRelatedModelsProvider,
+			long objectRelationshipId, Long[] primaryKeys)
+		throws Exception {
+
+		List<ObjectEntry> objectEntries =
+			objectRelatedModelsProvider.getRelatedModels(
+				0, objectRelationshipId, primaryKeys, null, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		Assert.assertEquals(
+			objectEntries.toString(), expectedSize, objectEntries.size());
+	}
+
 	public static void assertSearchRelatedModels(
 			int expectedSize, long groupId,
 			ObjectRelatedModelsProvider objectRelatedModelsProvider,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryPerformanceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryPerformanceTest.java
@@ -9,16 +9,23 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.admin.rest.client.http.HttpInvoker;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectFolder;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectFolderResource;
+import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
@@ -29,12 +36,23 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.performance.PerformanceTimer;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -54,12 +72,16 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsContextThreadLocal;
 
 import java.io.Closeable;
 
 import java.net.ConnectException;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Predicate;
@@ -103,23 +125,22 @@ public class ObjectEntryPerformanceTest {
 
 	@Test
 	public void testGetObjectEntries() throws Exception {
-		_customObjectDefinition =
-			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				false,
-				Collections.singletonList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, "Performance",
-						"performance")));
+		_objectDefinition1 = ObjectDefinitionTestUtil.addCustomObjectDefinition(
+			false,
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, "Performance",
+					"performance")));
 
-		_customObjectDefinition =
+		_objectDefinition1 =
 			_objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
-				_customObjectDefinition.getObjectDefinitionId());
+				_objectDefinition1.getObjectDefinitionId());
 
 		ObjectEntryManager objectEntryManager =
 			_objectEntryManagerRegistry.getObjectEntryManager(
-				_customObjectDefinition.getStorageType());
+				_objectDefinition1.getStorageType());
 
 		DTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
@@ -128,7 +149,7 @@ public class ObjectEntryPerformanceTest {
 
 		for (int i = 0; i < _objectEntriesCount; i++) {
 			objectEntryManager.addObjectEntry(
-				dtoConverterContext, _customObjectDefinition,
+				dtoConverterContext, _objectDefinition1,
 				new ObjectEntry() {
 					{
 						properties = HashMapBuilder.<String, Object>put(
@@ -143,12 +164,159 @@ public class ObjectEntryPerformanceTest {
 				GetterUtil.getInteger(
 					_properties.getProperty("object.entries.get.max.time")),
 				"Get object entries by object definition " +
-					_customObjectDefinition.getObjectDefinitionId())) {
+					_objectDefinition1.getObjectDefinitionId())) {
 
 			_objectEntryLocalService.getObjectEntries(
-				0, _customObjectDefinition.getObjectDefinitionId(),
+				0, _objectDefinition1.getObjectDefinitionId(),
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 		}
+	}
+
+	@Test
+	public void testGetObjectEntriesWithNestedFields() throws Exception {
+		String textObjectFieldName = "a" + RandomTestUtil.randomString();
+
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					RandomTestUtil.randomLocaleStringMap()
+				).name(
+					textObjectFieldName
+				).build()),
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			TestPropsValues.getUserId());
+
+		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					RandomTestUtil.randomLocaleStringMap()
+				).name(
+					"a" + RandomTestUtil.randomString()
+				).build()),
+			ObjectDefinitionConstants.SCOPE_COMPANY,
+			TestPropsValues.getUserId());
+
+		int objectRelationshipsCount = GetterUtil.getInteger(
+			_properties.getProperty("object.relationships.count"));
+
+		List<String> objectRelationshipNames = new ArrayList<>();
+
+		List<String> relationshipObjectFieldNames = new ArrayList<>();
+
+		for (int i = 0; i < objectRelationshipsCount; i++) {
+			ObjectRelationship objectRelationship =
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService, _objectDefinition2,
+					_objectDefinition3);
+
+			objectRelationshipNames.add(objectRelationship.getName());
+
+			ObjectField relationshipObjectField =
+				_objectFieldLocalService.getObjectField(
+					objectRelationship.getObjectFieldId2());
+
+			relationshipObjectFieldNames.add(relationshipObjectField.getName());
+		}
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(),
+			_objectDefinition2.getResourceName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), role.getRoleId(),
+			ObjectActionKeys.ADD_OBJECT_ENTRY);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(),
+			_objectDefinition3.getResourceName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), role.getRoleId(),
+			ObjectActionKeys.ADD_OBJECT_ENTRY);
+
+		User user = UserTestUtil.addUser();
+
+		UserLocalServiceUtil.addRoleUser(role.getRoleId(), user.getUserId());
+
+		String originalName = PrincipalThreadLocal.getName();
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition2.getStorageType());
+
+		DTOConverterContext dtoConverterContext =
+			new DefaultDTOConverterContext(
+				false, Collections.emptyMap(), _dtoConverterRegistry, null,
+				LocaleUtil.getDefault(), null, user);
+
+		for (int i = 0; i < _objectEntriesCount; i++) {
+			ObjectEntry objectEntry = objectEntryManager.addObjectEntry(
+				dtoConverterContext, _objectDefinition2,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							textObjectFieldName, RandomTestUtil.randomString()
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+			HashMap<String, Object> relatedObjectEntryProperties =
+				new HashMap<>();
+
+			for (String relationshipObjectFieldName :
+					relationshipObjectFieldNames) {
+
+				relatedObjectEntryProperties.put(
+					relationshipObjectFieldName, objectEntry.getId());
+			}
+
+			objectEntryManager.addObjectEntry(
+				dtoConverterContext, _objectDefinition3,
+				new ObjectEntry() {
+					{
+						properties = relatedObjectEntryProperties;
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+		}
+
+		// Nested fields: object relationship name
+
+		NestedFieldsContext originalNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			new NestedFieldsContext(
+				1, null, objectRelationshipNames, null, null, null));
+
+		try (Closeable closeable = new PerformanceTimer(
+				GetterUtil.getInteger(
+					_properties.getProperty("object.entries.get.max.time")),
+				"Get object entries with nested fields object relationship " +
+					"name by object definition " +
+						_objectDefinition2.getObjectDefinitionId())) {
+
+			objectEntryManager.getObjectEntries(
+				TestPropsValues.getCompanyId(), _objectDefinition2, null, null,
+				dtoConverterContext, (String)null, null, null, null);
+		}
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			originalNestedFieldsContext);
+
+		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
+
+		PrincipalThreadLocal.setName(originalName);
 	}
 
 	@Test
@@ -227,7 +395,7 @@ public class ObjectEntryPerformanceTest {
 			List<ObjectDefinition> objectDefinitions =
 				_objectDefinitionLocalService.getCustomObjectDefinitions(0);
 
-			_customObjectDefinition = objectDefinitions.get(0);
+			_objectDefinition1 = objectDefinitions.get(0);
 
 			_waitFor(
 				0,
@@ -300,7 +468,7 @@ public class ObjectEntryPerformanceTest {
 		while (predicate.test(currentObjectEntriesCount)) {
 			currentObjectEntriesCount =
 				_objectEntryLocalService.getObjectEntriesCount(
-					_customObjectDefinition.getObjectDefinitionId());
+					_objectDefinition1.getObjectDefinitionId());
 		}
 	}
 
@@ -312,14 +480,20 @@ public class ObjectEntryPerformanceTest {
 	@DeleteAfterTestRun
 	private Company _company;
 
-	@DeleteAfterTestRun
-	private ObjectDefinition _customObjectDefinition;
-
 	@Inject
 	private DTOConverterRegistry _dtoConverterRegistry;
 
 	@Inject
 	private JSONFactory _jsonFactory;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition3;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
@@ -331,6 +505,15 @@ public class ObjectEntryPerformanceTest {
 	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
 
 	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
 	private ObjectFolderResource.Factory _objectFolderResourceFactory;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/service/test/dependencies/object-entry-performance.properties
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/service/test/dependencies/object-entry-performance.properties
@@ -2,3 +2,4 @@ object.entries.count=500
 object.entries.delete.max.time=30000
 object.entries.get.max.time=60000
 object.entries.import.max.time=36000
+object.relationships.count=3


### PR DESCRIPTION
Performance test when a non-admin user is getting object entries with the nested field of object relationship names.

| Run #   | Without Solution (ms) | With Solution (ms) |
|---------|-----------------------|--------------------|
| Run 1  | 1492                  | 456                |
| Run 2  | 1136                  | 354                |
| Run 3  | 1206                  | 341                |
| Run 4  | 1057                  | 317                |
| Run 5  | 1108                  | 348                |
| Run 6  | 1053                  | 334                |
| Run 7  | 1118                  | 295                |
| Run 8  | 1047                  | 331                |
| Run 9  | 1036                  | 294                |
| Run 10 | 1007                  | 306                |