### PR TITLE
LPD-62047 [CMS] taxonomyCategoyIds not writable as expected

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -91,8 +91,10 @@ public class ServiceContextUtil {
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 
-		_setObjectEntryTaxonomyCategoryIds(
-			companyId, groupId, userId, objectEntry);
+		if (Validator.isNull(objectEntry.getTaxonomyCategoryIds())) {
+			_setObjectEntryTaxonomyCategoryIds(
+				companyId, groupId, userId, objectEntry);
+		}
 
 		if (Validator.isNotNull(objectEntry.getTaxonomyCategoryIds())) {
 			serviceContext.setAssetCategoryIds(


### PR DESCRIPTION
# What is this trying to solve?
https://liferay.atlassian.net/browse/LPD-62047

When updating an Object Entry, the `taxonomyCategoryIds` field was not being properly set due to a new behavior introduced in [liferay-portal#4667](https://github.com/liferay-bpm/liferay-portal/pull/4667).

That change allowed `taxonomyCategoryBriefs` to also be used as input to update the related model (AssetCategory) of an entry.

However, this caused issues when performing a PATCH with `taxonomyCategoryIds` in the payload, because the persistence layer relied on the state of `taxonomyCategoryBriefs`, which reflects the database state rather than the user input.

As a result, `taxonomyCategoryIds` was not writable as expected.

# How am I  fixing it?
The fix ensures that `taxonomyCategoryIds` remains the primary source of information when updating the related model (AssetCategory):

If `taxonomyCategoryIds` is defined in the input JSON, we use the existing behavior and directly persist those IDs.

Otherwise, we fall back to deriving `taxonomyCategoryIds` from the provided `taxonomyCategoryBriefs`.

This preserves backward compatibility with the new feature while restoring the expected behavior for clients that use `taxonomyCategoryIds`.

# How can you verify that it works?

`ObjectEntryResourceTest.testPatchObjectEntryWithTaxonomyCategories` was failing before this fix due to the bug. It now passes successfully.

`DefaultObjectEntryManagerImplTest.testAddObjectEntryWithMissingTaxonomyCategoryBriefReference` (initially introduced in a PR by Alicia García, later renamed) also passes.

Run the included automated tests to confirm.