### PR TITLE
LPD-65898 Remove testIdAttribute from object-web global configuration

### DIFF
--- a/modules/test/playwright/pages/commerce/commerceCatalogSystemSettingsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceCatalogSystemSettingsPage.ts
@@ -17,9 +17,9 @@ export class CommerceCatalogSystemSettingsPage {
 
 	constructor(page: Page) {
 		this.page = page;
-		this.editConfigurationSubmitButton = page.getByTestId(
-			'submitConfiguration'
-		);
+		this.editConfigurationSubmitButton = page
+			.getByRole('button', {name: 'Save'})
+			.or(page.getByRole('button', {name: 'Update'}));
 		this.enabledButton = page.getByLabel('enabled');
 		this.systemSettingsPage = new SystemSettingsPage(page);
 		this.uiElementsPage = new UIElementsPage(page);

--- a/modules/test/playwright/tests/object-web/main/config.ts
+++ b/modules/test/playwright/tests/object-web/main/config.ts
@@ -6,7 +6,4 @@
 export const config = {
 	name: 'object-web.main',
 	testDir: 'tests/object-web/main',
-	use: {
-		testIdAttribute: 'data-qa-id',
-	},
 };


### PR DESCRIPTION
### What is the goal of this [task](https://liferay.atlassian.net/browse/LPD-65898)?

Recently, the use of global configurations defining the `testIdAttribute` has been causing failures in our testing routines. We're creating a task to remove the use of getByTestId from `object-web` tests. As a quick fix, we're modifying this commerce function to remove this global property that has been affecting our tests.