### PR TITLE
LPD-66020 Display "this field is required" error message in page context language

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -172,6 +172,10 @@ const doEvaluate = debounce((fieldName, evaluatorContext, callback) => {
 			}),
 			trigger: fieldName,
 		}),
+		headers: {
+			'Accept': 'application/json',
+			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+		},
 		signal: controller && controller.signal,
 		url: EVALUATOR_URL,
 	})

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 35.2.2
+Bundle-Version: 35.3.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/HttpServletRequestThreadLocal.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/HttpServletRequestThreadLocal.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.util;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * @author Carolina Barbosa
+ */
+public class HttpServletRequestThreadLocal {
+
+	public static HttpServletRequest getHttpServletRequest() {
+		return _httpServletRequest.get();
+	}
+
+	public static void setHttpServletRequest(
+		HttpServletRequest httpServletRequest) {
+
+		_httpServletRequest.set(httpServletRequest);
+	}
+
+	private static final ThreadLocal<HttpServletRequest> _httpServletRequest =
+		new CentralizedThreadLocal<>(
+			HttpServletRequestThreadLocal.class + "._httpServletRequest",
+			() -> null);
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
@@ -1,1 +1,1 @@
-version 12.1.0
+version 12.2.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
@@ -41,6 +41,7 @@ import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.HttpServletRequestThreadLocal;
 import com.liferay.dynamic.data.mapping.util.NumericDDMFormFieldUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -56,6 +57,8 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -462,6 +465,17 @@ public class DDMFormEvaluatorHelper {
 				builder.build());
 
 		return getFieldPropertyResponse.getValue();
+	}
+
+	private Locale _getLocale() {
+		HttpServletRequest httpServletRequest =
+			HttpServletRequestThreadLocal.getHttpServletRequest();
+
+		if (httpServletRequest != null) {
+			return httpServletRequest.getLocale();
+		}
+
+		return _ddmFormEvaluatorEvaluateRequest.getLocale();
 	}
 
 	private Set<String> _getNonevaluableDDMFormFieldNames() {
@@ -913,8 +927,7 @@ public class DDMFormEvaluatorHelper {
 				}
 
 				String requiredErrorMessage = LanguageUtil.get(
-					_ddmFormEvaluatorEvaluateRequest.getLocale(),
-					"this-field-is-required");
+					_getLocale(), "this-field-is-required");
 
 				DDMFormField ddmFormField = _ddmFormFieldsMap.get(
 					ddmFormEvaluatorFieldContextKey.getName());
@@ -1091,8 +1104,7 @@ public class DDMFormEvaluatorHelper {
 
 			if (Validator.isNull(errorMessage)) {
 				errorMessage = LanguageUtil.get(
-					_ddmFormEvaluatorEvaluateRequest.getLocale(),
-					"this-field-is-invalid");
+					_getLocale(), "this-field-is-invalid");
 			}
 
 			builder.withParameter("errorMessage", errorMessage);
@@ -1127,8 +1139,7 @@ public class DDMFormEvaluatorHelper {
 				_setFieldAsInvalid(
 					ddmFormEvaluatorFieldContextKey,
 					LanguageUtil.get(
-						_ddmFormEvaluatorEvaluateRequest.getLocale(),
-						"input-format-is-not-satisfied"));
+						_getLocale(), "input-format-is-not-satisfied"));
 			}
 		}
 	}
@@ -1155,8 +1166,7 @@ public class DDMFormEvaluatorHelper {
 				_setFieldAsInvalid(
 					ddmFormEvaluatorFieldContextKey,
 					LanguageUtil.get(
-						_ddmFormEvaluatorEvaluateRequest.getLocale(),
-						"the-field-value-is-invalid"));
+						_getLocale(), "the-field-value-is-invalid"));
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/filter/DDMFormContextProviderFilter.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/filter/DDMFormContextProviderFilter.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer.internal.servlet.filter;
+
+import com.liferay.dynamic.data.mapping.util.HttpServletRequestThreadLocal;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.BaseFilter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Carolina Barbosa
+ */
+@Component(
+	property = {
+		"osgi.http.whiteboard.filter.name=com.liferay.dynamic.data.mapping.form.renderer.internal.servlet.filter.DDMFormContextProviderFilter",
+		"osgi.http.whiteboard.filter.pattern=/dynamic-data-mapping-form-context-provider/*"
+	},
+	service = Filter.class
+)
+public class DDMFormContextProviderFilter extends BaseFilter {
+
+	@Override
+	protected Log getLog() {
+		return _log;
+	}
+
+	@Override
+	protected void processFilter(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, FilterChain filterChain)
+		throws Exception {
+
+		HttpServletRequestThreadLocal.setHttpServletRequest(httpServletRequest);
+
+		try {
+			filterChain.doFilter(httpServletRequest, httpServletResponse);
+		}
+		finally {
+			HttpServletRequestThreadLocal.setHttpServletRequest(null);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMFormContextProviderFilter.class);
+
+}

--- a/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
@@ -2275,6 +2275,68 @@ test.describe('Manage object entries through View Object Entries', () => {
 		}
 	);
 
+	test('error message is displayed in the language of the site context', async ({
+		apiHelpers,
+		page,
+		viewObjectEntriesPage,
+	}) => {
+		const objectFields = generateObjectFields({
+			objectFieldBusinessTypes: [
+				{
+					businessType: 'Text',
+					label: {ar_SA: 'النص مطلوب', en_US: 'Text Required'},
+					required: true,
+				},
+			],
+		});
+
+		const objectDefinitionName = 'ObjectDefinition' + getRandomInt();
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.postObjectDefinition({
+				active: true,
+				label: {
+					ar_SA: objectDefinitionName + 'ar_SA',
+					en_US: objectDefinitionName + 'en_US',
+				},
+				name: objectDefinitionName,
+				objectFields,
+				pluralLabel: {
+					en_US: objectDefinitionName + 's',
+				},
+				scope: 'company',
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		siteLanguage = 'ar';
+
+		await viewObjectEntriesPage.goto(
+			objectDefinition.className,
+			siteLanguage
+		);
+
+		await page
+			.getByRole('button', {
+				name: `إضافة ${objectDefinition.label['ar_SA']}`,
+			})
+			.first()
+			.click();
+
+		await page.getByRole('textbox', {name: 'النص مطلوب'}).click();
+
+		await viewObjectEntriesPage.saveObjectEntryButtonArabic.click();
+
+		await expect(page.getByText('هذا الحقل مطلوب.')).toBeVisible();
+	});
+
 	test(
 		'error message is displayed when trying to view a deleted object entry with a user with view-only permissions',
 		{tag: ['@LPD-61276']},


### PR DESCRIPTION
### What is the goal of this [task](https://liferay.atlassian.net/browse/LPD-66020)?

This PR aims to display error messages returned by evaluate in the language of the page context (e.g. `localhost:8080/ar`), without modifying the business rules for localized required fields.

Therefore, we are not pursuing the approach of modifying the languageId property sent in the evaluation request.

### Test case:


https://github.com/user-attachments/assets/0100e392-19ba-4ea5-ad9a-782a089f2d10