### PR TITLE
LPD-63923

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.222
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 10.22.0
+Liferay-Require-SchemaVersion: 10.22.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -645,6 +645,12 @@ public class ObjectServiceUpgradeStepRegistrator
 			"10.21.0", "10.22.0",
 			UpgradeProcessFactory.addColumns(
 				"ObjectDefinition", "enableObjectEntrySubscription BOOLEAN"));
+
+		registry.register(
+			"10.22.0", "10.22.1",
+			UpgradeProcessFactory.runSQL(
+				"update ObjectEntry set rootObjectEntryId = 0 where " +
+					"rootObjectEntryId is null"));
 	}
 
 	@Reference


### PR DESCRIPTION
[LPD-63923](https://liferay.atlassian.net/browse/LPD-63923)

Hey @MarinhoFeliphe,
I am submitting this PR, but I’m aware that the SF is failing due to the following:
```shell
     [java] No need to create "ObjectEntryUpgradeProcess" class. Replace it by inline calls to the "UpgradeProcessFactory" class in the registrator class, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/upgrade_process_check.md: ./modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v10_22_1/ObjectEntryUpgradeProcess.java 13 (Checkstyle:UpgradeProcessCheck)
     [java] 1: No need to create "ObjectEntryUpgradeProcess" class. Replace it by inline calls to the "UpgradeProcessFactory" class in the registrator class, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/upgrade_process_check.md: ./modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v10_22_1/ObjectEntryUpgradeProcess.java 13 (Checkstyle:UpgradeProcessCheck)
``` 
As you know, I initially suggested performing the upgrade directly in the registrator class. However, considering the possibility of a request to add an upgrade test, I ended up following this current approach.

Given the urgency of this fix and the fact that I couldn’t come up with a way to both keep the upgrade in the registrator class and still properly test its effect, I’m submitting this for your review and guidance.

Thank you!

[LPD-63923]: https://liferay.atlassian.net/browse/LPD-63923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ