### PR TITLE
LPD-66193 Type error when restructuring nested fields

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/fieldSupport.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/fieldSupport.js
@@ -163,8 +163,12 @@ export function removeField(props, pages, fieldName, removeEmptyRows = true) {
 					rows,
 				};
 			})
-			.filter(({nestedFields = [], type}) => {
-				if (type === FIELD_TYPE_FIELDSET && !nestedFields.length) {
+			.filter(({nestedFields = [], rows = [], type}) => {
+				if (
+					type === FIELD_TYPE_FIELDSET &&
+					!nestedFields.length &&
+					!rows.length
+				) {
 					return false;
 				}
 

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formFields.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formFields.spec.ts
@@ -22,7 +22,7 @@ test.afterEach(async ({formsPage}) => {
 });
 
 test.describe('Manage fields through Form Preview page', () => {
-	test('assert that it is possible to delete the predefined value of a text field', async ({
+	test('Assert that it is possible to delete the predefined value of a text field', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 	}) => {
@@ -56,7 +56,7 @@ test.describe('Manage fields through Form Preview page', () => {
 		await newTabPage.close();
 	});
 
-	test('duplicating field with evaluation rules has correct behavior', async ({
+	test('Duplicating field with evaluation rules has correct behavior', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 		page,
@@ -99,76 +99,77 @@ test.describe('Manage fields through Form Preview page', () => {
 		).toHaveCount(2);
 	});
 
-	test('LPD-12824 HTML autocomplete attribute is rendered and has the configured value limited to 20 non-special characters in Date, Numeric and Text field types', async ({
-		formBuilderPage,
-		formBuilderSidePanelPage,
-	}) => {
-		const testData: {
-			expectedValue: string;
-			fieldTitle: FormFieldTypeTitle;
-			inputValue: string;
-		}[] = [
-			{
-				expectedValue: 'bday',
-				fieldTitle: 'Date',
-				inputValue: '+)(*&^%$#@ bday$__%  ',
-			},
-			{
-				expectedValue: 'one-time-code',
-				fieldTitle: 'Numeric',
-				inputValue: '****[][one-time-code&&#()',
-			},
-			{
-				expectedValue: 'transaction-currency',
-				fieldTitle: 'Text',
-				inputValue: 'transaction-currencyextracharacters',
-			},
-		];
+	test(
+		'HTML autocomplete attribute is rendered and has the configured value limited to 20 non-special characters in Date, Numeric and Text field types',
+		{tag: ['@LPD-12824']},
+		async ({formBuilderPage, formBuilderSidePanelPage}) => {
+			const testData: {
+				expectedValue: string;
+				fieldTitle: FormFieldTypeTitle;
+				inputValue: string;
+			}[] = [
+				{
+					expectedValue: 'bday',
+					fieldTitle: 'Date',
+					inputValue: '+)(*&^%$#@ bday$__%  ',
+				},
+				{
+					expectedValue: 'one-time-code',
+					fieldTitle: 'Numeric',
+					inputValue: '****[][one-time-code&&#()',
+				},
+				{
+					expectedValue: 'transaction-currency',
+					fieldTitle: 'Text',
+					inputValue: 'transaction-currencyextracharacters',
+				},
+			];
 
-		await formBuilderPage.goToNew();
+			await formBuilderPage.goToNew();
 
-		await expect(formBuilderPage.newFormHeading).toBeVisible();
+			await expect(formBuilderPage.newFormHeading).toBeVisible();
 
-		await formBuilderPage.fillFormTitle('Form' + getRandomInt());
+			await formBuilderPage.fillFormTitle('Form' + getRandomInt());
 
-		for (const data of testData) {
-			await formBuilderSidePanelPage.addFieldByDoubleClick(
-				data.fieldTitle
-			);
+			for (const data of testData) {
+				await formBuilderSidePanelPage.addFieldByDoubleClick(
+					data.fieldTitle
+				);
 
-			await formBuilderSidePanelPage.clickAdvancedTab();
+				await formBuilderSidePanelPage.clickAdvancedTab();
 
-			await expect(
-				formBuilderSidePanelPage.htmlAutocompleteAttributeField
-			).toBeVisible();
-
-			await formBuilderSidePanelPage.htmlAutocompleteAttributeField.fill(
-				data.inputValue
-			);
-
-			await formBuilderSidePanelPage.clickBackButton();
-		}
-
-		const newTabPage = await formBuilderPage.openPreviewForm();
-
-		for (const data of testData) {
-			if (data.fieldTitle === 'Date') {
 				await expect(
-					newTabPage.getByPlaceholder('__/__/____')
-				).toHaveAttribute('autocomplete', data.expectedValue);
+					formBuilderSidePanelPage.htmlAutocompleteAttributeField
+				).toBeVisible();
 
-				continue;
+				await formBuilderSidePanelPage.htmlAutocompleteAttributeField.fill(
+					data.inputValue
+				);
+
+				await formBuilderSidePanelPage.clickBackButton();
 			}
 
-			await expect(
-				newTabPage.getByLabel(data.fieldTitle)
-			).toHaveAttribute('autocomplete', data.expectedValue);
+			const newTabPage = await formBuilderPage.openPreviewForm();
+
+			for (const data of testData) {
+				if (data.fieldTitle === 'Date') {
+					await expect(
+						newTabPage.getByPlaceholder('__/__/____')
+					).toHaveAttribute('autocomplete', data.expectedValue);
+
+					continue;
+				}
+
+				await expect(
+					newTabPage.getByLabel(data.fieldTitle)
+				).toHaveAttribute('autocomplete', data.expectedValue);
+			}
+
+			await newTabPage.close();
 		}
+	);
 
-		await newTabPage.close();
-	});
-
-	test('make sure the aria-labelledby reference is present in the captcha form view', async ({
+	test('Make sure the aria-labelledby reference is present in the captcha form view', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 	}) => {
@@ -206,7 +207,7 @@ test.describe('Manage fields through Form Preview page', () => {
 		await newTabPage.close();
 	});
 
-	test('verify boolean field aria-labelledby is only created when there is corresponding label rendered', async ({
+	test('Verify boolean field aria-labelledby is only created when there is corresponding label rendered', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 	}) => {
@@ -351,7 +352,7 @@ test.describe('Manage fields through Form Preview page', () => {
 });
 
 test.describe('Manage fields through Form Builder page', () => {
-	test('assert edition of a rich text field predefined value that contains a rule', async ({
+	test('Assert edition of a rich text field predefined value that contains a rule', async ({
 		formBuilderPage,
 		formsPage,
 		page,
@@ -399,7 +400,7 @@ test.describe('Manage fields through Form Builder page', () => {
 		).toBeVisible();
 	});
 
-	test('assert that a date field can be previewed', async ({
+	test('Assert that a date field can be previewed', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 	}) => {
@@ -430,7 +431,7 @@ test.describe('Manage fields through Form Builder page', () => {
 		await expect(newTabPage.getByText(formattedDate)).toBeVisible();
 	});
 
-	test('assert that a fields group can be previewed', async ({
+	test('Assert that a fields group can be previewed', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 	}) => {
@@ -492,6 +493,7 @@ test.describe('Manage fields through Form Builder page', () => {
 		).toHaveCount(2);
 	});
 
+	test('Fields group can be translated and collapsed', async ({
 		formBuilderPage,
 		formBuilderSidePanelPage,
 		page,

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formFields.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/formFields.spec.ts
@@ -457,7 +457,41 @@ test.describe('Manage fields through Form Builder page', () => {
 		).toBeVisible();
 	});
 
-	test('fields group can be translated and collapsed', async ({
+	test('Can move the last field of a child group into the parent group field', async ({
+		formBuilderPage,
+		formBuilderSidePanelPage,
+		page,
+	}) => {
+		await test.step('go to form builder and create structure with two levels of nesting and one field in each', async () => {
+			await formBuilderPage.goToNew();
+
+			await formBuilderSidePanelPage.addFieldByDoubleClick('Text');
+
+			await formBuilderSidePanelPage.backButton.click();
+
+			await formBuilderSidePanelPage.addFieldToFieldGroup('Text', 0);
+
+			await formBuilderSidePanelPage.backButton.click();
+
+			await formBuilderSidePanelPage.addFieldToFieldGroup('Text', 2);
+
+			await page.getByLabel('Actions').nth(4).click();
+
+			await page.getByRole('menuitem', {name: 'Delete'}).click();
+		});
+
+		await test.step('drag field from child into the parent one to create new fieldGroup', async () => {
+			await page
+				.locator('.ddm-drag')
+				.nth(3)
+				.dragTo(page.locator('.ddm-drag').nth(1));
+		});
+
+		await expect(
+			page.getByLabel('Fields Group', {exact: true})
+		).toHaveCount(2);
+	});
+
 		formBuilderPage,
 		formBuilderSidePanelPage,
 		page,


### PR DESCRIPTION
Related issue: [LPD-66193](https://liferay.atlassian.net/browse/LPD-66193)

### Context
Currently, with a nested structure of at least two levels, each containing one field, when trying to drag the field from the second level to the field on the first level, thus creating a new group and deleting the previous one, the page is breaking. After some investigation I uncovered that the reason behind this bug was that we were not properly checking if the fieldset was empty before deleting it, so it got deleted prematurely, preventing the pages from being updated properly and breaking.

The goal with this fix is to only remove the fieldset once all info inside it has been emptied. 

[LPD-66193]: https://liferay.atlassian.net/browse/LPD-66193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ