### PR TITLE
LPD-64548 Language override does not follow user display language when using attachment object field

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
@@ -118,8 +118,7 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 		).put(
 			"tip",
 			_language.format(
-				ddmFormFieldRenderingContext.getLocale(),
-				"upload-a-x-no-larger-than-x",
+				themeDisplay.getLocale(), "upload-a-x-no-larger-than-x",
 				new Object[] {
 					ddmFormField.getProperty("acceptedFileExtensions"),
 					_language.formatStorageSize(

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributorTest.java
@@ -17,11 +17,17 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.configuration.UploadServletRequestConfigurationProvider;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -33,6 +39,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Pedro Leite
@@ -119,6 +127,45 @@ public class AttachmentDDMFormFieldTemplateContextContributorTest
 				"localizedObjectField"));
 	}
 
+	@Test
+	public void testGetParametersTip() {
+		Mockito.when(
+			_attachmentManager.getMaximumFileSize(
+				Mockito.anyLong(), Mockito.anyBoolean())
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		_ddmFormField.setProperty("contentURL", RandomTestUtil.randomString());
+		_ddmFormField.setProperty("localizedObjectField", true);
+
+		_testGetParametersTip(LocaleUtil.BRAZIL);
+		_testGetParametersTip(LocaleUtil.ENGLISH);
+	}
+
+	private DDMFormFieldRenderingContext _createDDMFormFieldRenderingContext(
+		Locale locale) {
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			new DDMFormFieldRenderingContext();
+
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getLocale()
+		).thenReturn(
+			locale
+		);
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		ddmFormFieldRenderingContext.setHttpServletRequest(httpServletRequest);
+
+		return ddmFormFieldRenderingContext;
+	}
+
 	private void _mockFileEntry(FileEntry fileEntry, Long value)
 		throws Exception {
 
@@ -138,7 +185,7 @@ public class AttachmentDDMFormFieldTemplateContextContributorTest
 	private void _setUpAttachmentManager() {
 		ReflectionTestUtil.setFieldValue(
 			_attachmentDDMFormFieldTemplateContextContributor,
-			"_attachmentManager", Mockito.mock(AttachmentManager.class));
+			"_attachmentManager", _attachmentManager);
 	}
 
 	private void _setUpDLAppLocalService() throws Exception {
@@ -178,9 +225,30 @@ public class AttachmentDDMFormFieldTemplateContextContributorTest
 			_uploadServletRequestConfigurationProvider);
 	}
 
+	private void _testGetParametersTip(Locale locale) {
+		String tip = RandomTestUtil.randomString();
+
+		Mockito.when(
+			language.format(
+				Mockito.eq(locale), Mockito.eq("upload-a-x-no-larger-than-x"),
+				Mockito.any(Object[].class))
+		).thenReturn(
+			tip
+		);
+
+		Assert.assertEquals(
+			tip,
+			MapUtil.getString(
+				_attachmentDDMFormFieldTemplateContextContributor.getParameters(
+					_ddmFormField, _createDDMFormFieldRenderingContext(locale)),
+				"tip"));
+	}
+
 	private final AttachmentDDMFormFieldTemplateContextContributor
 		_attachmentDDMFormFieldTemplateContextContributor =
 			new AttachmentDDMFormFieldTemplateContextContributor();
+	private final AttachmentManager _attachmentManager = Mockito.mock(
+		AttachmentManager.class);
 	private final DDMFormField _ddmFormField = new DDMFormField(
 		"field", ObjectDDMFormFieldTypeConstants.ATTACHMENT);
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPD-64548