### PR TITLE
LPD-57578 Fix unit test error and make variations on the test data

### DIFF
--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/UserNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/UserNotificationTypeTest.java
@@ -363,8 +363,6 @@ public class UserNotificationTypeTest extends BaseNotificationTypeTest {
 
 		_userGroupLocalService.addUserUserGroup(
 			user1.getUserId(), userGroup1.getUserGroupId());
-		_userGroupLocalService.addUserUserGroup(
-			user2.getUserId(), userGroup1.getUserGroupId());
 
 		UserGroup userGroup2 = UserGroupTestUtil.addUserGroup();
 


### PR DESCRIPTION
The current test code gives the following error when being executed. This is because the `userGroup1` includes both `user1` and `user2`, but the `finally` block deletes `userGroup1` without removing `user2` from it. In addition, the current `userGroup1` and `userGroup2` do not have any differences. This commit prevents adding `user2` to `userGroup1`, so that it fixes the test error and also adds variations to the test data.

```
com.liferay.notification.internal.type.test.UserNotificationTypeTest > testSendNotificationRecipientTypeUserGroup FAILED
    com.liferay.portal.kernel.exception.RequiredUserGroupException
    	at com.liferay.portal.service.impl.UserGroupLocalServiceImpl.deleteUserGroup(UserGroupLocalServiceImpl.java:430)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    	at com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:41)
    	at com.liferay.portal.spring.transaction.TransactionInterceptor.invoke(TransactionInterceptor.java:60)
    	at com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:48)
    	at com.liferay.portal.kernel.aop.ChainableMethodAdvice.invoke(ChainableMethodAdvice.java:55)
    	at com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:48)
    	at com.liferay.portal.kernel.aop.ChainableMethodAdvice.invoke(ChainableMethodAdvice.java:55)
    	at com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:48)
    	at com.liferay.portal.spring.aop.AopInvocationHandler.invoke(AopInvocationHandler.java:40)
    	at jdk.proxy3/jdk.proxy3.$Proxy115.deleteUserGroup(Unknown Source)
    	at com.liferay.notification.internal.type.test.UserNotificationTypeTest.testSendNotificationRecipientTypeUserGroup(UserNotificationTypeTest.java:400)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    	at com.liferay.arquillian.extension.junit.bridge.server.TestExecutorRunnable$3.evaluate(TestExecutorRunnable.java:344)
    	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$2.evaluate(AbstractTestRule.java:90)
    	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    	at com.liferay.arquillian.extension.junit.bridge.server.TestExecutorRunnable$1.evaluate(TestExecutorRunnable.java:228)
    	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at com.liferay.portal.kernel.test.rule.AbstractTestRule$1.evaluate(AbstractTestRule.java:50)
    	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    	at com.liferay.arquillian.extension.junit.bridge.server.TestExecutorRunnable._execute(TestExecutorRunnable.java:307)
    	at com.liferay.arquillian.extension.junit.bridge.server.TestExecutorRunnable.run(TestExecutorRunnable.java:86)
    	at java.base/java.lang.Thread.run(Thread.java:1583)

```