### PR TITLE
LPD-64952 Unbind object definition with object entries in a multiple parent context

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
@@ -376,18 +376,46 @@ public class ObjectDefinitionTreeUtil {
 	}
 
 	private static void _performActions(
-			long objectDefinitionId,
+			boolean addRootObjectEntryIdRestrictions,
+			ObjectDefinition objectDefinition,
 			ObjectEntryLocalService objectEntryLocalService, boolean parallel,
-			ActionableDynamicQuery.PerformActionMethod<?> performActionMethod)
+			ActionableDynamicQuery.PerformActionMethod<ObjectEntry>
+				performActionMethod)
 		throws PortalException {
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			objectEntryLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> dynamicQuery.add(
-				RestrictionsFactoryUtil.eq(
-					"objectDefinitionId", objectDefinitionId)));
+			dynamicQuery -> {
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.eq(
+						"objectDefinitionId",
+						objectDefinition.getObjectDefinitionId()));
+
+				if (!addRootObjectEntryIdRestrictions) {
+					return;
+				}
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.ne("rootObjectEntryId", 0L));
+
+				if (ArrayUtil.isEmpty(
+						objectDefinition.getRootObjectDefinitionIds())) {
+
+					return;
+				}
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.sqlRestriction(
+						StringBundler.concat(
+							"NOT EXISTS (SELECT 1 from ObjectEntry WHERE ",
+							"objectEntryId = this_.rootObjectEntryId AND ",
+							"objectDefinitionId IN (",
+							StringUtil.merge(
+								objectDefinition.getRootObjectDefinitionIds()),
+							"))")));
+			});
 		actionableDynamicQuery.setParallel(parallel);
 		actionableDynamicQuery.setPerformActionMethod(performActionMethod);
 
@@ -580,9 +608,8 @@ public class ObjectDefinitionTreeUtil {
 						objectRelationship.getObjectFieldId2());
 
 				_performActions(
-					objectDefinition1.getObjectDefinitionId(),
-					objectEntryLocalService, true,
-					(ObjectEntry objectEntry) -> _runSQL(
+					false, objectDefinition1, objectEntryLocalService, true,
+					objectEntry -> _runSQL(
 						objectRelationshipPersistence,
 						StringBundler.concat(
 							"update ObjectEntry set rootObjectEntryId = ",
@@ -599,10 +626,8 @@ public class ObjectDefinitionTreeUtil {
 							objectDefinition2.getClassName());
 
 					_performActions(
-						objectDefinition2.getObjectDefinitionId(),
-						objectEntryLocalService, true,
-						(ObjectEntry objectEntry) -> indexer.reindex(
-							objectEntry));
+						false, objectDefinition2, objectEntryLocalService, true,
+						indexer::reindex);
 				}
 			}
 
@@ -630,17 +655,17 @@ public class ObjectDefinitionTreeUtil {
 		}
 
 		_performActions(
-			objectDefinition.getObjectDefinitionId(), objectEntryLocalService,
-			false,
-			(ObjectEntry objectEntry) -> {
-				if (ArrayUtil.isEmpty(
+			true, objectDefinition, objectEntryLocalService, false,
+			objectEntry -> {
+				if (Arrays.equals(
+						new long[] {objectEntry.getObjectDefinitionId()},
 						objectDefinition.getRootObjectDefinitionIds())) {
 
-					objectEntry.setRootObjectEntryId(0);
-				}
-				else {
 					objectEntry.setRootObjectEntryId(
 						objectEntry.getObjectEntryId());
+				}
+				else {
+					objectEntry.setRootObjectEntryId(0);
 				}
 
 				objectEntryLocalService.updateObjectEntry(objectEntry);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -105,6 +105,51 @@ public class ObjectDefinitionTreeUtilTest {
 	public void setUp() throws Exception {
 		_objectDefinitionTreeFactory = new ObjectDefinitionTreeFactory(
 			_objectDefinitionLocalService, _objectRelationshipLocalService);
+
+		_objectDefinitionA = _addAndPublishCustomObjectDefinition();
+		_objectDefinitionAA = _addAndPublishCustomObjectDefinition();
+
+		_objectRelationshipA_AA =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinitionA,
+				_objectDefinitionAA);
+
+		_objectRelationshipA_AAObjectField2 =
+			_objectFieldLocalService.fetchObjectField(
+				_objectRelationshipA_AA.getObjectFieldId2());
+
+		_objectDefinitionAAA = _addAndPublishCustomObjectDefinition();
+
+		_objectRelationshipAA_AAA =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinitionAA,
+				_objectDefinitionAAA);
+
+		_objectRelationshipAA_AAAObjectField2 =
+			_objectFieldLocalService.fetchObjectField(
+				_objectRelationshipAA_AAA.getObjectFieldId2());
+
+		_objectDefinitionAAAA = _addAndPublishCustomObjectDefinition();
+
+		_objectRelationshipAAA_AAAA =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinitionAAA,
+				_objectDefinitionAAAA);
+
+		_objectRelationshipAAA_AAAAObjectField2 =
+			_objectFieldLocalService.fetchObjectField(
+				_objectRelationshipAAA_AAAA.getObjectFieldId2());
+
+		_objectDefinitionB = _addAndPublishCustomObjectDefinition();
+
+		_objectRelationshipB_AA =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinitionB,
+				_objectDefinitionAA);
+
+		_objectRelationshipB_AAObjectField2 =
+			_objectFieldLocalService.fetchObjectField(
+				_objectRelationshipB_AA.getObjectFieldId2());
 	}
 
 	@After
@@ -1172,11 +1217,387 @@ public class ObjectDefinitionTreeUtilTest {
 	public void testUnbindObjectDefinitionsWithObjectEntries()
 		throws Exception {
 
-		_testUnbindObjectDefinitionsWithObjectEntries();
-		_testUnbindObjectDefinitionsWithObjectEntriesWithDescendantAndParentNodes();
-		_testUnbindObjectDefinitionsWithObjectEntriesWithDescendantNode();
-		_testUnbindObjectDefinitionsWithObjectEntriesWithParentNode();
-		_testUnbindObjectDefinitionsWithObjectEntriesWithParentNodes();
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService, List.of(_objectRelationshipA_AA));
+
+		ObjectEntry objectEntryA1 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			_objectDefinitionAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipA_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, 0L
+			).put(
+				objectEntryA2, 0L
+			).put(
+				objectEntryAA1, 0L
+			).put(
+				objectEntryAA2, 0L
+			).put(
+				objectEntryAA3, 0L
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithObjectEntriesWithDescendantAndParentNodes()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(
+				_objectRelationshipA_AA, _objectRelationshipAA_AAA,
+				_objectRelationshipB_AA));
+
+		ObjectEntry objectEntryA = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryB = _addObjectEntry(
+			_objectDefinitionB, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipB_AAObjectField2.getName(),
+				objectEntryB.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA2 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			_objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA3 = _addObjectEntry(
+			_objectDefinitionAAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryB.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryB.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).put(
+				objectEntryB, objectEntryB.getObjectEntryId()
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipB_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, 0L
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAAA2, 0L
+			).put(
+				objectEntryAAA3, 0L
+			).put(
+				objectEntryB, 0L
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithObjectEntriesWithDescendantNode()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(_objectRelationshipA_AA, _objectRelationshipAA_AAA));
+
+		ObjectEntry objectEntryA1 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			_objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA2 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA3 = _addObjectEntry(
+			_objectDefinitionAAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipA_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, 0L
+			).put(
+				objectEntryA2, 0L
+			).put(
+				objectEntryAA1, objectEntryAA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryAA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryAA1.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryAA2.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithObjectEntriesWithParentNode()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(_objectRelationshipA_AA, _objectRelationshipAA_AAA));
+
+		ObjectEntry objectEntryA1 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			_objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA2 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA3 = _addObjectEntry(
+			_objectDefinitionAAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipAA_AAA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, 0L
+			).put(
+				objectEntryAAA2, 0L
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithObjectEntriesWithParentNodes()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(_objectRelationshipA_AA, _objectRelationshipB_AA));
+
+		ObjectEntry objectEntryA = _addObjectEntry(
+			_objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipA_AAObjectField2.getName(),
+				objectEntryA.getObjectEntryId()));
+
+		ObjectEntry objectEntryB = _addObjectEntry(
+			_objectDefinitionB, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			_objectDefinitionAA,
+			Map.of(
+				_objectRelationshipB_AAObjectField2.getName(),
+				objectEntryB.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			_objectDefinitionAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryB.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryB, objectEntryB.getObjectEntryId()
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipB_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, 0L
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryB, 0L
+			).build());
 	}
 
 	@Test
@@ -2322,478 +2743,6 @@ public class ObjectDefinitionTreeUtilTest {
 		Assert.assertFalse(objectAction.isActive());
 	}
 
-	private void _testUnbindObjectDefinitionsWithObjectEntries()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectEntry objectEntryA1 = _addObjectEntry(
-			objectDefinitionA, Map.of());
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectRelationshipA_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA1 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(objectField.getName(), objectEntryA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryA2 = _addObjectEntry(
-			objectDefinitionA, Map.of());
-
-		ObjectEntry objectEntryAA2 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(objectField.getName(), objectEntryA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAA3 = _addObjectEntry(
-			objectDefinitionAA, Map.of());
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipA_AA, _objectRelationshipLocalService);
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA1, 0L
-			).put(
-				objectEntryA2, 0L
-			).put(
-				objectEntryAA1, 0L
-			).put(
-				objectEntryAA2, 0L
-			).put(
-				objectEntryAA3, 0L
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithObjectEntriesWithDescendantAndParentNodes()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionB =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipB_AA = TreeTestUtil.bind(
-			objectDefinitionB.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectEntry objectEntryA = _addObjectEntry(objectDefinitionA, Map.of());
-
-		ObjectField objectRelationshipA_AAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipA_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA1 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipA_AAObjectField.getName(),
-				objectEntryA.getObjectEntryId()));
-
-		ObjectField objectRelationshipAA_AAAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipAA_AAA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			objectDefinitionAAA,
-			Map.of(
-				objectRelationshipAA_AAAObjectField.getName(),
-				objectEntryAA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryB = _addObjectEntry(objectDefinitionB, Map.of());
-
-		ObjectField objectRelationshipB_AAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipB_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA2 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipB_AAObjectField.getName(),
-				objectEntryB.getObjectEntryId()));
-
-		ObjectEntry objectEntryAAA2 = _addObjectEntry(
-			objectDefinitionAAA,
-			Map.of(
-				objectRelationshipAA_AAAObjectField.getName(),
-				objectEntryAA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAA3 = _addObjectEntry(
-			objectDefinitionAA, Map.of());
-
-		ObjectEntry objectEntryAAA3 = _addObjectEntry(
-			objectDefinitionAAA, Map.of());
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryB.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryAAA1, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAAA2, objectEntryB.getObjectEntryId()
-			).put(
-				objectEntryAAA3, 0L
-			).put(
-				objectEntryB, objectEntryB.getObjectEntryId()
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipB_AA, _objectRelationshipLocalService);
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA2, 0L
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryAAA1, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAAA2, 0L
-			).put(
-				objectEntryAAA3, 0L
-			).put(
-				objectEntryB, 0L
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithObjectEntriesWithDescendantNode()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectEntry objectEntryA1 = _addObjectEntry(
-			objectDefinitionA, Map.of());
-
-		ObjectField objectRelationshipA_AAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipA_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA1 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipA_AAObjectField.getName(),
-				objectEntryA1.getObjectEntryId()));
-
-		ObjectField objectRelationshipAA_AAAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipAA_AAA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			objectDefinitionAAA,
-			Map.of(
-				objectRelationshipAA_AAAObjectField.getName(),
-				objectEntryAA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryA2 = _addObjectEntry(
-			objectDefinitionA, Map.of());
-
-		ObjectEntry objectEntryAA2 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipA_AAObjectField.getName(),
-				objectEntryA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAA3 = _addObjectEntry(
-			objectDefinitionAA, Map.of());
-
-		ObjectEntry objectEntryAAA2 = _addObjectEntry(
-			objectDefinitionAAA,
-			Map.of(
-				objectRelationshipAA_AAAObjectField.getName(),
-				objectEntryAA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAAA3 = _addObjectEntry(
-			objectDefinitionAAA, Map.of());
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryAAA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryAAA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAAA3, 0L
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipA_AA, _objectRelationshipLocalService);
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA1, 0L
-			).put(
-				objectEntryA2, 0L
-			).put(
-				objectEntryAA1, objectEntryAA1.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryAA2.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryAAA1, objectEntryAA1.getObjectEntryId()
-			).put(
-				objectEntryAAA2, objectEntryAA2.getObjectEntryId()
-			).put(
-				objectEntryAAA3, 0L
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithObjectEntriesWithParentNode()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectEntry objectEntryA1 = _addObjectEntry(
-			objectDefinitionA, Map.of());
-
-		ObjectField objectRelationshipA_AAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipA_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA1 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipA_AAObjectField.getName(),
-				objectEntryA1.getObjectEntryId()));
-
-		ObjectField objectRelationshipAA_AAAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipAA_AAA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			objectDefinitionAAA,
-			Map.of(
-				objectRelationshipAA_AAAObjectField.getName(),
-				objectEntryAA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryA2 = _addObjectEntry(
-			objectDefinitionA, Map.of());
-
-		ObjectEntry objectEntryAA2 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipA_AAObjectField.getName(),
-				objectEntryA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAA3 = _addObjectEntry(
-			objectDefinitionAA, Map.of());
-
-		ObjectEntry objectEntryAAA2 = _addObjectEntry(
-			objectDefinitionAAA,
-			Map.of(
-				objectRelationshipAA_AAAObjectField.getName(),
-				objectEntryAA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAAA3 = _addObjectEntry(
-			objectDefinitionAAA, Map.of());
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryAAA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryAAA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAAA3, 0L
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipAA_AAA, _objectRelationshipLocalService);
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA1.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryA2.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryAAA1, 0L
-			).put(
-				objectEntryAAA2, 0L
-			).put(
-				objectEntryAAA3, 0L
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithObjectEntriesWithParentNodes()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionB =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipB_AA = TreeTestUtil.bind(
-			objectDefinitionB.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectEntry objectEntryA = _addObjectEntry(objectDefinitionA, Map.of());
-
-		ObjectField objectRelationshipA_AAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipA_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA1 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipA_AAObjectField.getName(),
-				objectEntryA.getObjectEntryId()));
-
-		ObjectEntry objectEntryB = _addObjectEntry(objectDefinitionB, Map.of());
-
-		ObjectField objectRelationshipB_AAObjectField =
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationshipB_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA2 = _addObjectEntry(
-			objectDefinitionAA,
-			Map.of(
-				objectRelationshipB_AAObjectField.getName(),
-				objectEntryB.getObjectEntryId()));
-
-		ObjectEntry objectEntryAA3 = _addObjectEntry(
-			objectDefinitionAA, Map.of());
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA2, objectEntryB.getObjectEntryId()
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryB, objectEntryB.getObjectEntryId()
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipB_AA, _objectRelationshipLocalService);
-
-		_assertRootObjectEntryIds(
-			LinkedHashMapBuilder.put(
-				objectEntryA, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA1, objectEntryA.getObjectEntryId()
-			).put(
-				objectEntryAA2, 0L
-			).put(
-				objectEntryAA3, 0L
-			).put(
-				objectEntryB, 0L
-			).build());
-	}
-
 	private void _testUnbindObjectDefinitionsWithParentNodes()
 		throws Exception {
 
@@ -2942,6 +2891,12 @@ public class ObjectDefinitionTreeUtilTest {
 	@Inject
 	private ObjectActionLocalService _objectActionLocalService;
 
+	private ObjectDefinition _objectDefinitionA;
+	private ObjectDefinition _objectDefinitionAA;
+	private ObjectDefinition _objectDefinitionAAA;
+	private ObjectDefinition _objectDefinitionAAAA;
+	private ObjectDefinition _objectDefinitionB;
+
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
@@ -2952,6 +2907,15 @@ public class ObjectDefinitionTreeUtilTest {
 
 	@Inject
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	private ObjectRelationship _objectRelationshipA_AA;
+	private ObjectField _objectRelationshipA_AAObjectField2;
+	private ObjectRelationship _objectRelationshipAA_AAA;
+	private ObjectField _objectRelationshipAA_AAAObjectField2;
+	private ObjectRelationship _objectRelationshipAAA_AAAA;
+	private ObjectField _objectRelationshipAAA_AAAAObjectField2;
+	private ObjectRelationship _objectRelationshipB_AA;
+	private ObjectField _objectRelationshipB_AAObjectField2;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -55,7 +55,7 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -124,9 +124,10 @@ public class ObjectDefinitionTreeUtilTest {
 		ObjectDefinition objectDefinitionAAA =
 			_addAndPublishCustomObjectDefinition("AAA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId());
+			objectDefinitionAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		_testBindObjectDefinitions(
 			objectDefinitionAAA,
@@ -261,17 +262,19 @@ public class ObjectDefinitionTreeUtilTest {
 		objectDefinitionAA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
 			"AA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId());
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		objectDefinitionAAA = _addAndPublishCustomObjectDefinition("AAA");
 		ObjectDefinition objectDefinitionAAAA =
 			_addAndPublishCustomObjectDefinition("AAAA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionAAA.getObjectDefinitionId(),
-			objectDefinitionAAAA.getObjectDefinitionId());
+			objectDefinitionAAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		_testBindObjectDefinitions(
 			objectDefinitionAA, objectDefinitionAAA,
@@ -313,9 +316,10 @@ public class ObjectDefinitionTreeUtilTest {
 		objectDefinitionAA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
 			"AA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId());
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		_testBindObjectDefinitions(
 			objectDefinitionAA, _addAndPublishCustomObjectDefinition("AAA"),
@@ -420,18 +424,20 @@ public class ObjectDefinitionTreeUtilTest {
 		objectDefinitionAA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
 			"AA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId());
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		objectDefinitionAAA =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition("AAA");
 		ObjectDefinition objectDefinitionAAAA =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition("AAAA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionAAA.getObjectDefinitionId(),
-			objectDefinitionAAAA.getObjectDefinitionId());
+			objectDefinitionAAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		_testBindObjectDefinitions(
 			objectDefinitionAA, objectDefinitionAAA,
@@ -568,9 +574,10 @@ public class ObjectDefinitionTreeUtilTest {
 			ObjectRelationshipEdgeException.class,
 			"The object relationship cannot be an edge in the root context " +
 				"because it would exceed the tree's maximum height",
-			() -> _bindObjectDefinitions(
+			() -> TreeTestUtil.bind(
 				objectDefinitionAAAAA.getObjectDefinitionId(),
-				objectDefinitionAAAAAA.getObjectDefinitionId()));
+				objectDefinitionAAAAAA.getObjectDefinitionId(),
+				_objectRelationshipLocalService));
 
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,
@@ -616,9 +623,10 @@ public class ObjectDefinitionTreeUtilTest {
 			ObjectRelationshipEdgeException.class,
 			"The object relationship cannot be an edge in the root context " +
 				"because it would exceed the tree's maximum height",
-			() -> _bindObjectDefinitions(
+			() -> TreeTestUtil.bind(
 				objectDefinitionAAA.getObjectDefinitionId(),
-				objectDefinitionAAAA.getObjectDefinitionId()));
+				objectDefinitionAAAA.getObjectDefinitionId(),
+				_objectRelationshipLocalService));
 
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,
@@ -935,9 +943,10 @@ public class ObjectDefinitionTreeUtilTest {
 		ObjectDefinition objectDefinitionAAA =
 			_addAndPublishCustomObjectDefinition("AAA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId());
+			objectDefinitionAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		ObjectDefinition objectDefinitionAAAA =
 			_addAndPublishCustomObjectDefinition("AAAA");
@@ -997,16 +1006,18 @@ public class ObjectDefinitionTreeUtilTest {
 			_addAndPublishCustomObjectDefinition("A");
 		objectDefinitionAA = _addAndPublishCustomObjectDefinition("AA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId());
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		objectDefinitionAAA = _addAndPublishCustomObjectDefinition("AAA");
 		objectDefinitionAAAA = _addAndPublishCustomObjectDefinition("AAAA");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionAAA.getObjectDefinitionId(),
-			objectDefinitionAAAA.getObjectDefinitionId());
+			objectDefinitionAAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		_testBindObjectDefinitions(
 			objectDefinitionAA, objectDefinitionAAA,
@@ -1080,9 +1091,10 @@ public class ObjectDefinitionTreeUtilTest {
 						"scope",
 				objectDefinitionB.getShortName(),
 				siteObjectDefinition.getShortName()),
-			() -> _bindObjectDefinitions(
+			() -> TreeTestUtil.bind(
 				objectDefinitionB.getObjectDefinitionId(),
-				siteObjectDefinition.getObjectDefinitionId()));
+				siteObjectDefinition.getObjectDefinitionId(),
+				_objectRelationshipLocalService));
 
 		// Unable to bind the object definitions because the object relationship
 		// must not create a circular reference in a root context
@@ -1090,26 +1102,29 @@ public class ObjectDefinitionTreeUtilTest {
 		ObjectDefinition objectDefinitionBBB =
 			_addAndPublishCustomObjectDefinition("BBB");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionBB.getObjectDefinitionId(),
-			objectDefinitionBBB.getObjectDefinitionId());
+			objectDefinitionBBB.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		AssertUtils.assertFailure(
 			ObjectRelationshipEdgeException.class,
 			"The object relationship must not create a circular reference in " +
 				"a root context",
-			() -> _bindObjectDefinitions(
+			() -> TreeTestUtil.bind(
 				objectDefinitionBBB.getObjectDefinitionId(),
-				objectDefinitionB.getObjectDefinitionId()));
+				objectDefinitionB.getObjectDefinitionId(),
+				_objectRelationshipLocalService));
 
 		ObjectDefinition objectDefinitionC =
 			_addAndPublishCustomObjectDefinition("C");
 		ObjectDefinition objectDefinitionCC =
 			_addAndPublishCustomObjectDefinition("CC");
 
-		_bindObjectDefinitions(
+		TreeTestUtil.bind(
 			objectDefinitionC.getObjectDefinitionId(),
-			objectDefinitionCC.getObjectDefinitionId());
+			objectDefinitionCC.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService,
@@ -1157,100 +1172,11 @@ public class ObjectDefinitionTreeUtilTest {
 	public void testUnbindObjectDefinitionsWithObjectEntries()
 		throws Exception {
 
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectEntry objectEntryA = _addObjectEntry(
-			objectDefinitionA, Collections.emptyMap());
-
-		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
-
-		_resourcePermissionLocalService.setResourcePermissions(
-			TestPropsValues.getCompanyId(), objectDefinitionA.getClassName(),
-			ResourceConstants.SCOPE_INDIVIDUAL,
-			String.valueOf(objectEntryA.getObjectEntryId()), role.getRoleId(),
-			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW});
-
-		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-			objectRelationshipA_AA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAA1 = _addObjectEntry(
-			objectDefinitionAA,
-			HashMapBuilder.<String, Serializable>put(
-				objectField.getName(), objectEntryA.getObjectEntryId()
-			).build());
-		ObjectEntry objectEntryAA2 = _addObjectEntry(
-			objectDefinitionAA,
-			HashMapBuilder.<String, Serializable>put(
-				objectField.getName(), objectEntryA.getObjectEntryId()
-			).build());
-
-		objectField = _objectFieldLocalService.fetchObjectField(
-			objectRelationshipAA_AAA.getObjectFieldId2());
-
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			objectDefinitionAAA,
-			HashMapBuilder.<String, Serializable>put(
-				objectField.getName(), objectEntryAA1.getObjectEntryId()
-			).build());
-		ObjectEntry objectEntryAAA2 = _addObjectEntry(
-			objectDefinitionAAA,
-			HashMapBuilder.<String, Serializable>put(
-				objectField.getName(), objectEntryAA2.getObjectEntryId()
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipA_AA, _objectRelationshipLocalService);
-
-		_entityCache.clearCache();
-
-		_assertRootObjectEntryId(0, objectEntryA.getObjectEntryId());
-		_assertRootObjectEntryId(
-			objectEntryAA1.getObjectEntryId(),
-			objectEntryAA1.getObjectEntryId());
-		_assertRootObjectEntryId(
-			objectEntryAA1.getObjectEntryId(),
-			objectEntryAAA1.getObjectEntryId());
-		_assertRootObjectEntryId(
-			objectEntryAA2.getObjectEntryId(),
-			objectEntryAA2.getObjectEntryId());
-		_assertRootObjectEntryId(
-			objectEntryAA2.getObjectEntryId(),
-			objectEntryAAA2.getObjectEntryId());
-
-		_assertHasResourcePermission(true, objectEntryA, role);
-		_assertHasResourcePermission(false, objectEntryAA1, role);
-		_assertHasResourcePermission(false, objectEntryAA2, role);
-		_assertHasResourcePermission(false, objectEntryAAA1, role);
-		_assertHasResourcePermission(false, objectEntryAAA2, role);
-
-		TreeTestUtil.unbind(
-			objectRelationshipAA_AAA, _objectRelationshipLocalService);
-
-		_entityCache.clearCache();
-
-		_assertRootObjectEntryId(0, objectEntryAA1.getObjectEntryId());
-		_assertRootObjectEntryId(0, objectEntryAA2.getObjectEntryId());
-		_assertRootObjectEntryId(0, objectEntryAAA1.getObjectEntryId());
-		_assertRootObjectEntryId(0, objectEntryAAA2.getObjectEntryId());
-
-		_assertHasResourcePermission(false, objectEntryAAA1, role);
-		_assertHasResourcePermission(false, objectEntryAAA2, role);
+		_testUnbindObjectDefinitionsWithObjectEntries();
+		_testUnbindObjectDefinitionsWithObjectEntriesWithDescendantAndParentNodes();
+		_testUnbindObjectDefinitionsWithObjectEntriesWithDescendantNode();
+		_testUnbindObjectDefinitionsWithObjectEntriesWithParentNode();
+		_testUnbindObjectDefinitionsWithObjectEntriesWithParentNodes();
 	}
 
 	@Test
@@ -1982,31 +1908,6 @@ public class ObjectDefinitionTreeUtilTest {
 			null, values, ServiceContextTestUtil.getServiceContext());
 	}
 
-	private void _assertHasResourcePermission(
-			boolean expectedHasResourcePermission, ObjectEntry objectEntry,
-			Role role)
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				objectEntry.getObjectDefinitionId());
-
-		Assert.assertEquals(
-			expectedHasResourcePermission,
-			_resourcePermissionLocalService.hasResourcePermission(
-				TestPropsValues.getCompanyId(), objectDefinition.getClassName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntry.getObjectEntryId()),
-				role.getRoleId(), ActionKeys.UPDATE));
-		Assert.assertEquals(
-			expectedHasResourcePermission,
-			_resourcePermissionLocalService.hasResourcePermission(
-				TestPropsValues.getCompanyId(), objectDefinition.getClassName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(objectEntry.getObjectEntryId()),
-				role.getRoleId(), ActionKeys.VIEW));
-	}
-
 	private void _assertRootObjectDefinitionIdIsZero(
 			String objectDefinitionShortName)
 		throws Exception {
@@ -2019,14 +1920,21 @@ public class ObjectDefinitionTreeUtilTest {
 		Assert.assertEquals(0, objectDefinition.getRootObjectDefinitionId());
 	}
 
-	private void _assertRootObjectEntryId(
-		long expectedRootObjectEntryId, long objectEntryId) {
+	private void _assertRootObjectEntryIds(Map<ObjectEntry, Long> expectedMap)
+		throws Exception {
 
-		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
-			objectEntryId);
+		_entityCache.clearCache();
 
-		Assert.assertEquals(
-			expectedRootObjectEntryId, objectEntry.getRootObjectEntryId());
+		for (Map.Entry<ObjectEntry, Long> entry : expectedMap.entrySet()) {
+			ObjectEntry objectEntry = entry.getKey();
+
+			objectEntry = _objectEntryLocalService.getObjectEntry(
+				objectEntry.getObjectEntryId());
+
+			Assert.assertEquals(
+				GetterUtil.getLong(entry.getValue()),
+				objectEntry.getRootObjectEntryId());
+		}
 	}
 
 	private void _assertScreenNavigationCategories(
@@ -2045,43 +1953,6 @@ public class ObjectDefinitionTreeUtilTest {
 		Assert.assertEquals(
 			screenNavigationCategories.toString(), expectedSize,
 			screenNavigationCategories.size());
-	}
-
-	private void _assertWorkflowDefinitionLink(String objectDefinitionName)
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				TestPropsValues.getCompanyId(), objectDefinitionName);
-
-		List<WorkflowDefinitionLink> workflowDefinitionLinks =
-			_workflowDefinitionLinkLocalService.getWorkflowDefinitionLinks(
-				objectDefinition.getCompanyId(),
-				objectDefinition.getClassName());
-
-		Assert.assertEquals(
-			workflowDefinitionLinks.toString(), 1,
-			workflowDefinitionLinks.size());
-
-		WorkflowDefinitionLink workflowDefinitionLink =
-			workflowDefinitionLinks.get(0);
-
-		Assert.assertEquals(
-			"Single Approver",
-			workflowDefinitionLink.getWorkflowDefinitionName());
-	}
-
-	private ObjectRelationship _bindObjectDefinitions(
-			long objectDefinitionId1, long objectDefinitionId2)
-		throws Exception {
-
-		return _objectRelationshipLocalService.addObjectRelationship(
-			StringUtil.randomId(), TestPropsValues.getUserId(),
-			objectDefinitionId1, objectDefinitionId2, 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			StringUtil.randomId(), false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 	}
 
 	private void _completeWorkflowTask(String className, long classPK)
@@ -2125,9 +1996,10 @@ public class ObjectDefinitionTreeUtilTest {
 				biConsumer)
 		throws Exception {
 
-		ObjectRelationship objectRelationship = _bindObjectDefinitions(
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
 			objectDefinition1.getObjectDefinitionId(),
-			objectDefinition2.getObjectDefinitionId());
+			objectDefinition2.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
 
 		Assert.assertTrue(objectRelationship.isEdge());
 		Assert.assertEquals(
@@ -2450,6 +2322,478 @@ public class ObjectDefinitionTreeUtilTest {
 		Assert.assertFalse(objectAction.isActive());
 	}
 
+	private void _testUnbindObjectDefinitionsWithObjectEntries()
+		throws Exception {
+
+		ObjectDefinition objectDefinitionA =
+			_addAndPublishCustomObjectDefinition();
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectEntry objectEntryA1 = _addObjectEntry(
+			objectDefinitionA, Map.of());
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationshipA_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(objectField.getName(), objectEntryA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(objectField.getName(), objectEntryA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			objectDefinitionAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).build());
+
+		TreeTestUtil.unbind(
+			objectRelationshipA_AA, _objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, 0L
+			).put(
+				objectEntryA2, 0L
+			).put(
+				objectEntryAA1, 0L
+			).put(
+				objectEntryAA2, 0L
+			).put(
+				objectEntryAA3, 0L
+			).build());
+	}
+
+	private void _testUnbindObjectDefinitionsWithObjectEntriesWithDescendantAndParentNodes()
+		throws Exception {
+
+		ObjectDefinition objectDefinitionA =
+			_addAndPublishCustomObjectDefinition();
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition objectDefinitionAAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
+			objectDefinitionAA.getObjectDefinitionId(),
+			objectDefinitionAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition objectDefinitionB =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipB_AA = TreeTestUtil.bind(
+			objectDefinitionB.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectEntry objectEntryA = _addObjectEntry(objectDefinitionA, Map.of());
+
+		ObjectField objectRelationshipA_AAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipA_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipA_AAObjectField.getName(),
+				objectEntryA.getObjectEntryId()));
+
+		ObjectField objectRelationshipAA_AAAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipAA_AAA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			objectDefinitionAAA,
+			Map.of(
+				objectRelationshipAA_AAAObjectField.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryB = _addObjectEntry(objectDefinitionB, Map.of());
+
+		ObjectField objectRelationshipB_AAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipB_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipB_AAObjectField.getName(),
+				objectEntryB.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA2 = _addObjectEntry(
+			objectDefinitionAAA,
+			Map.of(
+				objectRelationshipAA_AAAObjectField.getName(),
+				objectEntryAA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA3 = _addObjectEntry(
+			objectDefinitionAAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryB.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryB.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).put(
+				objectEntryB, objectEntryB.getObjectEntryId()
+			).build());
+
+		TreeTestUtil.unbind(
+			objectRelationshipB_AA, _objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, 0L
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAAA2, 0L
+			).put(
+				objectEntryAAA3, 0L
+			).put(
+				objectEntryB, 0L
+			).build());
+	}
+
+	private void _testUnbindObjectDefinitionsWithObjectEntriesWithDescendantNode()
+		throws Exception {
+
+		ObjectDefinition objectDefinitionA =
+			_addAndPublishCustomObjectDefinition();
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition objectDefinitionAAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
+			objectDefinitionAA.getObjectDefinitionId(),
+			objectDefinitionAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectEntry objectEntryA1 = _addObjectEntry(
+			objectDefinitionA, Map.of());
+
+		ObjectField objectRelationshipA_AAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipA_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipA_AAObjectField.getName(),
+				objectEntryA1.getObjectEntryId()));
+
+		ObjectField objectRelationshipAA_AAAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipAA_AAA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			objectDefinitionAAA,
+			Map.of(
+				objectRelationshipAA_AAAObjectField.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipA_AAObjectField.getName(),
+				objectEntryA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA2 = _addObjectEntry(
+			objectDefinitionAAA,
+			Map.of(
+				objectRelationshipAA_AAAObjectField.getName(),
+				objectEntryAA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA3 = _addObjectEntry(
+			objectDefinitionAAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+
+		TreeTestUtil.unbind(
+			objectRelationshipA_AA, _objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, 0L
+			).put(
+				objectEntryA2, 0L
+			).put(
+				objectEntryAA1, objectEntryAA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryAA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryAA1.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryAA2.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+	}
+
+	private void _testUnbindObjectDefinitionsWithObjectEntriesWithParentNode()
+		throws Exception {
+
+		ObjectDefinition objectDefinitionA =
+			_addAndPublishCustomObjectDefinition();
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition objectDefinitionAAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
+			objectDefinitionAA.getObjectDefinitionId(),
+			objectDefinitionAAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectEntry objectEntryA1 = _addObjectEntry(
+			objectDefinitionA, Map.of());
+
+		ObjectField objectRelationshipA_AAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipA_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipA_AAObjectField.getName(),
+				objectEntryA1.getObjectEntryId()));
+
+		ObjectField objectRelationshipAA_AAAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipAA_AAA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			objectDefinitionAAA,
+			Map.of(
+				objectRelationshipAA_AAAObjectField.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			objectDefinitionA, Map.of());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipA_AAObjectField.getName(),
+				objectEntryA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA2 = _addObjectEntry(
+			objectDefinitionAAA,
+			Map.of(
+				objectRelationshipAA_AAAObjectField.getName(),
+				objectEntryAA2.getObjectEntryId()));
+
+		ObjectEntry objectEntryAAA3 = _addObjectEntry(
+			objectDefinitionAAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+
+		TreeTestUtil.unbind(
+			objectRelationshipAA_AAA, _objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA1.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryA2.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryAAA1, 0L
+			).put(
+				objectEntryAAA2, 0L
+			).put(
+				objectEntryAAA3, 0L
+			).build());
+	}
+
+	private void _testUnbindObjectDefinitionsWithObjectEntriesWithParentNodes()
+		throws Exception {
+
+		ObjectDefinition objectDefinitionA =
+			_addAndPublishCustomObjectDefinition();
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition objectDefinitionB =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectRelationship objectRelationshipB_AA = TreeTestUtil.bind(
+			objectDefinitionB.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectEntry objectEntryA = _addObjectEntry(objectDefinitionA, Map.of());
+
+		ObjectField objectRelationshipA_AAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipA_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA1 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipA_AAObjectField.getName(),
+				objectEntryA.getObjectEntryId()));
+
+		ObjectEntry objectEntryB = _addObjectEntry(objectDefinitionB, Map.of());
+
+		ObjectField objectRelationshipB_AAObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationshipB_AA.getObjectFieldId2());
+
+		ObjectEntry objectEntryAA2 = _addObjectEntry(
+			objectDefinitionAA,
+			Map.of(
+				objectRelationshipB_AAObjectField.getName(),
+				objectEntryB.getObjectEntryId()));
+
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			objectDefinitionAA, Map.of());
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, objectEntryB.getObjectEntryId()
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryB, objectEntryB.getObjectEntryId()
+			).build());
+
+		TreeTestUtil.unbind(
+			objectRelationshipB_AA, _objectRelationshipLocalService);
+
+		_assertRootObjectEntryIds(
+			LinkedHashMapBuilder.put(
+				objectEntryA, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA1, objectEntryA.getObjectEntryId()
+			).put(
+				objectEntryAA2, 0L
+			).put(
+				objectEntryAA3, 0L
+			).put(
+				objectEntryB, 0L
+			).build());
+	}
+
 	private void _testUnbindObjectDefinitionsWithParentNodes()
 		throws Exception {
 
@@ -2575,7 +2919,21 @@ public class ObjectDefinitionTreeUtilTest {
 			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), 0,
 			objectDefinition.getClassName(), 0, 0, "Single Approver", 1);
 
-		_assertWorkflowDefinitionLink(objectDefinitionName);
+		List<WorkflowDefinitionLink> workflowDefinitionLinks =
+			_workflowDefinitionLinkLocalService.getWorkflowDefinitionLinks(
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName());
+
+		Assert.assertEquals(
+			workflowDefinitionLinks.toString(), 1,
+			workflowDefinitionLinks.size());
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			workflowDefinitionLinks.get(0);
+
+		Assert.assertEquals(
+			"Single Approver",
+			workflowDefinitionLink.getWorkflowDefinitionName());
 	}
 
 	@Inject

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -1404,15 +1404,14 @@ public class ObjectDefinitionTreeUtilTest {
 
 		ObjectEntry objectEntryA1 = _addObjectEntry(
 			_objectDefinitionA, Map.of());
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
 
 		ObjectEntry objectEntryAA1 = _addObjectEntry(
 			_objectDefinitionAA,
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryA2 = _addObjectEntry(
-			_objectDefinitionA, Map.of());
 
 		ObjectEntry objectEntryAA2 = _addObjectEntry(
 			_objectDefinitionAA,
@@ -1474,12 +1473,6 @@ public class ObjectDefinitionTreeUtilTest {
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA.getObjectEntryId()));
 
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			_objectDefinitionAAA,
-			Map.of(
-				_objectRelationshipAA_AAAObjectField2.getName(),
-				objectEntryAA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryB = _addObjectEntry(
 			_objectDefinitionB, Map.of());
 
@@ -1489,14 +1482,20 @@ public class ObjectDefinitionTreeUtilTest {
 				_objectRelationshipB_AAObjectField2.getName(),
 				objectEntryB.getObjectEntryId()));
 
+		ObjectEntry objectEntryAA3 = _addObjectEntry(
+			_objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA1.getObjectEntryId()));
+
 		ObjectEntry objectEntryAAA2 = _addObjectEntry(
 			_objectDefinitionAAA,
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA2.getObjectEntryId()));
-
-		ObjectEntry objectEntryAA3 = _addObjectEntry(
-			_objectDefinitionAA, Map.of());
 
 		ObjectEntry objectEntryAAA3 = _addObjectEntry(
 			_objectDefinitionAAA, Map.of());
@@ -1555,21 +1554,14 @@ public class ObjectDefinitionTreeUtilTest {
 
 		ObjectEntry objectEntryA1 = _addObjectEntry(
 			_objectDefinitionA, Map.of());
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
 
 		ObjectEntry objectEntryAA1 = _addObjectEntry(
 			_objectDefinitionAA,
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			_objectDefinitionAAA,
-			Map.of(
-				_objectRelationshipAA_AAAObjectField2.getName(),
-				objectEntryAA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryA2 = _addObjectEntry(
-			_objectDefinitionA, Map.of());
 
 		ObjectEntry objectEntryAA2 = _addObjectEntry(
 			_objectDefinitionAA,
@@ -1579,6 +1571,12 @@ public class ObjectDefinitionTreeUtilTest {
 
 		ObjectEntry objectEntryAA3 = _addObjectEntry(
 			_objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA1.getObjectEntryId()));
 
 		ObjectEntry objectEntryAAA2 = _addObjectEntry(
 			_objectDefinitionAAA,
@@ -1643,21 +1641,14 @@ public class ObjectDefinitionTreeUtilTest {
 
 		ObjectEntry objectEntryA1 = _addObjectEntry(
 			_objectDefinitionA, Map.of());
+		ObjectEntry objectEntryA2 = _addObjectEntry(
+			_objectDefinitionA, Map.of());
 
 		ObjectEntry objectEntryAA1 = _addObjectEntry(
 			_objectDefinitionAA,
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryAAA1 = _addObjectEntry(
-			_objectDefinitionAAA,
-			Map.of(
-				_objectRelationshipAA_AAAObjectField2.getName(),
-				objectEntryAA1.getObjectEntryId()));
-
-		ObjectEntry objectEntryA2 = _addObjectEntry(
-			_objectDefinitionA, Map.of());
 
 		ObjectEntry objectEntryAA2 = _addObjectEntry(
 			_objectDefinitionAA,
@@ -1667,6 +1658,12 @@ public class ObjectDefinitionTreeUtilTest {
 
 		ObjectEntry objectEntryAA3 = _addObjectEntry(
 			_objectDefinitionAA, Map.of());
+
+		ObjectEntry objectEntryAAA1 = _addObjectEntry(
+			_objectDefinitionAAA,
+			Map.of(
+				_objectRelationshipAA_AAAObjectField2.getName(),
+				objectEntryAA1.getObjectEntryId()));
 
 		ObjectEntry objectEntryAAA2 = _addObjectEntry(
 			_objectDefinitionAAA,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -118,6 +118,13 @@ public class ObjectDefinitionTreeUtilTest {
 			_objectFieldLocalService.fetchObjectField(
 				_objectRelationshipA_AA.getObjectFieldId2());
 
+		_objectDefinitionAB = _addAndPublishCustomObjectDefinition();
+
+		_objectRelationshipA_AB =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinitionA,
+				_objectDefinitionAB);
+
 		_objectDefinitionAAA = _addAndPublishCustomObjectDefinition();
 
 		_objectRelationshipAA_AAA =
@@ -135,10 +142,6 @@ public class ObjectDefinitionTreeUtilTest {
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				_objectRelationshipLocalService, _objectDefinitionAAA,
 				_objectDefinitionAAAA);
-
-		_objectRelationshipAAA_AAAAObjectField2 =
-			_objectFieldLocalService.fetchObjectField(
-				_objectRelationshipAAA_AAAA.getObjectFieldId2());
 
 		_objectDefinitionB = _addAndPublishCustomObjectDefinition();
 
@@ -1182,13 +1185,192 @@ public class ObjectDefinitionTreeUtilTest {
 
 	@Test
 	public void testUnbindObjectDefinitions() throws Exception {
-		_testUnbindObjectDefinitions();
-		_testUnbindObjectDefinitionsWithDescendantNode();
-		_testUnbindObjectDefinitionsWithDescendantNodeAndGrandParentNodes();
-		_testUnbindObjectDefinitionsWithDescendantNodeAndParentNodes();
-		_testUnbindObjectDefinitionsWithGrandParentNodes();
-		_testUnbindObjectDefinitionsWithParentNodes();
-		_testUnbindObjectDefinitionsWithSiblingNode();
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService, List.of(_objectRelationshipA_AA));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[] {_objectDefinitionA}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipA_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[0]
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[0]
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithDescendantNode()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(_objectRelationshipA_AA, _objectRelationshipAA_AAA));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionA}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipA_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[0]
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionAA}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionAA}
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithDescendantNodeAndGrandParentNodes()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(
+				_objectRelationshipA_AA, _objectRelationshipAA_AAA,
+				_objectRelationshipAAA_AAAA, _objectRelationshipB_AA));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionAAAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[] {_objectDefinitionB}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipAA_AAA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionAAA}
+			).put(
+				_objectDefinitionAAAA,
+				new ObjectDefinition[] {_objectDefinitionAAA}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[] {_objectDefinitionB}
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithDescendantNodeAndParentNodes()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(
+				_objectRelationshipA_AA, _objectRelationshipAA_AAA,
+				_objectRelationshipB_AA));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[] {_objectDefinitionB}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipB_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[0]
+			).build());
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithGrandParentNodes()
+		throws Exception {
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(
+				_objectRelationshipA_AA, _objectRelationshipAA_AAA,
+				_objectRelationshipB_AA));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionAAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[] {_objectDefinitionB}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipAA_AAA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionAAA, new ObjectDefinition[0]
+			).put(
+				_objectDefinitionB, new ObjectDefinition[] {_objectDefinitionB}
+			).build());
 	}
 
 	@Test
@@ -1665,6 +1847,37 @@ public class ObjectDefinitionTreeUtilTest {
 	}
 
 	@Test
+	public void testUnbindObjectDefinitionsWithParentNodes() throws Exception {
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(_objectRelationshipA_AA, _objectRelationshipB_AA));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA,
+				new ObjectDefinition[] {_objectDefinitionA, _objectDefinitionB}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[] {_objectDefinitionB}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipB_AA.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionB, new ObjectDefinition[0]
+			).build());
+	}
+
+	@Test
 	public void testUnbindObjectDefinitionsWithResourcePermissions()
 		throws Exception {
 
@@ -1760,6 +1973,36 @@ public class ObjectDefinitionTreeUtilTest {
 				ResourceConstants.SCOPE_GROUP_TEMPLATE,
 				String.valueOf(GroupConstants.DEFAULT_PARENT_GROUP_ID),
 				organizationRole.getRoleId(), objectAction.getName()));
+	}
+
+	@Test
+	public void testUnbindObjectDefinitionsWithSiblingNode() throws Exception {
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			List.of(_objectRelationshipA_AA, _objectRelationshipA_AB));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAB, new ObjectDefinition[] {_objectDefinitionA}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectRelationshipLocalService.getObjectRelationship(
+				_objectRelationshipA_AB.getObjectRelationshipId()),
+			_objectRelationshipLocalService);
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				_objectDefinitionAB, new ObjectDefinition[0]
+			).build());
 	}
 
 	@Test
@@ -2446,266 +2689,6 @@ public class ObjectDefinitionTreeUtilTest {
 			_objectDefinitionLocalService);
 	}
 
-	private void _testUnbindObjectDefinitions() throws Exception {
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionA}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipA_AA, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[0]
-			).put(
-				objectDefinitionAA, new ObjectDefinition[0]
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithDescendantNode()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AA = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAAA, new ObjectDefinition[] {objectDefinitionA}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipA_AA, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[0]
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionAA}
-			).put(
-				objectDefinitionAAA, new ObjectDefinition[] {objectDefinitionAA}
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithDescendantNodeAndGrandParentNodes()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionAAA.getObjectDefinitionId(),
-			objectDefinitionAAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionB =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionB.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionAAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionAAAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionB, new ObjectDefinition[] {objectDefinitionB}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipAA_AAA, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionAAA,
-				new ObjectDefinition[] {objectDefinitionAAA}
-			).put(
-				objectDefinitionAAAA,
-				new ObjectDefinition[] {objectDefinitionAAA}
-			).put(
-				objectDefinitionB, new ObjectDefinition[] {objectDefinitionB}
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithDescendantNodeAndParentNodes()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionB =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipB_AA = TreeTestUtil.bind(
-			objectDefinitionB.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionAAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionB, new ObjectDefinition[] {objectDefinitionB}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipB_AA, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAAA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionB, new ObjectDefinition[0]
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithGrandParentNodes()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAAA =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipAA_AAA = TreeTestUtil.bind(
-			objectDefinitionAA.getObjectDefinitionId(),
-			objectDefinitionAAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionB =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionB.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionAAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionB, new ObjectDefinition[] {objectDefinitionB}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipAA_AAA, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionAAA, new ObjectDefinition[0]
-			).put(
-				objectDefinitionB, new ObjectDefinition[] {objectDefinitionB}
-			).build());
-	}
-
 	private void _testUnbindObjectDefinitionsWithObjectAction(
 			String objectDefinitionShortName,
 			String rootObjectDefinitionShortName, Tree tree)
@@ -2741,93 +2724,6 @@ public class ObjectDefinitionTreeUtilTest {
 			objectAction.getObjectActionTriggerKey(),
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE);
 		Assert.assertFalse(objectAction.isActive());
-	}
-
-	private void _testUnbindObjectDefinitionsWithParentNodes()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionB =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipB_AA = TreeTestUtil.bind(
-			objectDefinitionB.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA,
-				new ObjectDefinition[] {objectDefinitionA, objectDefinitionB}
-			).put(
-				objectDefinitionB, new ObjectDefinition[] {objectDefinitionB}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipB_AA, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionB, new ObjectDefinition[0]
-			).build());
-	}
-
-	private void _testUnbindObjectDefinitionsWithSiblingNode()
-		throws Exception {
-
-		ObjectDefinition objectDefinitionA =
-			_addAndPublishCustomObjectDefinition();
-		ObjectDefinition objectDefinitionAA =
-			_addAndPublishCustomObjectDefinition();
-
-		TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAA.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		ObjectDefinition objectDefinitionAB =
-			_addAndPublishCustomObjectDefinition();
-
-		ObjectRelationship objectRelationshipA_AB = TreeTestUtil.bind(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionAB.getObjectDefinitionId(),
-			_objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAB, new ObjectDefinition[] {objectDefinitionA}
-			).build());
-
-		TreeTestUtil.unbind(
-			objectRelationshipA_AB, _objectRelationshipLocalService);
-
-		TreeTestUtil.assertRootObjectDefinitionIds(
-			LinkedHashMapBuilder.put(
-				objectDefinitionA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAA, new ObjectDefinition[] {objectDefinitionA}
-			).put(
-				objectDefinitionAB, new ObjectDefinition[0]
-			).build());
 	}
 
 	private void _unbindObjectDefinitions(
@@ -2895,6 +2791,7 @@ public class ObjectDefinitionTreeUtilTest {
 	private ObjectDefinition _objectDefinitionAA;
 	private ObjectDefinition _objectDefinitionAAA;
 	private ObjectDefinition _objectDefinitionAAAA;
+	private ObjectDefinition _objectDefinitionAB;
 	private ObjectDefinition _objectDefinitionB;
 
 	@Inject
@@ -2910,10 +2807,10 @@ public class ObjectDefinitionTreeUtilTest {
 
 	private ObjectRelationship _objectRelationshipA_AA;
 	private ObjectField _objectRelationshipA_AAObjectField2;
+	private ObjectRelationship _objectRelationshipA_AB;
 	private ObjectRelationship _objectRelationshipAA_AAA;
 	private ObjectField _objectRelationshipAA_AAAObjectField2;
 	private ObjectRelationship _objectRelationshipAAA_AAAA;
-	private ObjectField _objectRelationshipAAA_AAAAObjectField2;
 	private ObjectRelationship _objectRelationshipB_AA;
 	private ObjectField _objectRelationshipB_AAObjectField2;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -1412,13 +1412,11 @@ public class ObjectDefinitionTreeUtilTest {
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryAA2 = _addObjectEntry(
 			_objectDefinitionAA,
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA2.getObjectEntryId()));
-
 		ObjectEntry objectEntryAA3 = _addObjectEntry(
 			_objectDefinitionAA, Map.of());
 
@@ -1490,13 +1488,11 @@ public class ObjectDefinitionTreeUtilTest {
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryAAA2 = _addObjectEntry(
 			_objectDefinitionAAA,
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA2.getObjectEntryId()));
-
 		ObjectEntry objectEntryAAA3 = _addObjectEntry(
 			_objectDefinitionAAA, Map.of());
 
@@ -1562,13 +1558,11 @@ public class ObjectDefinitionTreeUtilTest {
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryAA2 = _addObjectEntry(
 			_objectDefinitionAA,
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA2.getObjectEntryId()));
-
 		ObjectEntry objectEntryAA3 = _addObjectEntry(
 			_objectDefinitionAA, Map.of());
 
@@ -1577,13 +1571,11 @@ public class ObjectDefinitionTreeUtilTest {
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryAAA2 = _addObjectEntry(
 			_objectDefinitionAAA,
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA2.getObjectEntryId()));
-
 		ObjectEntry objectEntryAAA3 = _addObjectEntry(
 			_objectDefinitionAAA, Map.of());
 
@@ -1649,13 +1641,11 @@ public class ObjectDefinitionTreeUtilTest {
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryAA2 = _addObjectEntry(
 			_objectDefinitionAA,
 			Map.of(
 				_objectRelationshipA_AAObjectField2.getName(),
 				objectEntryA2.getObjectEntryId()));
-
 		ObjectEntry objectEntryAA3 = _addObjectEntry(
 			_objectDefinitionAA, Map.of());
 
@@ -1664,13 +1654,11 @@ public class ObjectDefinitionTreeUtilTest {
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA1.getObjectEntryId()));
-
 		ObjectEntry objectEntryAAA2 = _addObjectEntry(
 			_objectDefinitionAAA,
 			Map.of(
 				_objectRelationshipAA_AAAObjectField2.getName(),
 				objectEntryAA2.getObjectEntryId()));
-
 		ObjectEntry objectEntryAAA3 = _addObjectEntry(
 			_objectDefinitionAAA, Map.of());
 


### PR DESCRIPTION
Related: [LPD-64952](https://liferay.atlassian.net/browse/LPD-64952)

Start reviewing from: https://github.com/liferay-bpm/liferay-portal/pull/5123/commits/4e52b693e4330fbe7ce0f5a2588d7495f8e97a0b

[LPD-64952]: https://liferay.atlassian.net/browse/LPD-64952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ