### PR TITLE
LPD-62835 Replace deprecated rest context path references of system modifiable object definitions from ObjectDefinitionUtil

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/display/context/CommerceReturnContentDisplayContext.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/display/context/CommerceReturnContentDisplayContext.java
@@ -828,8 +828,8 @@ public class CommerceReturnContentDisplayContext {
 					objectEntry.getGroupId(),
 					commerceReturnToCommerceReturnItems.
 						getObjectRelationshipId(),
-					commerceReturn.getId(), true, null, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS),
+					null, commerceReturn.getId(), true, null, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null),
 				curObjectEntry -> {
 					Map<String, Serializable> values =
 						curObjectEntry.getValues();

--- a/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/display/context/CommerceReturnEditDisplayContext.java
+++ b/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/display/context/CommerceReturnEditDisplayContext.java
@@ -681,9 +681,9 @@ public class CommerceReturnEditDisplayContext {
 
 		return _objectEntryLocalService.getOneToManyObjectEntries(
 			objectEntry.getGroupId(),
-			objectRelationship.getObjectRelationshipId(),
+			objectRelationship.getObjectRelationshipId(), null,
 			objectEntry.getObjectEntryId(), true, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			QueryUtil.ALL_POS, null);
 	}
 
 	private boolean _hasStatusCompleted() throws Exception {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/contributor/CommerceReturnObjectEntryValuesContributor.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/contributor/CommerceReturnObjectEntryValuesContributor.java
@@ -134,8 +134,8 @@ public class CommerceReturnObjectEntryValuesContributor
 					originalObjectEntry.getObjectDefinitionId(),
 					"commerceReturnToCommerceReturnItems"
 				).getObjectRelationshipId(),
-				originalObjectEntry.getObjectEntryId(), true, null,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				null, originalObjectEntry.getObjectEntryId(), true, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		Map<String, List<ObjectEntry>> returnItemStatusObjectEntriesMap =
 			_toReturnItemStatusObjectEntriesMap(objectEntries);

--- a/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/related/models/DeleteOnDisassociateObjectRelatedModelsProvider.java
+++ b/modules/apps/headless/headless-builder/headless-builder-impl/src/main/java/com/liferay/headless/builder/internal/object/related/models/DeleteOnDisassociateObjectRelatedModelsProvider.java
@@ -11,7 +11,9 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.List;
@@ -89,22 +91,23 @@ public class DeleteOnDisassociateObjectRelatedModelsProvider
 
 	@Override
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException {
 
 		return _objectRelatedModelsProvider.getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, search, start, end);
+			groupId, objectRelationshipId, predicate, primaryKey, search, start,
+			end, sorts);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException {
 
 		return _objectRelatedModelsProvider.getRelatedModelsCount(
-			groupId, objectRelationshipId, primaryKey, search);
+			groupId, objectRelationshipId, predicate, primaryKey, search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 110.1.0
+Bundle-Version: 111.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -132,23 +132,22 @@ public class ObjectDefinitionUtil {
 		).put(
 			"DataSet", "/data-set-admin/data-sets"
 		).put(
-			"DataSetAction", "/data-set-admin/data-sets/actions"
+			"DataSetAction", "/data-set-admin/actions"
 		).put(
-			"DataSetCardsSection", "/data-set-admin/data-sets/cards-sections"
+			"DataSetCardsSection", "/data-set-admin/cards-sections"
 		).put(
 			"DataSetClientExtensionFilter",
-			"/data-set-admin/data-sets/client-extension-filters"
+			"/data-set-admin/client-extension-filters"
 		).put(
-			"DataSetDateFilter", "/data-set-admin/data-sets/date-filters"
+			"DataSetDateFilter", "/data-set-admin/date-filters"
 		).put(
-			"DataSetListSection", "/data-set-admin/data-sets/list-sections"
+			"DataSetListSection", "/data-set-admin/list-sections"
 		).put(
-			"DataSetSelectionFilter",
-			"/data-set-admin/data-sets/selection-filters"
+			"DataSetSelectionFilter", "/data-set-admin/selection-filters"
 		).put(
-			"DataSetSort", "/data-set-admin/data-sets/sorts"
+			"DataSetSort", "/data-set-admin/sorts"
 		).put(
-			"DataSetTableSection", "/data-set-admin/data-sets/table-sections"
+			"DataSetTableSection", "/data-set-admin/table-sections"
 		).put(
 			"ExternalVideo", "/cms/external-videos"
 		).put(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsProvider.java
@@ -6,8 +6,10 @@
 package com.liferay.object.related.models;
 
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Sort;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,13 +44,13 @@ public interface ObjectRelatedModelsProvider<T extends BaseModel<T>> {
 	public String getObjectRelationshipType();
 
 	public List<T> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException;
 
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException;
 
 	public default List<T> getUnrelatedModels(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -409,15 +409,24 @@ public interface ObjectEntryLocalService
 		long groupId, long objectEntryFolderId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Map<Object, Long> getOneToManyAggregationCounts(
+			long groupId, long objectDefinitionId, long objectEntryId,
+			long objectRelationshipId, String aggregationTerm,
+			Predicate predicate, boolean related, String search, int start,
+			int end)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -528,23 +528,39 @@ public class ObjectEntryLocalServiceUtil {
 			groupId, objectEntryFolderId);
 	}
 
-	public static List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
+	public static Map<Object, Long> getOneToManyAggregationCounts(
+			long groupId, long objectDefinitionId, long objectEntryId,
+			long objectRelationshipId, String aggregationTerm,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
 			boolean related, String search, int start, int end)
 		throws PortalException {
 
+		return getService().getOneToManyAggregationCounts(
+			groupId, objectDefinitionId, objectEntryId, objectRelationshipId,
+			aggregationTerm, predicate, related, search, start, end);
+	}
+
+	public static List<ObjectEntry> getOneToManyObjectEntries(
+			long groupId, long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search, int start, int end,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws PortalException {
+
 		return getService().getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
-			end);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search, start, end, sorts);
 	}
 
 	public static int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search);
 	}
 
 	public static ObjectEntry getOrAddEmptyObjectEntry(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -604,25 +604,42 @@ public class ObjectEntryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.Map<Object, Long> getOneToManyAggregationCounts(
+			long groupId, long objectDefinitionId, long objectEntryId,
+			long objectRelationshipId, String aggregationTerm,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			boolean related, String search, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getOneToManyAggregationCounts(
+			groupId, objectDefinitionId, objectEntryId, objectRelationshipId,
+			aggregationTerm, predicate, related, search, start, end);
+	}
+
+	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
-				boolean related, String search, int start, int end)
+				long groupId, long objectRelationshipId,
+				com.liferay.petra.sql.dsl.expression.Predicate predicate,
+				long primaryKey, boolean related, String search, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
-			end);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search, start, end, sorts);
 	}
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryLocalService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryService.java
@@ -6,10 +6,12 @@
 package com.liferay.object.service;
 
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.BaseService;
@@ -114,14 +116,15 @@ public interface ObjectEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceUtil.java
@@ -143,22 +143,26 @@ public class ObjectEntryServiceUtil {
 	}
 
 	public static List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search, int start, int end)
+			long groupId, long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search, int start, int end,
+			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
-			end);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search, start, end, sorts);
 	}
 
 	public static int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws PortalException {
 
 		return getService().getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search);
 	}
 
 	public static ObjectEntry getOrAddEmptyObjectEntry(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryServiceWrapper.java
@@ -158,23 +158,27 @@ public class ObjectEntryServiceWrapper
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
-				long groupId, long objectRelationshipId, long primaryKey,
-				boolean related, String search, int start, int end)
+				long groupId, long objectRelationshipId,
+				com.liferay.petra.sql.dsl.expression.Predicate predicate,
+				long primaryKey, boolean related, String search, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, related, search, start,
-			end);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search, start, end, sorts);
 	}
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectEntryTreeFactory.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/tree/ObjectEntryTreeFactory.java
@@ -49,8 +49,9 @@ public class ObjectEntryTreeFactory extends BaseTreeFactory {
 							_objectEntryLocalService.getOneToManyObjectEntries(
 								parentObjectEntry.getGroupId(),
 								objectRelationship.getObjectRelationshipId(),
-								parentObjectEntry.getPrimaryKey(), true, null,
-								QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+								null, parentObjectEntry.getPrimaryKey(), true,
+								null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+								null),
 							objectEntry -> new Node(
 								new Edge(
 									objectRelationship.

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
@@ -1,1 +1,1 @@
-version 9.2.0
+version 10.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 76.1.0
+version 77.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 12.0.0

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/DefaultObjectEntryManager.java
@@ -164,14 +164,15 @@ public interface DefaultObjectEntryManager extends ObjectEntryManager {
 		throws Exception;
 
 	public Page<ObjectEntry> getRelatedObjectEntries(
-			DTOConverterContext dtoConverterContext, long objectEntryId,
-			ObjectRelationship objectRelationship, Pagination pagination)
+			Aggregation aggregation, DTOConverterContext dtoConverterContext,
+			String externalReferenceCode, String filterString,
+			ObjectRelationship objectRelationship, Pagination pagination,
+			String scopeKey, String search, Sort[] sorts)
 		throws Exception;
 
 	public Page<ObjectEntry> getRelatedObjectEntries(
-			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, ObjectRelationship objectRelationship,
-			Pagination pagination, String scopeKey)
+			DTOConverterContext dtoConverterContext, long objectEntryId,
+			ObjectRelationship objectRelationship, Pagination pagination)
 		throws Exception;
 
 	public ObjectEntry getRelatedObjectEntry(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -700,6 +700,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 											serviceRegistration) {
 
 								return new ObjectEntryRelatedObjectsResourceImpl(
+									_entityModelProvider,
 									_objectDefinitionLocalService,
 									_objectEntryLocalService,
 									_objectEntryManagerRegistry,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -924,8 +924,9 @@ public class ObjectEntryDTOConverter
 				List<?> relatedModels =
 					objectRelatedModelsProvider.getRelatedModels(
 						relatedObjectDefinitionGroupId,
-						objectRelationship.getObjectRelationshipId(),
-						primaryKey, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+						objectRelationship.getObjectRelationshipId(), null,
+						primaryKey, null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+						null);
 
 				if (relatedObjectDefinition.isUnmodifiableSystemObject()) {
 					SystemObjectDefinitionManager

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -7,6 +7,7 @@ package com.liferay.object.rest.internal.manager.v1_0;
 
 import com.liferay.account.exception.NoSuchGroupException;
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntryModel;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.attachment.ExportImportAttachmentManager;
@@ -66,6 +67,7 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.sql.dsl.Column;
@@ -602,41 +604,6 @@ public class DefaultObjectEntryManagerImpl
 
 		long groupId = getGroupId(objectDefinition, scopeKey);
 
-		int start = _getStartPosition(pagination);
-		int end = _getEndPosition(pagination);
-
-		List<Facet> facets = new ArrayList<>();
-
-		if ((aggregation != null) &&
-			(aggregation.getAggregationTerms() != null)) {
-
-			Map<String, String> aggregationTerms =
-				aggregation.getAggregationTerms();
-
-			for (Map.Entry<String, String> entry1 :
-					aggregationTerms.entrySet()) {
-
-				List<Facet.FacetValue> facetValues = new ArrayList<>();
-
-				Map<Object, Long> aggregationCounts =
-					objectEntryLocalService.getAggregationCounts(
-						groupId, objectDefinition.getObjectDefinitionId(),
-						entry1.getKey(), predicate, start, end);
-
-				for (Map.Entry<Object, Long> entry2 :
-						aggregationCounts.entrySet()) {
-
-					Long value = entry2.getValue();
-
-					facetValues.add(
-						new Facet.FacetValue(
-							value.intValue(), String.valueOf(entry2.getKey())));
-				}
-
-				facets.add(new Facet(entry1.getKey(), facetValues));
-			}
-		}
-
 		Long[] groupIds = null;
 
 		if (StringUtil.equals(
@@ -647,11 +614,14 @@ public class DefaultObjectEntryManagerImpl
 				_depotEntryLocalService.getGroupConnectedDepotEntries(
 					groupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS),
-				depotEntry -> depotEntry.getGroupId(), Long.class);
+				DepotEntryModel::getGroupId, Long.class);
 		}
 		else {
 			groupIds = new Long[] {groupId};
 		}
+
+		int start = _getStartPosition(pagination);
+		int end = _getEndPosition(pagination);
 
 		return Page.of(
 			HashMapBuilder.put(
@@ -691,7 +661,11 @@ public class DefaultObjectEntryManagerImpl
 					objectDefinition.getResourceName(), groupId,
 					dtoConverterContext.getUriInfo())
 			).build(),
-			facets,
+			_getFacets(
+				aggregation,
+				aggregationTerm -> objectEntryLocalService.getAggregationCounts(
+					groupId, objectDefinition.getObjectDefinitionId(),
+					aggregationTerm, predicate, start, end)),
 			TransformUtil.transform(
 				objectEntryLocalService.getPrimaryKeys(
 					groupIds, companyId, dtoConverterContext.getUserId(),
@@ -853,6 +827,28 @@ public class DefaultObjectEntryManagerImpl
 
 	@Override
 	public Page<ObjectEntry> getRelatedObjectEntries(
+			Aggregation aggregation, DTOConverterContext dtoConverterContext,
+			String externalReferenceCode, String filterString,
+			ObjectRelationship objectRelationship, Pagination pagination,
+			String scopeKey, String search, Sort[] sorts)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
+
+		return _getRelatedObjectEntries(
+			aggregation, dtoConverterContext, filterString,
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId2()),
+			_objectEntryService.getObjectEntry(
+				externalReferenceCode, getGroupId(objectDefinition, scopeKey),
+				objectDefinition.getObjectDefinitionId()),
+			objectRelationship, pagination, objectDefinition, search, sorts);
+	}
+
+	@Override
+	public Page<ObjectEntry> getRelatedObjectEntries(
 			DTOConverterContext dtoConverterContext, long objectEntryId,
 			ObjectRelationship objectRelationship, Pagination pagination)
 		throws Exception {
@@ -876,31 +872,10 @@ public class DefaultObjectEntryManagerImpl
 				pagination);
 		}
 
-		return _getObjectEntryRelatedObjectEntries(
-			dtoConverterContext, relatedObjectDefinition,
+		return _getRelatedObjectEntries(
+			null, dtoConverterContext, null, relatedObjectDefinition,
 			_objectEntryService.getObjectEntry(objectEntryId),
-			objectRelationship, pagination, objectDefinition);
-	}
-
-	@Override
-	public Page<ObjectEntry> getRelatedObjectEntries(
-			DTOConverterContext dtoConverterContext,
-			String externalReferenceCode, ObjectRelationship objectRelationship,
-			Pagination pagination, String scopeKey)
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId1());
-
-		return _getObjectEntryRelatedObjectEntries(
-			dtoConverterContext,
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId2()),
-			_objectEntryService.getObjectEntry(
-				externalReferenceCode, getGroupId(objectDefinition, scopeKey),
-				objectDefinition.getObjectDefinitionId()),
-			objectRelationship, pagination, objectDefinition);
+			objectRelationship, pagination, objectDefinition, null, null);
 	}
 
 	@Override
@@ -973,10 +948,10 @@ public class DefaultObjectEntryManagerImpl
 				(List<BaseModel<?>>)
 					objectRelatedModelsProvider.getRelatedModels(
 						serviceBuilderObjectEntry.getGroupId(),
-						objectRelationship.getObjectRelationshipId(),
+						objectRelationship.getObjectRelationshipId(), null,
 						serviceBuilderObjectEntry.getPrimaryKey(), null,
 						_getStartPosition(pagination),
-						_getEndPosition(pagination)),
+						_getEndPosition(pagination), null),
 				baseModel -> _toDTO(
 					baseModel, serviceBuilderObjectEntry,
 					_systemObjectDefinitionManagerRegistry.
@@ -985,7 +960,7 @@ public class DefaultObjectEntryManagerImpl
 			pagination,
 			objectRelatedModelsProvider.getRelatedModelsCount(
 				serviceBuilderObjectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getObjectRelationshipId(), null,
 				serviceBuilderObjectEntry.getPrimaryKey(), null));
 	}
 
@@ -1972,6 +1947,44 @@ public class DefaultObjectEntryManagerImpl
 		return QueryUtil.ALL_POS;
 	}
 
+	private List<Facet> _getFacets(
+			Aggregation aggregation,
+			UnsafeFunction<String, Map<Object, Long>, Exception> unsafeFunction)
+		throws Exception {
+
+		List<Facet> facets = new ArrayList<>();
+
+		if ((aggregation == null) ||
+			(aggregation.getAggregationTerms() == null)) {
+
+			return facets;
+		}
+
+		Map<String, String> aggregationTerms =
+			aggregation.getAggregationTerms();
+
+		for (Map.Entry<String, String> entry1 : aggregationTerms.entrySet()) {
+			List<Facet.FacetValue> facetValues = new ArrayList<>();
+
+			Map<Object, Long> aggregationCounts = unsafeFunction.apply(
+				entry1.getKey());
+
+			for (Map.Entry<Object, Long> entry2 :
+					aggregationCounts.entrySet()) {
+
+				Long value = entry2.getValue();
+
+				facetValues.add(
+					new Facet.FacetValue(
+						value.intValue(), String.valueOf(entry2.getKey())));
+			}
+
+			facets.add(new Facet(entry1.getKey(), facetValues));
+		}
+
+		return facets;
+	}
+
 	private long _getFileEntryGroupId(
 		String groupExternalReferenceCode, ObjectDefinition objectDefinition,
 		String scopeKey) {
@@ -2108,53 +2121,6 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT;
-	}
-
-	private Page<ObjectEntry> _getObjectEntryRelatedObjectEntries(
-			DTOConverterContext dtoConverterContext,
-			ObjectDefinition objectDefinition,
-			com.liferay.object.model.ObjectEntry objectEntry,
-			ObjectRelationship objectRelationship, Pagination pagination,
-			ObjectDefinition parentObjectDefinition)
-		throws Exception {
-
-		long groupId = objectEntry.getGroupId();
-
-		if (Objects.equals(
-				objectDefinition.getScope(),
-				ObjectDefinitionConstants.SCOPE_COMPANY)) {
-
-			groupId = 0;
-		}
-
-		ObjectRelatedModelsProvider objectRelatedModelsProvider =
-			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
-				objectDefinition.getClassName(),
-				objectDefinition.getCompanyId(), objectRelationship.getType());
-
-		return Page.of(
-			HashMapBuilder.put(
-				"get",
-				ActionUtil.addAction(
-					ActionKeys.VIEW,
-					ObjectEntryRelatedObjectsResourceImpl.class,
-					objectEntry.getObjectEntryId(),
-					"getCurrentObjectEntriesObjectRelationshipNamePage", null,
-					objectEntry.getUserId(),
-					parentObjectDefinition.getClassName(), groupId,
-					dtoConverterContext.getUriInfo())
-			).build(),
-			_toObjectEntries(
-				dtoConverterContext,
-				objectRelatedModelsProvider.getRelatedModels(
-					groupId, objectRelationship.getObjectRelationshipId(),
-					objectEntry.getPrimaryKey(), null,
-					_getStartPosition(pagination),
-					_getEndPosition(pagination))),
-			pagination,
-			objectRelatedModelsProvider.getRelatedModelsCount(
-				groupId, objectRelationship.getObjectRelationshipId(),
-				objectEntry.getPrimaryKey(), null));
 	}
 
 	private DTOConverterContext _getObjectEntryVersionDTOConverterContext(
@@ -2328,8 +2294,8 @@ public class DefaultObjectEntryManagerImpl
 
 		return objectRelatedModelsProvider.getRelatedModels(
 			GroupThreadLocal.getGroupId(),
-			objectRelationship.getObjectRelationshipId(), primaryKey, null, -1,
-			-1);
+			objectRelationship.getObjectRelationshipId(), null, primaryKey,
+			null, -1, -1, null);
 	}
 
 	private ObjectDefinition _getRelatedObjectDefinition(
@@ -2349,6 +2315,62 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		return relatedObjectDefinition;
+	}
+
+	private Page<ObjectEntry> _getRelatedObjectEntries(
+			Aggregation aggregation, DTOConverterContext dtoConverterContext,
+			String filterString, ObjectDefinition objectDefinition,
+			com.liferay.object.model.ObjectEntry objectEntry,
+			ObjectRelationship objectRelationship, Pagination pagination,
+			ObjectDefinition parentObjectDefinition, String search,
+			Sort[] sorts)
+		throws Exception {
+
+		ObjectRelatedModelsProvider objectRelatedModelsProvider =
+			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
+				objectDefinition.getClassName(),
+				objectDefinition.getCompanyId(), objectRelationship.getType());
+
+		long groupId = getGroupId(
+			objectDefinition, String.valueOf(objectEntry.getGroupId()));
+
+		Predicate predicate = _filterFactory.create(
+			_objectDefinitionFilterParser.parse(filterString, objectDefinition),
+			objectDefinition);
+
+		int start = _getStartPosition(pagination);
+		int end = _getEndPosition(pagination);
+
+		return Page.of(
+			HashMapBuilder.put(
+				"get",
+				ActionUtil.addAction(
+					ActionKeys.VIEW,
+					ObjectEntryRelatedObjectsResourceImpl.class,
+					objectEntry.getObjectEntryId(),
+					"getCurrentObjectEntriesObjectRelationshipNamePage", null,
+					objectEntry.getUserId(),
+					parentObjectDefinition.getClassName(), groupId,
+					dtoConverterContext.getUriInfo())
+			).build(),
+			_getFacets(
+				aggregation,
+				aggregationTerm ->
+					objectEntryLocalService.getOneToManyAggregationCounts(
+						groupId, objectDefinition.getObjectDefinitionId(),
+						objectEntry.getObjectEntryId(),
+						objectRelationship.getObjectRelationshipId(),
+						aggregationTerm, predicate, true, search, start, end)),
+			_toObjectEntries(
+				dtoConverterContext,
+				objectRelatedModelsProvider.getRelatedModels(
+					groupId, objectRelationship.getObjectRelationshipId(),
+					predicate, objectEntry.getPrimaryKey(), search, start, end,
+					sorts)),
+			pagination,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				groupId, objectRelationship.getObjectRelationshipId(),
+				predicate, objectEntry.getPrimaryKey(), search));
 	}
 
 	private ObjectEntry _getRelatedObjectEntry(
@@ -2465,12 +2487,12 @@ public class DefaultObjectEntryManagerImpl
 			_toObjectEntries(
 				dtoConverterContext,
 				objectRelatedModelsProvider.getRelatedModels(
-					groupId, objectRelationship.getObjectRelationshipId(),
+					groupId, objectRelationship.getObjectRelationshipId(), null,
 					objectEntryId, null, _getStartPosition(pagination),
-					_getEndPosition(pagination))),
+					_getEndPosition(pagination), null)),
 			pagination,
 			objectRelatedModelsProvider.getRelatedModelsCount(
-				groupId, objectRelationship.getObjectRelationshipId(),
+				groupId, objectRelationship.getObjectRelationshipId(), null,
 				objectEntryId, null));
 	}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2326,13 +2326,13 @@ public class DefaultObjectEntryManagerImpl
 			Sort[] sorts)
 		throws Exception {
 
+		long groupId = getGroupId(
+			objectDefinition, String.valueOf(objectEntry.getGroupId()));
+
 		ObjectRelatedModelsProvider objectRelatedModelsProvider =
 			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
 				objectDefinition.getClassName(),
 				objectDefinition.getCompanyId(), objectRelationship.getType());
-
-		long groupId = getGroupId(
-			objectDefinition, String.valueOf(objectEntry.getGroupId()));
 
 		Predicate predicate = _filterFactory.create(
 			_objectDefinitionFilterParser.parse(filterString, objectDefinition),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
@@ -9,9 +9,13 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,6 +37,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
 
@@ -42,7 +47,8 @@ import java.util.List;
 /**
  * @author Carlos Correa
  */
-public abstract class BaseObjectEntryRelatedObjectsResourceImpl {
+public abstract class BaseObjectEntryRelatedObjectsResourceImpl
+	implements EntityModelResource {
 
 	@DELETE
 	@Operation(
@@ -151,11 +157,15 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl {
 				in = ParameterIn.PATH, name = "currentExternalReferenceCode"
 			),
 			@Parameter(in = ParameterIn.PATH, name = "objectRelationshipName"),
+			@Parameter(in = ParameterIn.QUERY, name = "aggregationTerms"),
 			@Parameter(in = ParameterIn.QUERY, name = "fields"),
+			@Parameter(in = ParameterIn.QUERY, name = "filter"),
 			@Parameter(in = ParameterIn.QUERY, name = "nestedFields"),
 			@Parameter(in = ParameterIn.QUERY, name = "page"),
 			@Parameter(in = ParameterIn.QUERY, name = "pageSize"),
-			@Parameter(in = ParameterIn.QUERY, name = "restrictFields")
+			@Parameter(in = ParameterIn.QUERY, name = "restrictFields"),
+			@Parameter(in = ParameterIn.QUERY, name = "search"),
+			@Parameter(in = ParameterIn.QUERY, name = "sort")
 		}
 	)
 	@Path(
@@ -171,7 +181,9 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl {
 				@NotNull @Parameter(hidden = true)
 				@PathParam("objectRelationshipName")
 				String objectRelationshipName,
-				@Context Pagination pagination)
+				@Parameter(hidden = true) @QueryParam("search") String search,
+				@Context Aggregation aggregation, @Context Filter filter,
+				@Context Pagination pagination, @Context Sort[] sorts)
 		throws Exception;
 
 	@GET
@@ -276,11 +288,15 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl {
 				in = ParameterIn.PATH, name = "currentExternalReferenceCode"
 			),
 			@Parameter(in = ParameterIn.PATH, name = "objectRelationshipName"),
+			@Parameter(in = ParameterIn.QUERY, name = "aggregationTerms"),
 			@Parameter(in = ParameterIn.QUERY, name = "fields"),
+			@Parameter(in = ParameterIn.QUERY, name = "filter"),
 			@Parameter(in = ParameterIn.QUERY, name = "nestedFields"),
 			@Parameter(in = ParameterIn.QUERY, name = "page"),
 			@Parameter(in = ParameterIn.QUERY, name = "pageSize"),
-			@Parameter(in = ParameterIn.QUERY, name = "restrictFields")
+			@Parameter(in = ParameterIn.QUERY, name = "restrictFields"),
+			@Parameter(in = ParameterIn.QUERY, name = "search"),
+			@Parameter(in = ParameterIn.QUERY, name = "sort")
 		}
 	)
 	@Path(
@@ -298,7 +314,9 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl {
 				@NotNull @Parameter(hidden = true)
 				@PathParam("objectRelationshipName")
 				String objectRelationshipName,
-				@Context Pagination pagination)
+				@Parameter(hidden = true) @QueryParam("search") String search,
+				@Context Aggregation aggregation, @Context Filter filter,
+				@Context Pagination pagination, @Context Sort[] sorts)
 		throws Exception;
 
 	@GET

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryRelatedObjectsResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.object.rest.internal.resource.v1_0;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -635,6 +636,10 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl
 				String relatedExternalReferenceCode)
 		throws Exception;
 
+	public void setContextCompany(Company contextCompany) {
+		this.contextCompany = contextCompany;
+	}
+
 	protected <T, R, E extends Throwable> List<R> transform(
 		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
 
@@ -642,6 +647,7 @@ public abstract class BaseObjectEntryRelatedObjectsResourceImpl
 	}
 
 	protected AcceptLanguage contextAcceptLanguage;
+	protected Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected UriInfo contextUriInfo;
 	protected User contextUser;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
@@ -15,17 +15,26 @@ import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
+import com.liferay.object.rest.odata.entity.v1_0.provider.EntityModelProvider;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
+import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Map;
 
@@ -36,12 +45,14 @@ public class ObjectEntryRelatedObjectsResourceImpl
 	extends BaseObjectEntryRelatedObjectsResourceImpl {
 
 	public ObjectEntryRelatedObjectsResourceImpl(
+		EntityModelProvider entityModelProvider,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManagerRegistry objectEntryManagerRegistry,
 		ObjectRelatedModelsProviderRegistry objectRelatedModelsProviderRegistry,
 		ObjectRelationshipLocalService objectRelationshipLocalService) {
 
+		_entityModelProvider = entityModelProvider;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManagerRegistry = objectEntryManagerRegistry;
@@ -132,12 +143,14 @@ public class ObjectEntryRelatedObjectsResourceImpl
 	public Page<Object>
 			getByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNamePage(
 				String currentExternalReferenceCode,
-				String objectRelationshipName, Pagination pagination)
+				String objectRelationshipName, String search,
+				Aggregation aggregation, Filter filter, Pagination pagination,
+				Sort[] sorts)
 		throws Exception {
 
 		return _getRelatedObjectEntries(
-			null, currentExternalReferenceCode, objectRelationshipName,
-			pagination);
+			aggregation, currentExternalReferenceCode, objectRelationshipName,
+			pagination, null, search, sorts);
 	}
 
 	@Override
@@ -202,6 +215,21 @@ public class ObjectEntryRelatedObjectsResourceImpl
 	}
 
 	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectDefinition.getObjectDefinitionId(),
+				GetterUtil.getString(
+					multivaluedMap.getFirst("objectRelationshipName")));
+
+		return _entityModelProvider.getEntityModel(
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId2()));
+	}
+
+	@Override
 	public Object getObjectEntryObjectRelationshipNameRelatedObjectEntry(
 			Long currentObjectEntryId, String objectRelationshipName,
 			Long relatedObjectEntryId)
@@ -224,12 +252,14 @@ public class ObjectEntryRelatedObjectsResourceImpl
 	public Page<Object>
 			getScopeScopeKeyByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNamePage(
 				String scopeKey, String currentExternalReferenceCode,
-				String objectRelationshipName, Pagination pagination)
+				String objectRelationshipName, String search,
+				Aggregation aggregation, Filter filter, Pagination pagination,
+				Sort[] sorts)
 		throws Exception {
 
 		return _getRelatedObjectEntries(
-			scopeKey, currentExternalReferenceCode, objectRelationshipName,
-			pagination);
+			aggregation, currentExternalReferenceCode, objectRelationshipName,
+			pagination, scopeKey, search, sorts);
 	}
 
 	@Override
@@ -467,6 +497,9 @@ public class ObjectEntryRelatedObjectsResourceImpl
 			currentExternalReferenceCode, scopeKey);
 	}
 
+	public void setContextCompany(Company contextCompany) {
+	}
+
 	private void _checkCurrentObjectEntry(
 			DefaultObjectEntryManager defaultObjectEntryManager,
 			long relatedObjectEntryId)
@@ -532,9 +565,25 @@ public class ObjectEntryRelatedObjectsResourceImpl
 			contextUser);
 	}
 
+	private String _getFilterString() {
+		if (contextHttpServletRequest != null) {
+			return ParamUtil.getString(contextHttpServletRequest, "filter");
+		}
+
+		if (contextUriInfo == null) {
+			return null;
+		}
+
+		MultivaluedMap<String, String> queryParameters =
+			contextUriInfo.getQueryParameters();
+
+		return queryParameters.getFirst("filter");
+	}
+
 	private Page<Object> _getRelatedObjectEntries(
-			String scopeKey, String currentExternalReferenceCode,
-			String objectRelationshipName, Pagination pagination)
+			Aggregation aggregation, String externalReferenceCode,
+			String objectRelationshipName, Pagination pagination,
+			String scopeKey, String search, Sort[] sorts)
 		throws Exception {
 
 		DefaultObjectEntryManager defaultObjectEntryManager =
@@ -549,11 +598,12 @@ public class ObjectEntryRelatedObjectsResourceImpl
 
 		Page<ObjectEntry> page =
 			defaultObjectEntryManager.getRelatedObjectEntries(
-				_getDTOConverterContext(null), currentExternalReferenceCode,
-				objectRelationship, pagination, scopeKey);
+				aggregation, _getDTOConverterContext(null),
+				externalReferenceCode, _getFilterString(), objectRelationship,
+				pagination, scopeKey, search, sorts);
 
 		return Page.of(
-			page.getActions(),
+			page.getActions(), page.getFacets(),
 			transform(
 				page.getItems(),
 				objectEntry -> _getRelatedObjectEntry(
@@ -593,6 +643,8 @@ public class ObjectEntryRelatedObjectsResourceImpl
 
 		return objectEntry;
 	}
+
+	private final EntityModelProvider _entityModelProvider;
 
 	@Context
 	private ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
@@ -19,6 +19,9 @@ import com.liferay.object.rest.odata.entity.v1_0.provider.EntityModelProvider;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
@@ -216,15 +219,22 @@ public class ObjectEntryRelatedObjectsResourceImpl
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.getObjectRelationship(
-				_objectDefinition.getObjectDefinitionId(),
-				GetterUtil.getString(
-					multivaluedMap.getFirst("objectRelationshipName")));
+		try {
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					_objectDefinition.getObjectDefinitionId(),
+					GetterUtil.getString(
+						multivaluedMap.getFirst("objectRelationshipName")));
 
-		return _entityModelProvider.getEntityModel(
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId2()));
+			return _entityModelProvider.getEntityModel(
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectRelationship.getObjectDefinitionId2()));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return null;
 	}
 
 	@Override
@@ -638,6 +648,9 @@ public class ObjectEntryRelatedObjectsResourceImpl
 
 		return objectEntry;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryRelatedObjectsResourceImpl.class);
 
 	private final EntityModelProvider _entityModelProvider;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
@@ -19,7 +19,6 @@ import com.liferay.object.rest.odata.entity.v1_0.provider.EntityModelProvider;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
@@ -117,8 +116,7 @@ public class ObjectEntryRelatedObjectsResourceImpl
 		ObjectRelatedModelsProvider objectRelatedModelsProvider =
 			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
 				relatedObjectDefinition.getClassName(),
-				relatedObjectDefinition.getCompanyId(),
-				objectRelationship.getType());
+				contextCompany.getCompanyId(), objectRelationship.getType());
 
 		objectRelatedModelsProvider.disassociateRelatedModels(
 			contextUser.getUserId(),
@@ -495,9 +493,6 @@ public class ObjectEntryRelatedObjectsResourceImpl
 				_objectDefinition.getObjectDefinitionId(),
 				objectRelationshipName),
 			currentExternalReferenceCode, scopeKey);
-	}
-
-	public void setContextCompany(Company contextCompany) {
 	}
 
 	private void _checkCurrentObjectEntry(

--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.vulcan.aggregation.Facet;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -106,6 +107,60 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 		}
 	}
 
+	protected void assertEquals(
+			Page<ObjectEntry> actualPage, Page<ObjectEntry> expectedPage)
+		throws Exception {
+
+		if (expectedPage.getFacets() != null) {
+			assertFacets(actualPage.getFacets(), expectedPage.getFacets());
+		}
+
+		assertEquals(
+			(List<ObjectEntry>)actualPage.getItems(),
+			(List<ObjectEntry>)expectedPage.getItems());
+	}
+
+	protected void assertFacets(
+			List<Facet> actualFacets, List<Facet> expectedFacets)
+		throws Exception {
+
+		Assert.assertEquals(
+			actualFacets.toString(), expectedFacets.size(),
+			actualFacets.size());
+
+		for (int i = 0; i < expectedFacets.size(); i++) {
+			Facet actualFacet = actualFacets.get(i);
+			Facet expectedFacet = expectedFacets.get(i);
+
+			Assert.assertEquals(
+				expectedFacet.getFacetCriteria(),
+				actualFacet.getFacetCriteria());
+
+			List<Facet.FacetValue> actualFacetFacetValues =
+				actualFacet.getFacetValues();
+
+			List<Facet.FacetValue> expectedFacetFacetValues =
+				expectedFacet.getFacetValues();
+
+			Assert.assertEquals(
+				actualFacetFacetValues.toString(),
+				expectedFacetFacetValues.size(), actualFacetFacetValues.size());
+
+			for (int j = 0; j < expectedFacetFacetValues.size(); j++) {
+				Facet.FacetValue actualFacetValue = actualFacetFacetValues.get(
+					j);
+				Facet.FacetValue expectedFacetValue =
+					expectedFacetFacetValues.get(j);
+
+				Assert.assertEquals(
+					expectedFacetValue.getNumberOfOccurrences(),
+					actualFacetValue.getNumberOfOccurrences());
+				Assert.assertEquals(
+					expectedFacetValue.getTerm(), actualFacetValue.getTerm());
+			}
+		}
+	}
+
 	protected void assertObjectEntryProperties(
 			ObjectEntry actualObjectEntry,
 			Map<String, Object> actualObjectEntryProperties,
@@ -141,6 +196,19 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 		return null;
 	}
 
+	protected Sort[] getSorts(String sort) {
+		if (sort == null) {
+			return new Sort[] {SortFactoryUtil.create("createDate", false)};
+		}
+
+		String[] sortParts = StringUtil.split(sort, ":");
+
+		return new Sort[] {
+			SortFactoryUtil.create(
+				sortParts[0], Objects.equals(sortParts[1], "desc"))
+		};
+	}
+
 	protected String getValue(Object value) {
 		if (value == null) {
 			return null;
@@ -171,24 +239,9 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 			Map<String, String> context, ObjectEntry... expectedObjectEntries)
 		throws Exception {
 
-		Sort[] sorts = null;
-
-		if (context.containsKey("sort")) {
-			String[] sort = StringUtil.split(context.get("sort"), ":");
-
-			sorts = new Sort[] {
-				SortFactoryUtil.create(sort[0], Objects.equals(sort[1], "desc"))
-			};
-		}
-		else {
-			sorts = new Sort[] {SortFactoryUtil.create("createDate", false)};
-		}
-
-		Page<ObjectEntry> page = getObjectEntries(context, sorts);
-
 		assertEquals(
-			(List<ObjectEntry>)page.getItems(),
-			ListUtil.fromArray(expectedObjectEntries));
+			getObjectEntries(context, getSorts(context.get("sort"))),
+			Page.of(ListUtil.fromArray(expectedObjectEntries)));
 	}
 
 	protected static User adminUser;

--- a/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
+++ b/modules/apps/object/object-rest-test-util/src/main/java/com/liferay/object/rest/test/util/BaseObjectEntryManagerImplTestCase.java
@@ -118,6 +118,9 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 		assertEquals(
 			(List<ObjectEntry>)actualPage.getItems(),
 			(List<ObjectEntry>)expectedPage.getItems());
+
+		Assert.assertEquals(
+			expectedPage.getTotalCount(), actualPage.getTotalCount());
 	}
 
 	protected void assertFacets(
@@ -241,7 +244,9 @@ public abstract class BaseObjectEntryManagerImplTestCase {
 
 		assertEquals(
 			getObjectEntries(context, getSorts(context.get("sort"))),
-			Page.of(ListUtil.fromArray(expectedObjectEntries)));
+			Page.of(
+				ListUtil.fromArray(expectedObjectEntries), null,
+				expectedObjectEntries.length));
 	}
 
 	protected static User adminUser;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -324,6 +324,8 @@ public class DefaultObjectEntryManagerImplTest
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
 					new TextObjectFieldBuilder(
+					).indexed(
+						true
 					).labelMap(
 						RandomTestUtil.randomLocaleStringMap()
 					).name(
@@ -334,6 +336,8 @@ public class DefaultObjectEntryManagerImplTest
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
 					new TextObjectFieldBuilder(
+					).indexed(
+						true
 					).labelMap(
 						RandomTestUtil.randomLocaleStringMap()
 					).name(
@@ -5234,7 +5238,12 @@ public class DefaultObjectEntryManagerImplTest
 			Collections.singletonMap("textObjectFieldName", StringPool.BLANK),
 			_objectDefinition1);
 
-		_assertAggregationFacetValue(2, textObjectFieldValue, page);
+		assertFacets(
+			List.of(
+				new Facet(
+					"textObjectFieldName",
+					List.of(new Facet.FacetValue(2, textObjectFieldValue)))),
+			page.getFacets());
 
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(adminUser));
@@ -5265,10 +5274,16 @@ public class DefaultObjectEntryManagerImplTest
 				_objectRelationshipFieldName, StringPool.BLANK),
 			_objectDefinition2);
 
-		_assertAggregationFacetValue(
-			1, String.valueOf(parentObjectEntry1.getId()), page);
-		_assertAggregationFacetValue(
-			2, String.valueOf(parentObjectEntry2.getId()), page);
+		assertFacets(
+			List.of(
+				new Facet(
+					_objectRelationshipFieldName,
+					List.of(
+						new Facet.FacetValue(
+							1, String.valueOf(parentObjectEntry1.getId())),
+						new Facet.FacetValue(
+							2, String.valueOf(parentObjectEntry2.getId()))))),
+			page.getFacets());
 
 		_defaultObjectEntryManager.updateObjectEntry(
 			_simpleDTOConverterContext, _objectDefinition2,
@@ -5286,10 +5301,16 @@ public class DefaultObjectEntryManagerImplTest
 				_objectRelationshipFieldName, StringPool.BLANK),
 			_objectDefinition2);
 
-		_assertAggregationFacetValue(
-			2, String.valueOf(parentObjectEntry1.getId()), page);
-		_assertAggregationFacetValue(
-			1, String.valueOf(parentObjectEntry2.getId()), page);
+		assertFacets(
+			List.of(
+				new Facet(
+					_objectRelationshipFieldName,
+					List.of(
+						new Facet.FacetValue(
+							2, String.valueOf(parentObjectEntry1.getId())),
+						new Facet.FacetValue(
+							1, String.valueOf(parentObjectEntry2.getId()))))),
+			page.getFacets());
 
 		_defaultObjectEntryManager.deleteObjectEntry(
 			_simpleDTOConverterContext, _objectDefinition2,
@@ -5300,10 +5321,16 @@ public class DefaultObjectEntryManagerImplTest
 				_objectRelationshipFieldName, StringPool.BLANK),
 			_objectDefinition2);
 
-		_assertAggregationFacetValue(
-			1, String.valueOf(parentObjectEntry1.getId()), page);
-		_assertAggregationFacetValue(
-			1, String.valueOf(parentObjectEntry2.getId()), page);
+		assertFacets(
+			List.of(
+				new Facet(
+					_objectRelationshipFieldName,
+					List.of(
+						new Facet.FacetValue(
+							1, String.valueOf(parentObjectEntry1.getId())),
+						new Facet.FacetValue(
+							1, String.valueOf(parentObjectEntry2.getId()))))),
+			page.getFacets());
 	}
 
 	@Test
@@ -5619,6 +5646,26 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testGetRelatedObjectEntries() throws Exception {
+		_testGetRelatedObjectEntries(
+			_companyObjectEntryA, _companyObjectRelationshipA_AA, null,
+			(filter, search, sorts) ->
+				_defaultObjectEntryManager.getRelatedObjectEntries(
+					null, _createDTOConverterContext(),
+					_companyObjectEntryA.getExternalReferenceCode(), filter,
+					_companyObjectRelationshipA_AA, null, null, search, sorts));
+		_testGetRelatedObjectEntries(
+			_siteObjectEntryA, _siteObjectRelationshipA_AA,
+			_group.getGroupKey(),
+			(filter, search, sorts) ->
+				_defaultObjectEntryManager.getRelatedObjectEntries(
+					null, _createDTOConverterContext(),
+					_siteObjectEntryA.getExternalReferenceCode(), filter,
+					_siteObjectRelationshipA_AA, null, _group.getGroupKey(),
+					search, sorts));
+	}
+
+	@Test
 	public void testGetRelatedObjectEntriesWithAccountEntryRestricted()
 		throws Exception {
 
@@ -5869,6 +5916,59 @@ public class DefaultObjectEntryManagerImplTest
 	}
 
 	@Test
+	public void testGetRelatedObjectEntriesWithAggregationFacets()
+		throws Exception {
+
+		String textObjectFieldValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntryAA1 =
+			_defaultObjectEntryManager.addRelatedObjectEntry(
+				_simpleDTOConverterContext,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", textObjectFieldValue
+						).build();
+					}
+				},
+				_companyObjectEntryA.getId(), _companyObjectRelationshipA_AA);
+		ObjectEntry objectEntryAA2 =
+			_defaultObjectEntryManager.addRelatedObjectEntry(
+				_simpleDTOConverterContext,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", textObjectFieldValue
+						).build();
+					}
+				},
+				_companyObjectEntryA.getId(), _companyObjectRelationshipA_AA);
+
+		Page<ObjectEntry> page =
+			_defaultObjectEntryManager.getRelatedObjectEntries(
+				new Aggregation() {
+					{
+						setAggregationTerms(
+							Collections.singletonMap(
+								"textObjectFieldName", StringPool.BLANK));
+					}
+				},
+				_createDTOConverterContext(),
+				_companyObjectEntryA.getExternalReferenceCode(), null,
+				_companyObjectRelationshipA_AA, null, null, null, null);
+
+		assertFacets(
+			page.getFacets(),
+			List.of(
+				new Facet(
+					"textObjectFieldName",
+					List.of(new Facet.FacetValue(2, textObjectFieldValue)))));
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntryAA1.getId());
+		_objectEntryLocalService.deleteObjectEntry(objectEntryAA2.getId());
+	}
+
+	@Test
 	public void testGetRelatedObjectEntriesWithRootObjectEntryId()
 		throws Exception {
 
@@ -5880,9 +5980,9 @@ public class DefaultObjectEntryManagerImplTest
 			ObjectDefinitionConstants.SCOPE_COMPANY,
 			(objectEntry, objectRelationship) ->
 				_defaultObjectEntryManager.getRelatedObjectEntries(
-					_createDTOConverterContext(),
-					objectEntry.getExternalReferenceCode(), objectRelationship,
-					null, null));
+					null, _createDTOConverterContext(),
+					objectEntry.getExternalReferenceCode(), null,
+					objectRelationship, null, null, null, null));
 		_testGetRelatedObjectEntriesWithRootObjectEntryId(
 			_companyObjectDefinitionA, _companyObjectDefinitionAA,
 			_companyObjectDefinitionB, _companyObjectEntryA,
@@ -5900,9 +6000,10 @@ public class DefaultObjectEntryManagerImplTest
 			_group.getGroupKey(),
 			(objectEntry, objectRelationship) ->
 				_defaultObjectEntryManager.getRelatedObjectEntries(
-					_createDTOConverterContext(),
-					objectEntry.getExternalReferenceCode(), objectRelationship,
-					null, _group.getGroupKey()));
+					null, _createDTOConverterContext(),
+					objectEntry.getExternalReferenceCode(), null,
+					objectRelationship, null, _group.getGroupKey(), null,
+					null));
 	}
 
 	@Test
@@ -8079,9 +8180,10 @@ public class DefaultObjectEntryManagerImplTest
 		return _addObjectDefinition(
 			List.of(
 				new TextObjectFieldBuilder(
+				).indexed(
+					true
 				).labelMap(
-					LocalizedMapUtil.getLocalizedMap(
-						RandomTestUtil.randomString())
+					RandomTestUtil.randomLocaleStringMap()
 				).name(
 					"textObjectFieldName"
 				).build()),
@@ -8490,28 +8592,6 @@ public class DefaultObjectEntryManagerImplTest
 			actions2,
 			action2 -> Assert.assertFalse(
 				objectEntryActions.containsKey(action2)));
-	}
-
-	private void _assertAggregationFacetValue(
-		Integer expectedNumberOfOccurrences, String facetValueTerm,
-		Page<ObjectEntry> page) {
-
-		List<Facet> facets = page.getFacets();
-
-		Assert.assertFalse(ListUtil.isEmpty(facets));
-
-		Facet facet = facets.get(0);
-
-		List<Facet.FacetValue> facetValues = ListUtil.filter(
-			facet.getFacetValues(),
-			facetValue -> Objects.equals(facetValue.getTerm(), facetValueTerm));
-
-		Assert.assertFalse(ListUtil.isEmpty(facetValues));
-
-		Facet.FacetValue facetValue = facetValues.get(0);
-
-		Assert.assertEquals(
-			expectedNumberOfOccurrences, facetValue.getNumberOfOccurrences());
 	}
 
 	private void _assertCountAggregationObjectFieldValue(
@@ -9574,6 +9654,78 @@ public class DefaultObjectEntryManagerImplTest
 					relatedObjectEntriesSize, objectEntryPage.getTotalCount());
 			}
 		}
+	}
+
+	private void _testGetRelatedObjectEntries(
+			ObjectEntry objectEntryA, ObjectRelationship objectRelationshipA_AA,
+			String scopeKey,
+			UnsafeTriFunction
+				<String, String, Sort[], Page<ObjectEntry>, Exception>
+					unsafeTriFunction)
+		throws Exception {
+
+		// Equals expression
+
+		ObjectEntry objectEntryAA1 =
+			_defaultObjectEntryManager.addRelatedObjectEntry(
+				_simpleDTOConverterContext,
+				objectEntryA.getExternalReferenceCode(),
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", "textObjectFieldValue1"
+						).build();
+					}
+				},
+				objectRelationshipA_AA, scopeKey);
+		ObjectEntry objectEntryAA2 =
+			_defaultObjectEntryManager.addRelatedObjectEntry(
+				_simpleDTOConverterContext,
+				objectEntryA.getExternalReferenceCode(),
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"textObjectFieldName", "textObjectFieldValue2"
+						).build();
+					}
+				},
+				objectRelationshipA_AA, scopeKey);
+
+		assertEquals(
+			unsafeTriFunction.apply(
+				buildEqualsExpressionFilterString(
+					"textObjectFieldName", "textObjectFieldValue1"),
+				null, null),
+			Page.of(List.of(objectEntryAA1)));
+		assertEquals(
+			unsafeTriFunction.apply(
+				buildEqualsExpressionFilterString(
+					"textObjectFieldName", "textObjectFieldValue2"),
+				null, null),
+			Page.of(List.of(objectEntryAA2)));
+
+		// Search
+
+		assertEquals(
+			unsafeTriFunction.apply(null, "textObjectFieldValue", null),
+			Page.of(List.of(objectEntryAA1, objectEntryAA2)));
+		assertEquals(
+			unsafeTriFunction.apply(null, "textObjectFieldValue1", null),
+			Page.of(List.of(objectEntryAA1)));
+
+		// Sort
+
+		assertEquals(
+			unsafeTriFunction.apply(
+				null, null, getSorts("textObjectFieldName:asc")),
+			Page.of(List.of(objectEntryAA1, objectEntryAA2)));
+		assertEquals(
+			unsafeTriFunction.apply(
+				null, null, getSorts("textObjectFieldName:desc")),
+			Page.of(List.of(objectEntryAA2, objectEntryAA1)));
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntryAA1.getId());
+		_objectEntryLocalService.deleteObjectEntry(objectEntryAA2.getId());
 	}
 
 	private void _testGetRelatedObjectEntriesWithRootObjectEntryId(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -113,6 +113,7 @@ import com.liferay.object.tree.Node;
 import com.liferay.object.tree.Tree;
 import com.liferay.object.tree.constants.TreeConstants;
 import com.liferay.petra.function.UnsafeBiFunction;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.UnsafeTriFunction;
 import com.liferay.petra.lang.SafeCloseable;
@@ -9696,33 +9697,33 @@ public class DefaultObjectEntryManagerImplTest
 				buildEqualsExpressionFilterString(
 					"textObjectFieldName", "textObjectFieldValue1"),
 				null, null),
-			Page.of(List.of(objectEntryAA1)));
+			Page.of(List.of(objectEntryAA1), null, 1));
 		assertEquals(
 			unsafeTriFunction.apply(
 				buildEqualsExpressionFilterString(
 					"textObjectFieldName", "textObjectFieldValue2"),
 				null, null),
-			Page.of(List.of(objectEntryAA2)));
+			Page.of(List.of(objectEntryAA2), null, 1));
 
 		// Search
 
 		assertEquals(
 			unsafeTriFunction.apply(null, "textObjectFieldValue", null),
-			Page.of(List.of(objectEntryAA1, objectEntryAA2)));
+			Page.of(List.of(objectEntryAA1, objectEntryAA2), null, 2));
 		assertEquals(
 			unsafeTriFunction.apply(null, "textObjectFieldValue1", null),
-			Page.of(List.of(objectEntryAA1)));
+			Page.of(List.of(objectEntryAA1), null, 1));
 
 		// Sort
 
 		assertEquals(
 			unsafeTriFunction.apply(
 				null, null, getSorts("textObjectFieldName:asc")),
-			Page.of(List.of(objectEntryAA1, objectEntryAA2)));
+			Page.of(List.of(objectEntryAA1, objectEntryAA2), null, 2));
 		assertEquals(
 			unsafeTriFunction.apply(
 				null, null, getSorts("textObjectFieldName:desc")),
-			Page.of(List.of(objectEntryAA2, objectEntryAA1)));
+			Page.of(List.of(objectEntryAA2, objectEntryAA1), null, 1));
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA1.getId());
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA2.getId());
@@ -9787,20 +9788,17 @@ public class DefaultObjectEntryManagerImplTest
 
 		_addRoleUser(new String[] {ActionKeys.VIEW}, objectDefinitionA, _user);
 
-		Page<ObjectEntry> objectEntryPage = unsafeBiFunction.apply(
-			objectEntryA, objectRelationshipA_AA);
+		UnsafeSupplier<Page<ObjectEntry>, Exception> unsafeSupplier =
+			() -> _objectEntryManager.getObjectEntries(
+				TestPropsValues.getCompanyId(), objectDefinitionAA, scopeKey,
+				null, _createDTOConverterContext(), (String)null, null, null,
+				null);
 
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			List.of(objectEntryA_AA));
-
-		objectEntryPage = _objectEntryManager.getObjectEntries(
-			TestPropsValues.getCompanyId(), objectDefinitionAA, scopeKey, null,
-			_createDTOConverterContext(), (String)null, null, null, null);
-
+			unsafeBiFunction.apply(objectEntryA, objectRelationshipA_AA),
+			Page.of(List.of(objectEntryA_AA), null, 1));
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			Collections.emptyList());
+			unsafeSupplier.get(), Page.of(Collections.emptyList(), null, 0));
 
 		AssertUtils.assertFailure(
 			PrincipalException.MustHavePermission.class,
@@ -9824,13 +9822,8 @@ public class DefaultObjectEntryManagerImplTest
 				objectEntryA.getId()),
 			() -> unsafeBiFunction.apply(objectEntryA, objectRelationshipA_AA));
 
-		objectEntryPage = _objectEntryManager.getObjectEntries(
-			TestPropsValues.getCompanyId(), objectDefinitionAA, scopeKey, null,
-			_createDTOConverterContext(), (String)null, null, null, null);
-
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			List.of(objectEntryAA));
+			unsafeSupplier.get(), Page.of(List.of(objectEntryAA), null, 1));
 
 		AssertUtils.assertFailure(
 			PrincipalException.MustHavePermission.class,
@@ -9856,20 +9849,11 @@ public class DefaultObjectEntryManagerImplTest
 				_createDTOConverterContext(), objectEntryA.getId(),
 				objectRelationshipA_AA, null));
 
-		objectEntryPage = _objectEntryManager.getObjectEntries(
-			TestPropsValues.getCompanyId(), objectDefinitionAA, scopeKey, null,
-			_createDTOConverterContext(), (String)null, null, null, null);
-
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			Collections.emptyList());
-
-		objectEntryPage = unsafeBiFunction.apply(
-			objectEntryB, objectRelationshipB_AA);
-
+			unsafeSupplier.get(), Page.of(Collections.emptyList(), null, 0));
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			List.of(objectEntryB_AA));
+			unsafeBiFunction.apply(objectEntryB, objectRelationshipB_AA),
+			Page.of(List.of(objectEntryB_AA), null, 1));
 
 		// User with permission to view object definitions A, AA, and B
 
@@ -9879,27 +9863,14 @@ public class DefaultObjectEntryManagerImplTest
 		_addRoleUser(new String[] {ActionKeys.VIEW}, objectDefinitionAA, _user);
 		_addRoleUser(new String[] {ActionKeys.VIEW}, objectDefinitionB, _user);
 
-		objectEntryPage = unsafeBiFunction.apply(
-			objectEntryA, objectRelationshipA_AA);
-
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			List.of(objectEntryA_AA));
-
-		objectEntryPage = _objectEntryManager.getObjectEntries(
-			TestPropsValues.getCompanyId(), objectDefinitionAA, scopeKey, null,
-			_createDTOConverterContext(), (String)null, null, null, null);
-
+			unsafeBiFunction.apply(objectEntryA, objectRelationshipA_AA),
+			Page.of(List.of(objectEntryA_AA), null, 1));
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			List.of(objectEntryAA));
-
-		objectEntryPage = unsafeBiFunction.apply(
-			objectEntryB, objectRelationshipB_AA);
-
+			unsafeSupplier.get(), Page.of(List.of(objectEntryAA), null, 1));
 		assertEquals(
-			(List<ObjectEntry>)objectEntryPage.getItems(),
-			List.of(objectEntryB_AA));
+			unsafeBiFunction.apply(objectEntryB, objectRelationshipB_AA),
+			Page.of(List.of(objectEntryB_AA), null, 1));
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA.getId());
 		_objectEntryLocalService.deleteObjectEntry(objectEntryA_AA.getId());

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -6038,7 +6038,11 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.object.rest.internal.resource.v1_0." +
+					"ObjectEntryRelatedObjectsResourceImpl",
+				LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
 					"WebApplicationExceptionMapper",
 				LoggerTestUtil.ERROR)) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -1835,7 +1835,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -1864,6 +1878,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -2126,7 +2154,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -2155,6 +2197,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -3046,7 +3102,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -3075,6 +3145,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -3391,7 +3475,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -3420,6 +3518,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -2304,7 +2304,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -2333,6 +2347,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -2595,7 +2623,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -2624,6 +2666,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -2886,7 +2942,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -2915,6 +2985,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -3806,7 +3890,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -3835,6 +3933,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -4151,7 +4263,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -4180,6 +4306,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}
@@ -4496,7 +4636,21 @@
 					},
 					{
 						"in": "query",
+						"name": "aggregationTerms",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
 						"name": "fields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "filter",
 						"schema": {
 							"type": "string"
 						}
@@ -4525,6 +4679,20 @@
 					{
 						"in": "query",
 						"name": "restrictFields",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "search",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"in": "query",
+						"name": "sort",
 						"schema": {
 							"type": "string"
 						}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -39,13 +39,13 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 		return InfoPage.of(
 			objectEntryLocalService.getOneToManyObjectEntries(
 				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getObjectRelationshipId(), null,
 				objectEntry.getObjectEntryId(), true, null,
-				pagination.getStart(), pagination.getEnd()),
+				pagination.getStart(), pagination.getEnd(), null),
 			pagination,
 			objectEntryLocalService.getOneToManyObjectEntriesCount(
 				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getObjectRelationshipId(), null,
 				objectEntry.getObjectEntryId(), true, null));
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1to1ObjectRelatedModelsProviderImpl.java
@@ -15,7 +15,9 @@ import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -56,7 +58,7 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, 0, 1);
+			groupId, objectRelationshipId, null, primaryKey, null, 0, 1, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -139,22 +141,24 @@ public class ObjectEntry1to1ObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, true, search, 0, 1);
+			groupId, objectRelationshipId, predicate, primaryKey, true, search,
+			0, 1, sorts);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException {
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, search, 0, 1);
+			groupId, objectRelationshipId, predicate, primaryKey, search, 0, 1,
+			null);
 
 		return relatedModels.size();
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
@@ -15,8 +15,10 @@ import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
@@ -57,8 +59,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, null, primaryKey, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -148,23 +150,23 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, primaryKey, true, search, start,
-			end);
+			groupId, objectRelationshipId, predicate, primaryKey, true, search,
+			start, end, sorts);
 	}
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, true, search);
+			groupId, objectRelationshipId, predicate, primaryKey, true, search);
 	}
 
 	@Override
@@ -175,8 +177,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntries(
-			groupId, objectRelationshipId, objectEntryId, false, search, start,
-			end);
+			groupId, objectRelationshipId, null, objectEntryId, false, search,
+			start, end, null);
 	}
 
 	@Override
@@ -186,7 +188,7 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		return _objectEntryService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, objectEntryId, false, search);
+			groupId, objectRelationshipId, null, objectEntryId, false, search);
 	}
 
 	@Override
@@ -200,8 +202,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, null, primaryKey, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -239,8 +241,8 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 
 		for (ObjectEntry objectEntry :
 				getRelatedModels(
-					groupId, objectRelationshipId, primaryKey, null,
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+					groupId, objectRelationshipId, null, primaryKey, null,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
 			if (!objectEntry.isInTrash()) {
 				continue;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsProviderImpl.java
@@ -13,8 +13,10 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ServiceContext;
 
 import java.util.List;
@@ -46,8 +48,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, null, primaryKey, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -108,8 +110,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 	}
 
 	public List<ObjectEntry> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -123,8 +125,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -175,8 +177,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<ObjectEntry> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, null, primaryKey, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -226,8 +228,8 @@ public class ObjectEntryMtoMObjectRelatedModelsProviderImpl
 
 		for (ObjectEntry objectEntry :
 				getRelatedModels(
-					groupId, objectRelationshipId, primaryKey, null,
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+					groupId, objectRelationshipId, null, primaryKey, null,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
 
 			if (!objectEntry.isInTrash()) {
 				continue;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
@@ -24,6 +24,7 @@ import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.sql.dsl.expression.Expression;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
@@ -32,6 +33,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -85,8 +87,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 				objectRelationshipId);
 
 		List<T> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, null, primaryKey, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -249,8 +251,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<T> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException {
 
 		PersistedModelLocalService persistedModelLocalService =
@@ -274,8 +276,8 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException {
 
 		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
@@ -23,12 +23,14 @@ import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.petra.sql.dsl.query.JoinStep;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 
@@ -71,8 +73,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 		throws PortalException {
 
 		List<T> relatedModels = getRelatedModels(
-			groupId, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-			QueryUtil.ALL_POS);
+			groupId, objectRelationshipId, null, primaryKey, null,
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		if (relatedModels.isEmpty()) {
 			return;
@@ -138,8 +140,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 
 	@Override
 	public List<T> getRelatedModels(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search, int start, int end, Sort[] sorts)
 		throws PortalException {
 
 		PersistedModelLocalService persistedModelLocalService =
@@ -161,8 +163,8 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 
 	@Override
 	public int getRelatedModelsCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, String search)
 		throws PortalException {
 
 		PersistedModelLocalService persistedModelLocalService =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectEntryServiceHttp.java
@@ -586,8 +586,10 @@ public class ObjectEntryServiceHttp {
 	public static java.util.List<com.liferay.object.model.ObjectEntry>
 			getOneToManyObjectEntries(
 				HttpPrincipal httpPrincipal, long groupId,
-				long objectRelationshipId, long primaryKey, boolean related,
-				String search, int start, int end)
+				long objectRelationshipId,
+				com.liferay.petra.sql.dsl.expression.Predicate predicate,
+				long primaryKey, boolean related, String search, int start,
+				int end, com.liferay.portal.kernel.search.Sort[] sorts)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -596,8 +598,8 @@ public class ObjectEntryServiceHttp {
 				_getOneToManyObjectEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
-				search, start, end);
+				methodKey, groupId, objectRelationshipId, predicate, primaryKey,
+				related, search, start, end, sorts);
 
 			Object returnObj = null;
 
@@ -630,8 +632,9 @@ public class ObjectEntryServiceHttp {
 
 	public static int getOneToManyObjectEntriesCount(
 			HttpPrincipal httpPrincipal, long groupId,
-			long objectRelationshipId, long primaryKey, boolean related,
-			String search)
+			long objectRelationshipId,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -640,8 +643,8 @@ public class ObjectEntryServiceHttp {
 				_getOneToManyObjectEntriesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, objectRelationshipId, primaryKey, related,
-				search);
+				methodKey, groupId, objectRelationshipId, predicate, primaryKey,
+				related, search);
 
 			Object returnObj = null;
 
@@ -1210,12 +1213,16 @@ public class ObjectEntryServiceHttp {
 		new Class[] {String.class, long.class, long.class};
 	private static final Class<?>[] _getOneToManyObjectEntriesParameterTypes13 =
 		new Class[] {
-			long.class, long.class, long.class, boolean.class, String.class,
-			int.class, int.class
+			long.class, long.class,
+			com.liferay.petra.sql.dsl.expression.Predicate.class, long.class,
+			boolean.class, String.class, int.class, int.class,
+			com.liferay.portal.kernel.search.Sort[].class
 		};
 	private static final Class<?>[]
 		_getOneToManyObjectEntriesCountParameterTypes14 = new Class[] {
-			long.class, long.class, long.class, boolean.class, String.class
+			long.class, long.class,
+			com.liferay.petra.sql.dsl.expression.Predicate.class, long.class,
+			boolean.class, String.class
 		};
 	private static final Class<?>[] _getOrAddEmptyObjectEntryParameterTypes15 =
 		new Class[] {String.class, long.class, long.class, long.class};

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -933,15 +933,15 @@ public class ObjectEntryLocalServiceImpl
 		).from(
 			dynamicObjectDefinitionTable
 		).innerJoinON(
-			ObjectEntryTable.INSTANCE,
-			ObjectEntryTable.INSTANCE.objectEntryId.eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
-		).innerJoinON(
 			extensionDynamicObjectDefinitionTable,
 			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
 			).eq(
 				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
 			)
+		).innerJoinON(
+			ObjectEntryTable.INSTANCE,
+			ObjectEntryTable.INSTANCE.objectEntryId.eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
 		).where(
 			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
 				objectDefinitionId
@@ -1172,37 +1172,89 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	@Override
-	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search, int start, int end)
+	public Map<Object, Long> getOneToManyAggregationCounts(
+			long groupId, long objectDefinitionId, long objectEntryId,
+			long objectRelationshipId, String aggregationTerm,
+			Predicate predicate, boolean related, String search, int start,
+			int end)
 		throws PortalException {
 
+		Table table = _objectFieldLocalService.getTable(
+			objectDefinitionId, aggregationTerm);
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectDefinitionId, aggregationTerm);
+
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinitionId);
+
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
-			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
-			groupId, objectRelationshipId, primaryKey, related, search
-		).orderBy(
-			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
+			DSLQueryFactoryUtil.select(
+				table.getColumn(objectField.getDBColumnName()),
+				DSLFunctionFactoryUtil.countDistinct(
+					dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+				).as(
+					"aggregationCount"
+				)),
+			groupId, objectRelationshipId, predicate, objectEntryId, related,
+			search
+		).groupBy(
+			table.getColumn(objectField.getDBColumnName())
 		).limit(
 			start, end
 		);
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("Get one to many related object entries: " + dslQuery);
+		Map<Object, Long> aggregationCounts = new HashMap<>();
+
+		for (Object[] values : (List<Object[]>)dslQuery(dslQuery)) {
+			aggregationCounts.put(
+				GetterUtil.getObject(values[0]), GetterUtil.getLong(values[1]));
 		}
 
-		return objectEntryPersistence.dslQuery(dslQuery);
+		return aggregationCounts;
+	}
+
+	@Override
+	public List<ObjectEntry> getOneToManyObjectEntries(
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search, int start, int end,
+			Sort[] sorts)
+		throws PortalException {
+
+		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
+			DSLQueryFactoryUtil.select(ObjectEntryTable.INSTANCE), groupId,
+			objectRelationshipId, predicate, primaryKey, related, search
+		).limit(
+			start, end
+		);
+
+		if (sorts == null) {
+			sorts = new Sort[] {new Sort("id", Sort.LONG_TYPE, false)};
+		}
+
+		ObjectRelationshipLocalService objectRelationshipLocalService =
+			_objectRelationshipLocalServiceSnapshot.get();
+
+		ObjectRelationship objectRelationship =
+			objectRelationshipLocalService.getObjectRelationship(
+				objectRelationshipId);
+
+		return objectEntryPersistence.dslQuery(
+			_applyOrderBy(
+				dslQuery, objectRelationship.getObjectDefinitionId2(), sorts));
 	}
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws PortalException {
 
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.countDistinct(
 				ObjectEntryTable.INSTANCE.objectEntryId),
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
@@ -1325,23 +1377,9 @@ public class ObjectEntryLocalServiceImpl
 			start, end
 		);
 
-		if (sorts != null) {
-			SortDSLQueryVisitor sortDSLQueryVisitor = new SortDSLQueryVisitor(
-				_objectFieldLocalService,
-				_objectRelationshipLocalServiceSnapshot.get());
-
-			for (Sort sort : sorts) {
-				dslQuery = sortDSLQueryVisitor.visit(
-					dslQuery,
-					new com.liferay.object.internal.sort.Sort(
-						_objectDefinitionPersistence.findByPrimaryKey(
-							objectDefinitionId),
-						sort));
-			}
-		}
-
 		return TransformUtil.transform(
-			objectEntryPersistence.dslQuery(dslQuery),
+			objectEntryPersistence.dslQuery(
+				_applyOrderBy(dslQuery, objectDefinitionId, sorts)),
 			value -> (Long)_getResult(
 				value, objectDefinitionId,
 				dynamicObjectDefinitionTable.getPrimaryKeyColumn()));
@@ -2682,6 +2720,30 @@ public class ObjectEntryLocalServiceImpl
 			});
 	}
 
+	private DSLQuery _applyOrderBy(
+			DSLQuery dslQuery, long objectDefinitionId, Sort[] sorts)
+		throws PortalException {
+
+		if (sorts == null) {
+			return dslQuery;
+		}
+
+		SortDSLQueryVisitor sortDSLQueryVisitor = new SortDSLQueryVisitor(
+			_objectFieldLocalService,
+			_objectRelationshipLocalServiceSnapshot.get());
+
+		for (Sort sort : sorts) {
+			dslQuery = sortDSLQueryVisitor.visit(
+				dslQuery,
+				new com.liferay.object.internal.sort.Sort(
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectDefinitionId),
+					sort));
+		}
+
+		return dslQuery;
+	}
+
 	private void _checkObjectEntriesByDisplayDate(long companyId, Date date)
 		throws PortalException {
 
@@ -4017,7 +4079,8 @@ public class ObjectEntryLocalServiceImpl
 
 	private GroupByStep _getOneToManyObjectEntriesGroupByStep(
 			FromStep fromStep, long groupId, long objectRelationshipId,
-			long primaryKey, boolean related, String search)
+			Predicate predicate, long primaryKey, boolean related,
+			String search)
 		throws PortalException {
 
 		ObjectRelationship objectRelationship =
@@ -4134,11 +4197,10 @@ public class ObjectEntryLocalServiceImpl
 						rootObjectDefinitionId);
 				}
 			).and(
-				ObjectEntrySearchUtil.getRelatedModelsPredicate(
-					_objectDefinitionPersistence.fetchByPrimaryKey(
-						objectRelationship.getObjectDefinitionId2()),
-					_objectFieldLocalService, search,
-					dynamicObjectDefinitionTable)
+				Predicate.withParentheses(
+					_fillPredicate(
+						objectRelationship.getObjectDefinitionId2(), predicate,
+						search))
 			)
 		);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1179,14 +1179,14 @@ public class ObjectEntryLocalServiceImpl
 			int end)
 		throws PortalException {
 
-		Table table = _objectFieldLocalService.getTable(
-			objectDefinitionId, aggregationTerm);
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinitionId);
 
 		ObjectField objectField = _objectFieldLocalService.getObjectField(
 			objectDefinitionId, aggregationTerm);
 
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_getDynamicObjectDefinitionTable(objectDefinitionId);
+		Table table = _objectFieldLocalService.getTable(
+			objectDefinitionId, aggregationTerm);
 
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.select(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1316,66 +1316,16 @@ public class ObjectEntryLocalServiceImpl
 			int start, int end, Sort[] sorts)
 		throws PortalException {
 
-		DynamicObjectDefinitionLocalizationTable
-			dynamicObjectDefinitionLocalizationTable =
-				DynamicObjectDefinitionLocalizationTableFactory.create(
-					_objectDefinitionPersistence.findByPrimaryKey(
-						objectDefinitionId),
-					_objectFieldLocalService);
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_getDynamicObjectDefinitionTable(objectDefinitionId);
-		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
-			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
-
-		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			ObjectEntryTable.INSTANCE.objectEntryId
-		).from(
-			dynamicObjectDefinitionTable
-		).innerJoinON(
-			extensionDynamicObjectDefinitionTable,
-			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
-			).eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
-			)
-		).innerJoinON(
-			ObjectEntryTable.INSTANCE,
-			ObjectEntryTable.INSTANCE.objectEntryId.eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
-		).leftJoinOn(
-			dynamicObjectDefinitionLocalizationTable,
-			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
-				dynamicObjectDefinitionLocalizationTable,
-				dynamicObjectDefinitionTable)
-		).where(
-			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
-				objectDefinitionId
-			).and(
-				ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(
-					ObjectEntryTable.INSTANCE.objectEntryId
-				).or(
-					ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(0L)
-				).withParentheses()
-			).and(
-				ObjectEntryTable.INSTANCE.status.neq(
-					WorkflowConstants.STATUS_IN_TRASH)
-			).and(
-				() -> {
-					if (ArrayUtil.isEmpty(groupIds)) {
-						return null;
-					}
-
-					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
-				}
-			).and(
-				Predicate.withParentheses(
-					_fillPredicate(objectDefinitionId, predicate, search))
-			).and(
-				_getPermissionWherePredicate(
-					dynamicObjectDefinitionTable, groupIds)
-			)
+		DSLQuery dslQuery = _getObjectEntriesGroupByStep(
+			groupIds,
+			DSLQueryFactoryUtil.select(ObjectEntryTable.INSTANCE.objectEntryId),
+			objectDefinitionId, predicate, search
 		).limit(
 			start, end
 		);
+
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinitionId);
 
 		return TransformUtil.transform(
 			objectEntryPersistence.dslQuery(
@@ -1629,57 +1579,12 @@ public class ObjectEntryLocalServiceImpl
 			long objectDefinitionId, Predicate predicate, String search)
 		throws PortalException {
 
-		DynamicObjectDefinitionLocalizationTable
-			dynamicObjectDefinitionLocalizationTable =
-				DynamicObjectDefinitionLocalizationTableFactory.create(
-					_objectDefinitionPersistence.findByPrimaryKey(
-						objectDefinitionId),
-					_objectFieldLocalService);
-		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
-			_getDynamicObjectDefinitionTable(objectDefinitionId);
-		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
-			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
-
-		DSLQuery dslQuery = DSLQueryFactoryUtil.countDistinct(
-			ObjectEntryTable.INSTANCE.objectEntryId
-		).from(
-			dynamicObjectDefinitionTable
-		).innerJoinON(
-			extensionDynamicObjectDefinitionTable,
-			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
-			).eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
-			)
-		).innerJoinON(
-			ObjectEntryTable.INSTANCE,
-			ObjectEntryTable.INSTANCE.objectEntryId.eq(
-				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
-		).leftJoinOn(
-			dynamicObjectDefinitionLocalizationTable,
-			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
-				dynamicObjectDefinitionLocalizationTable,
-				dynamicObjectDefinitionTable)
-		).where(
-			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
-				objectDefinitionId
-			).and(
-				() -> {
-					if (ArrayUtil.isEmpty(groupIds)) {
-						return null;
-					}
-
-					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
-				}
-			).and(
-				Predicate.withParentheses(
-					_fillPredicate(objectDefinitionId, predicate, search))
-			).and(
-				_getPermissionWherePredicate(
-					dynamicObjectDefinitionTable, groupIds)
-			)
-		);
-
-		return objectEntryPersistence.dslQueryCount(dslQuery);
+		return objectEntryPersistence.dslQueryCount(
+			_getObjectEntriesGroupByStep(
+				groupIds,
+				DSLQueryFactoryUtil.countDistinct(
+					ObjectEntryTable.INSTANCE.objectEntryId),
+				objectDefinitionId, predicate, search));
 	}
 
 	@Override
@@ -4059,6 +3964,69 @@ public class ObjectEntryLocalServiceImpl
 				ObjectEntrySearchUtil.getRelatedModelsPredicate(
 					objectDefinition2, _objectFieldLocalService, search,
 					dynamicObjectDefinitionTable)
+			)
+		);
+	}
+
+	private GroupByStep _getObjectEntriesGroupByStep(
+			Long[] groupIds, FromStep fromStep, long objectDefinitionId,
+			Predicate predicate, String search)
+		throws PortalException {
+
+		DynamicObjectDefinitionLocalizationTable
+			dynamicObjectDefinitionLocalizationTable =
+				DynamicObjectDefinitionLocalizationTableFactory.create(
+					_objectDefinitionPersistence.findByPrimaryKey(
+						objectDefinitionId),
+					_objectFieldLocalService);
+		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
+			_getDynamicObjectDefinitionTable(objectDefinitionId);
+		DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable =
+			_getExtensionDynamicObjectDefinitionTable(objectDefinitionId);
+
+		return fromStep.from(
+			dynamicObjectDefinitionTable
+		).innerJoinON(
+			extensionDynamicObjectDefinitionTable,
+			extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn(
+			).eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn()
+			)
+		).innerJoinON(
+			ObjectEntryTable.INSTANCE,
+			ObjectEntryTable.INSTANCE.objectEntryId.eq(
+				dynamicObjectDefinitionTable.getPrimaryKeyColumn())
+		).leftJoinOn(
+			dynamicObjectDefinitionLocalizationTable,
+			ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate(
+				dynamicObjectDefinitionLocalizationTable,
+				dynamicObjectDefinitionTable)
+		).where(
+			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+				objectDefinitionId
+			).and(
+				ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(
+					ObjectEntryTable.INSTANCE.objectEntryId
+				).or(
+					ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(0L)
+				).withParentheses()
+			).and(
+				ObjectEntryTable.INSTANCE.status.neq(
+					WorkflowConstants.STATUS_IN_TRASH)
+			).and(
+				() -> {
+					if (ArrayUtil.isEmpty(groupIds)) {
+						return null;
+					}
+
+					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
+				}
+			).and(
+				Predicate.withParentheses(
+					_fillPredicate(objectDefinitionId, predicate, search))
+			).and(
+				_getPermissionWherePredicate(
+					dynamicObjectDefinitionTable, groupIds)
 			)
 		);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.base.ObjectEntryServiceBaseImpl;
 import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -47,6 +48,7 @@ import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -326,14 +328,15 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public List<ObjectEntry> getOneToManyObjectEntries(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search, int start, int end)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search, int start, int end,
+			Sort[] sorts)
 		throws PortalException {
 
 		List<ObjectEntry> objectEntries =
 			objectEntryLocalService.getOneToManyObjectEntries(
-				groupId, objectRelationshipId, primaryKey, related, search,
-				start, end);
+				groupId, objectRelationshipId, predicate, primaryKey, related,
+				search, start, end, sorts);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
 			for (ObjectEntry objectEntry : objectEntries) {
@@ -348,12 +351,13 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 	@Override
 	public int getOneToManyObjectEntriesCount(
-			long groupId, long objectRelationshipId, long primaryKey,
-			boolean related, String search)
+			long groupId, long objectRelationshipId, Predicate predicate,
+			long primaryKey, boolean related, String search)
 		throws PortalException {
 
 		return objectEntryLocalService.getOneToManyObjectEntriesCount(
-			groupId, objectRelationshipId, primaryKey, related, search);
+			groupId, objectRelationshipId, predicate, primaryKey, related,
+			search);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1700,8 +1700,8 @@ public class ObjectRelationshipLocalServiceImpl
 
 				int relatedObjectEntriesCount =
 					_objectEntryLocalService.getOneToManyObjectEntriesCount(
-						0, objectRelationship.getObjectRelationshipId(), 0L,
-						false, null);
+						0, objectRelationship.getObjectRelationshipId(), null,
+						0L, false, null);
 
 				if (relatedObjectEntriesCount > 0) {
 					throw new ObjectRelationshipEdgeException(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -765,7 +765,7 @@ public class ObjectRelatedModelsProviderTest {
 		Assert.assertEquals(
 			0,
 			_objectRelatedModelsProvider.getRelatedModelsCount(
-				0, _objectRelationship.getObjectRelationshipId(),
+				0, _objectRelationship.getObjectRelationshipId(), null,
 				parentObjectEntry.getObjectEntryId(), null));
 
 		_resourcePermissionLocalService.setResourcePermissions(
@@ -776,7 +776,7 @@ public class ObjectRelatedModelsProviderTest {
 		Assert.assertEquals(
 			expectedRelatedModelsCount,
 			_objectRelatedModelsProvider.getRelatedModelsCount(
-				0, _objectRelationship.getObjectRelationshipId(),
+				0, _objectRelationship.getObjectRelationshipId(), null,
 				parentObjectEntry.getObjectEntryId(), null));
 
 		_resourcePermissionLocalService.removeResourcePermission(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/util/ObjectRelationshipTestUtil.java
@@ -42,8 +42,8 @@ public class ObjectRelationshipTestUtil {
 
 		List<ObjectEntry> objectEntries =
 			objectRelatedModelsProvider.getRelatedModels(
-				0, objectRelationshipId, primaryKey, null, QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS);
+				0, objectRelationshipId, null, primaryKey, null,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		Assert.assertEquals(
 			objectEntries.toString(), expectedSize, objectEntries.size());
@@ -57,8 +57,8 @@ public class ObjectRelationshipTestUtil {
 
 		List<ObjectEntry> objectEntries =
 			objectRelatedModelsProvider.getRelatedModels(
-				groupId, objectRelationshipId, primaryKey, search,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				groupId, objectRelationshipId, null, primaryKey, search,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		Assert.assertEquals(
 			objectEntries.toString(), expectedSize, objectEntries.size());

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/data/provider/RelatedModelsFDSDataProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/data/provider/RelatedModelsFDSDataProvider.java
@@ -78,9 +78,9 @@ public class RelatedModelsFDSDataProvider
 
 		return TransformUtil.transform(
 			(List<ObjectEntry>)objectRelatedModelsProvider.getRelatedModels(
-				groupId, objectRelationshipId, objectEntryId,
+				groupId, objectRelationshipId, null, objectEntryId,
 				fdsKeywords.getKeywords(), fdsPagination.getStartPosition(),
-				fdsPagination.getEndPosition()),
+				fdsPagination.getEndPosition(), null),
 			objectEntry -> new RelatedModel(
 				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
 				objectEntry.getTitleValue(), false));
@@ -116,7 +116,8 @@ public class RelatedModelsFDSDataProvider
 
 		return objectRelatedModelsProvider.getRelatedModelsCount(
 			objectScopeProvider.getGroupId(httpServletRequest),
-			objectRelationshipId, objectEntryId, fdsKeywords.getKeywords());
+			objectRelationshipId, null, objectEntryId,
+			fdsKeywords.getKeywords());
 	}
 
 	@Reference

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/provider/SystemRelatedModelsFDSDataProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/provider/SystemRelatedModelsFDSDataProvider.java
@@ -85,9 +85,9 @@ public class SystemRelatedModelsFDSDataProvider
 		return TransformUtil.transform(
 			(List<BaseModel<?>>)objectRelatedModelsProvider.getRelatedModels(
 				objectScopeProvider.getGroupId(httpServletRequest),
-				objectRelationshipId, objectEntryId, fdsKeywords.getKeywords(),
-				fdsPagination.getStartPosition(),
-				fdsPagination.getEndPosition()),
+				objectRelationshipId, null, objectEntryId,
+				fdsKeywords.getKeywords(), fdsPagination.getStartPosition(),
+				fdsPagination.getEndPosition(), null),
 			relatedModel -> {
 				ObjectField titleObjectField =
 					_objectFieldLocalService.fetchObjectField(
@@ -155,7 +155,8 @@ public class SystemRelatedModelsFDSDataProvider
 
 		return objectRelatedModelsProvider.getRelatedModelsCount(
 			objectScopeProvider.getGroupId(httpServletRequest),
-			objectRelationshipId, objectEntryId, fdsKeywords.getKeywords());
+			objectRelationshipId, null, objectEntryId,
+			fdsKeywords.getKeywords());
 	}
 
 	@Reference


### PR DESCRIPTION
Related: 

- [LPD-62317](https://liferay.atlassian.net/browse/LPD-62317)
- [LPD-62835](https://liferay.atlassian.net/browse/LPD-62835)

Start reviewing from https://github.com/liferay-bpm/liferay-portal/pull/5046/commits/630be5fbd2714b7daec4196dfa7ff4111149db5f

[LPD-62317]: https://liferay.atlassian.net/browse/LPD-62317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-62835]: https://liferay.atlassian.net/browse/LPD-62835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ