### PR TITLE
LPD-65367 Close toast when redirect to Recycle Bin

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/displayUndoDeleteSuccessToast.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/utils/displayUndoDeleteSuccessToast.ts
@@ -59,6 +59,18 @@ export default function displayUndoDeleteSuccessToast(
 
 			closeToast();
 		}
+
+		if (
+			target instanceof HTMLElement &&
+			target
+				.closest('a')
+				?.classList.contains(recycleBinToastInfo.className)
+		) {
+
+			// @ts-ignore
+
+			closeToast();
+		}
 	};
 
 	openToast(openToastSuccessProps);

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -334,6 +334,10 @@ test(
 				page,
 				`Success:${contentName} has been permanently deleted.`
 			);
+
+			await expect(
+				page.getByText(`Success:${contentName} was moved to the`)
+			).toBeHidden();
 		});
 	}
 );


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-65367

the PR removing `@ts-ignore` will be a follow-up since this is a blocker

previous PR: https://github.com/liferay-bpm/liferay-portal/pull/5112

cc: @bryceosterhaus