### PR TITLE
LPD-58309 Multiple calls to postObjectEntry causes 'Deadlock found when trying to get lock; try restarting transaction'

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/attachment/AttachmentManager.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/attachment/AttachmentManager.java
@@ -25,6 +25,11 @@ public interface AttachmentManager {
 			ServiceContext serviceContext, long userId)
 		throws PortalException;
 
+	public DLFolder getDLFolder(
+			long companyId, long groupId, String portletId,
+			ServiceContext serviceContext, long userId)
+		throws PortalException;
+
 	public long getMaximumFileSize(long objectFieldId, boolean signedIn);
 
 	public FileEntry getOrAddFileEntry(

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/attachment/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/attachment/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
@@ -107,12 +107,42 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			ObjectDefinition objectDefinition =
 				objectField.getObjectDefinition();
 
-			dlFolderId = _getRepositoryFolderId(
+			DLFolder dlFolder = getDLFolder(
 				companyId, groupId, objectDefinition.getPortletId(),
 				serviceContext, userId);
+
+			dlFolderId = dlFolder.getFolderId();
 		}
 
 		return _dlFolderLocalService.getDLFolder(dlFolderId);
+	}
+
+	@Override
+	public DLFolder getDLFolder(
+			long companyId, long groupId, String portletId,
+			ServiceContext serviceContext, long userId)
+		throws PortalException {
+
+		Repository repository = _getRepository(
+			groupId, portletId, serviceContext);
+
+		if (repository == null) {
+			return null;
+		}
+
+		DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
+			repository.getGroupId(), repository.getDlFolderId(),
+			String.valueOf(userId));
+
+		if (dlFolder != null) {
+			return dlFolder;
+		}
+
+		return _dlFolderLocalService.addFolder(
+			null, _userLocalService.getGuestUserId(companyId),
+			repository.getGroupId(), repository.getRepositoryId(), false,
+			repository.getDlFolderId(), String.valueOf(userId), null, false,
+			serviceContext);
 	}
 
 	@Override
@@ -312,35 +342,6 @@ public class AttachmentManagerImpl implements AttachmentManager {
 
 		return _portletFileRepository.addPortletRepository(
 			groupId, portletId, serviceContext);
-	}
-
-	private Long _getRepositoryFolderId(
-			long companyId, long groupId, String portletId,
-			ServiceContext serviceContext, long userId)
-		throws PortalException {
-
-		Repository repository = _getRepository(
-			groupId, portletId, serviceContext);
-
-		if (repository == null) {
-			return null;
-		}
-
-		DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
-			repository.getGroupId(), repository.getDlFolderId(),
-			String.valueOf(userId));
-
-		if (dlFolder != null) {
-			return dlFolder.getFolderId();
-		}
-
-		dlFolder = _dlFolderLocalService.addFolder(
-			null, _userLocalService.getGuestUserId(companyId),
-			repository.getGroupId(), repository.getRepositoryId(), false,
-			repository.getDlFolderId(), String.valueOf(userId), null, false,
-			serviceContext);
-
-		return dlFolder.getFolderId();
 	}
 
 	private Long _getStorageDLFolderId(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/DepotEntryModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/DepotEntryModelListenerTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.File;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Fábio Alves
+ */
+@RunWith(Arquillian.class)
+public class DepotEntryModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		Bundle testBundle = FrameworkUtil.getBundle(
+			DepotEntryModelListenerTest.class);
+
+		BundleContext bundleContext = testBundle.getBundleContext();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			if (Objects.equals(
+					bundle.getSymbolicName(),
+					"com.liferay.site.initializer.cms")) {
+
+				_deleteFile(bundle, "01.object.folder");
+				_deleteFile(bundle, "02.object.definition");
+
+				CompletableFuture<Void> completableFuture =
+					_batchEngineUnitProcessor.processBatchEngineUnits(
+						_batchEngineUnitReader.getBatchEngineUnits(bundle));
+
+				completableFuture.join();
+
+				break;
+			}
+		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testOnAfterCreate() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_BASIC_DOCUMENT", group.getCompanyId());
+
+		Repository repository = _portletFileRepository.getPortletRepository(
+			group.getGroupId(), objectDefinition.getPortletId());
+
+		Assert.assertNotNull(
+			_dlFolderLocalService.fetchFolder(
+				group.getGroupId(), repository.getDlFolderId(),
+				String.valueOf(TestPropsValues.getUserId())));
+
+		Assert.assertNotNull(
+			_repositoryLocalService.fetchRepository(
+				group.getGroupId(), TempFileEntryUtil.class.getName(),
+				TempFileEntryUtil.class.getName()));
+	}
+
+	private void _deleteFile(Bundle bundle, String fileName) {
+		File file = bundle.getDataFile(
+			".com.liferay.site.initializer.cms.internal.batch." + fileName +
+				".batch.engine.data.json.0.processed");
+
+		if ((file != null) && file.exists()) {
+			file.delete();
+		}
+	}
+
+	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFolderLocalService _dlFolderLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private PortletFileRepository _portletFileRepository;
+
+	@Inject
+	private RepositoryLocalService _repositoryLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/model/listener/test/GroupModelListenerTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.site.cms.site.initializer.util.CMSDefaultPermissionUtil;
 
 import java.io.File;
@@ -57,7 +58,9 @@ public class GroupModelListenerTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/DepotEntryModelListener.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/model/listener/DepotEntryModelListener.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.model.listener;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.util.DLAppHelperThreadLocal;
+import com.liferay.object.field.attachment.AttachmentManager;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RepositoryLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.repository.temporaryrepository.TemporaryFileEntryRepository;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(service = ModelListener.class)
+public class DepotEntryModelListener extends BaseModelListener<DepotEntry> {
+
+	@Override
+	public void onAfterCreate(DepotEntry depotEntry)
+		throws ModelListenerException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				depotEntry.getCompanyId(), "LPD-17564") ||
+			(depotEntry.getType() != DepotConstants.TYPE_SPACE)) {
+
+			return;
+		}
+
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		if ((group == null) || !group.isDepot()) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_BASIC_DOCUMENT", depotEntry.getCompanyId());
+
+		if (objectDefinition == null) {
+			return;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+		}
+
+		try {
+			DLFolder dlFolder = _attachmentManager.getDLFolder(
+				objectDefinition.getCompanyId(), group.getGroupId(),
+				objectDefinition.getPortletId(), serviceContext,
+				PrincipalThreadLocal.getUserId());
+
+			if (dlFolder == null) {
+				return;
+			}
+
+			try (SafeCloseable safeCloseable =
+					DLAppHelperThreadLocal.setEnabledWithSafeCloseable(false)) {
+
+				Repository repository = _repositoryLocalService.fetchRepository(
+					group.getGroupId(), TempFileEntryUtil.class.getName(),
+					TempFileEntryUtil.class.getName());
+
+				if (repository != null) {
+					return;
+				}
+
+				_repositoryLocalService.addRepository(
+					null, PrincipalThreadLocal.getUserId(), group.getGroupId(),
+					_portal.getClassNameId(
+						TemporaryFileEntryRepository.class.getName()),
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+					TempFileEntryUtil.class.getName(), StringPool.BLANK,
+					TempFileEntryUtil.class.getName(), new UnicodeProperties(),
+					true, serviceContext);
+			}
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Reference
+	private AttachmentManager _attachmentManager;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private RepositoryLocalService _repositoryLocalService;
+
+}


### PR DESCRIPTION
## Issue Description

When creating a new CMS space and uploading multiple files simultaneously, a concurrency issue occurs in the creation of the default repository for the site. The `PortletFileRepository` service attempts to add a repository more than once under concurrent requests, which can result in duplicated repository creation attempts or exceptions being thrown.

This situation arises because multiple threads may simultaneously detect that no repository exists and then attempt to create one, leading to a race condition.

Steps to Reproduce

1. Create a new CMS space.
2. Upload multiple files at the same time.
3. Observe that the repository creation logic is executed concurrently, potentially producing duplicate repository creation attempts or errors.

## Implemented Fix (`DepotEntryModelListener#onAfterCreate`)

We applied a provisional fix in the `DepotEntryModelListener` during the CMS space creation flow. When a group of type **Depot** is created, and a DepotEntry of type `TYPE_SPACE` is created, and the feature flag `LPD-17564` is enabled, the listener ensures that the default repository and required folders are created.

This approach prevents the absence of the repository during concurrent operations, but it does not fully eliminate the possibility of concurrent attempts since multiple threads may still reach the creation step at the same time.

## Integration Test (`PortletFileRepositoryTest#testAddPortletRepositoryConcurrently`)

To validate the concurrency scenario, we wrote an integration test that explicitly reproduces the race condition:

- A `CountDownLatch` is used to synchronize three threads, forcing them to attempt to add the same repository concurrently.
- Each thread calls `_portletFileRepository.addPortletRepository` using the same `portletId`.
- After execution, the test retrieves all repositories associated with the given `portletId` and asserts that only one repository exists.

This test confirms the expected behavior under concurrent access and validates that the repository creation logic behaves consistently. Importantly, the issue can be reproduced regardless of whether the portletId comes from an object definition or is a randomly generated value.

## Considerations and Limitations

The current fix ensures that repository creation is attempted in a controlled manner within the `DepotEntryModelListener`, but it remains a provisional solution. Since this functionality belongs to the Content team, we do not have full confidence that this is the optimal or long-term approach.

Alternative solutions have been suggested, such as using the `@Retry` annotation to re-attempt the operation after a thread lock occurs. This would allow the system to fetch the entity created by another thread instead of retrying the creation blindly.

Further evaluation by the Content team is recommended to determine whether the implemented fix should be maintained, replaced, or extended with retry semantics or another concurrency-control mechanism.