### PR TITLE
LPD-62917 404 is expected because a three-segment match for GET request is defined, so path matching is not finding a good match before perfoming a method matching in order to retrieve 405

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -5959,7 +5959,7 @@ public class ObjectEntryResourceTest {
 				LoggerTestUtil.ERROR)) {
 
 			Assert.assertEquals(
-				405,
+				404,
 				HTTPTestUtil.invokeToHttpCode(
 					null,
 					_objectDefinition1.getRESTContextPath() +


### PR DESCRIPTION
Related: [LPD-62917](https://liferay.atlassian.net/browse/LPD-62917)

[LPD-62917]: https://liferay.atlassian.net/browse/LPD-62917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ