### PR TITLE
LPD-66180 Ensure that only root object entries are expected to have object layouts that are registered under the hood

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectDefinitionUtil.java
@@ -52,6 +52,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Carolina Barbosa
@@ -411,19 +412,6 @@ public class ObjectDefinitionUtil {
 		};
 	}
 
-	private static String _getValue(
-		UnsafeFunction<String, String, Exception> unsafeFunction,
-		String value) {
-
-		if (value == StringPool.BLANK) {
-			return StringPool.BLANK;
-		}
-
-		return StringUtil.merge(
-			TransformUtil.transform(
-				value.split("\\s*,\\s*"), unsafeFunction, String.class));
-	}
-
 	private static ObjectDefinitionSetting _toObjectDefinitionSetting(
 		GroupLocalService groupLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
@@ -434,70 +422,68 @@ public class ObjectDefinitionUtil {
 			return null;
 		}
 
+		if (StringUtil.equals(
+				ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+				serviceBuilderObjectDefinitionSetting.getName())) {
+
+			return _toObjectDefinitionSetting(
+				ObjectDefinitionSettingConstants.
+					NAME_ACCEPTED_GROUP_EXTERNAL_REFERENCE_CODES,
+				groupId -> {
+					Group group = groupLocalService.getGroup(
+						GetterUtil.getLong(groupId));
+
+					return group.getExternalReferenceCode();
+				},
+				serviceBuilderObjectDefinitionSetting.getValue());
+		}
+		else if (StringUtil.equals(
+					ObjectDefinitionSettingConstants.
+						NAME_ROOT_OBJECT_DEFINITION_IDS,
+					serviceBuilderObjectDefinitionSetting.getName())) {
+
+			return _toObjectDefinitionSetting(
+				ObjectDefinitionSettingConstants.
+					NAME_ROOT_OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODES,
+				rootObjectDefinitionId -> {
+					com.liferay.object.model.ObjectDefinition
+						serviceBuilderObjectDefinition =
+							objectDefinitionLocalService.getObjectDefinition(
+								GetterUtil.getLong(rootObjectDefinitionId));
+
+					return serviceBuilderObjectDefinition.
+						getExternalReferenceCode();
+				},
+				serviceBuilderObjectDefinitionSetting.getValue());
+		}
+
 		ObjectDefinitionSetting objectDefinitionSetting =
 			new ObjectDefinitionSetting();
 
 		objectDefinitionSetting.setName(
-			() -> {
-				if (StringUtil.equals(
-						ObjectDefinitionSettingConstants.
-							NAME_ACCEPTED_GROUP_IDS,
-						serviceBuilderObjectDefinitionSetting.getName())) {
-
-					return ObjectDefinitionSettingConstants.
-						NAME_ACCEPTED_GROUP_EXTERNAL_REFERENCE_CODES;
-				}
-
-				if (StringUtil.equals(
-						ObjectDefinitionSettingConstants.
-							NAME_ROOT_OBJECT_DEFINITION_IDS,
-						serviceBuilderObjectDefinitionSetting.getName())) {
-
-					return ObjectDefinitionSettingConstants.
-						NAME_ROOT_OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODES;
-				}
-
-				return serviceBuilderObjectDefinitionSetting.getName();
-			});
+			serviceBuilderObjectDefinitionSetting::getName);
 		objectDefinitionSetting.setValue(
-			() -> {
-				if (StringUtil.equals(
-						ObjectDefinitionSettingConstants.
-							NAME_ACCEPTED_GROUP_IDS,
-						serviceBuilderObjectDefinitionSetting.getName())) {
+			serviceBuilderObjectDefinitionSetting::getValue);
 
-					return _getValue(
-						groupId -> {
-							Group group = groupLocalService.getGroup(
-								GetterUtil.getLong(groupId));
+		return objectDefinitionSetting;
+	}
 
-							return group.getExternalReferenceCode();
-						},
-						serviceBuilderObjectDefinitionSetting.getValue());
-				}
+	private static ObjectDefinitionSetting _toObjectDefinitionSetting(
+		String name, UnsafeFunction<String, String, Exception> unsafeFunction,
+		String value) {
 
-				if (StringUtil.equals(
-						ObjectDefinitionSettingConstants.
-							NAME_ROOT_OBJECT_DEFINITION_IDS,
-						serviceBuilderObjectDefinitionSetting.getName())) {
+		if (Objects.equals(value, StringPool.BLANK)) {
+			return null;
+		}
 
-					return _getValue(
-						rootObjectDefinitionId -> {
-							com.liferay.object.model.ObjectDefinition
-								serviceBuilderObjectDefinition =
-									objectDefinitionLocalService.
-										getObjectDefinition(
-											GetterUtil.getLong(
-												rootObjectDefinitionId));
+		ObjectDefinitionSetting objectDefinitionSetting =
+			new ObjectDefinitionSetting();
 
-							return serviceBuilderObjectDefinition.
-								getExternalReferenceCode();
-						},
-						serviceBuilderObjectDefinitionSetting.getValue());
-				}
-
-				return serviceBuilderObjectDefinitionSetting.getValue();
-			});
+		objectDefinitionSetting.setName(() -> name);
+		objectDefinitionSetting.setValue(
+			() -> StringUtil.merge(
+				TransformUtil.transform(
+					value.split("\\s*,\\s*"), unsafeFunction, String.class)));
 
 		return objectDefinitionSetting;
 	}

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -132,19 +132,7 @@ public class ObjectDefinitionResourceTest
 	@Override
 	@Test
 	public void testGetObjectDefinition() throws Exception {
-		super.testGetObjectDefinition();
-
-		ObjectDefinition objectDefinition =
-			objectDefinitionResource.postObjectDefinition(
-				randomObjectDefinition());
-
-		String objectDefinitionPluralName = StringUtil.lowerCaseFirstLetter(
-			TextFormatter.formatPlural(objectDefinition.getName()));
-
-		Assert.assertEquals(
-			"/o/c/" + objectDefinitionPluralName,
-			objectDefinition.getRestContextPath());
-
+		_testGetObjectDefinition();
 		_testGetObjectDefinitionWithRootObjectDefinitionExternalReferenceCodes();
 		_testGetObjectDefinitionWithWorkflowDefinitionLink();
 	}
@@ -1928,13 +1916,27 @@ public class ObjectDefinitionResourceTest
 		return objectDefinition;
 	}
 
+	private void _testGetObjectDefinition() throws Exception {
+		super.testGetObjectDefinition();
+
+		ObjectDefinition objectDefinition =
+			objectDefinitionResource.postObjectDefinition(
+				randomObjectDefinition());
+
+		String objectDefinitionPluralName = StringUtil.lowerCaseFirstLetter(
+			TextFormatter.formatPlural(objectDefinition.getName()));
+
+		Assert.assertEquals(
+			"/o/c/" + objectDefinitionPluralName,
+			objectDefinition.getRestContextPath());
+	}
+
 	private void _testGetObjectDefinitionWithRootObjectDefinitionExternalReferenceCodes()
 		throws Exception {
 
 		ObjectDefinition objectDefinitionA =
 			objectDefinitionResource.postObjectDefinition(
 				randomObjectDefinition());
-
 		ObjectDefinition objectDefinitionAA =
 			objectDefinitionResource.postObjectDefinition(
 				randomObjectDefinition());
@@ -1954,18 +1956,16 @@ public class ObjectDefinitionResourceTest
 		objectDefinitionAA = objectDefinitionResource.getObjectDefinition(
 			objectDefinitionAA.getId());
 
-		Assert.assertEquals(
+		Assert.assertArrayEquals(
 			new ObjectDefinitionSetting[] {
 				new ObjectDefinitionSetting() {
 					{
-						setName(
+						name =
 							ObjectDefinitionSettingConstants.
-								NAME_ROOT_OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODES);
-						setValue(
-							StringBundler.concat(
-								objectDefinitionA.getExternalReferenceCode(),
-								",",
-								objectDefinitionB.getExternalReferenceCode()));
+								NAME_ROOT_OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODES;
+						value =
+							objectDefinitionA.getExternalReferenceCode() + "," +
+								objectDefinitionB.getExternalReferenceCode();
 					}
 				}
 			},
@@ -1979,18 +1979,9 @@ public class ObjectDefinitionResourceTest
 		objectDefinitionAA = objectDefinitionResource.getObjectDefinition(
 			objectDefinitionAA.getId());
 
-		Assert.assertEquals(
-			new ObjectDefinitionSetting[] {
-				new ObjectDefinitionSetting() {
-					{
-						setName(
-							ObjectDefinitionSettingConstants.
-								NAME_ROOT_OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODES);
-						setValue("");
-					}
-				}
-			},
-			objectDefinitionAA.getObjectDefinitionSettings());
+		Assert.assertTrue(
+			ArrayUtil.isEmpty(
+				objectDefinitionAA.getObjectDefinitionSettings()));
 	}
 
 	@TestInfo("LPD-63538")

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -62,7 +62,6 @@ import com.liferay.object.service.ObjectLayoutLocalService;
 import com.liferay.object.service.ObjectLayoutTabLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
-import com.liferay.object.tree.Edge;
 import com.liferay.object.tree.Node;
 import com.liferay.object.tree.ObjectDefinitionTreeFactory;
 import com.liferay.object.tree.Tree;
@@ -90,8 +89,8 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.trash.TrashHandler;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
@@ -560,7 +559,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				objectRelationships);
 
 		try {
-			if (objectDefinition.isRootNode()) {
+			if (ArrayUtil.isNotEmpty(
+					objectDefinition.getRootObjectDefinitionIds())) {
+
 				_registerRootObjectLayoutTabScreenNavigationCategories(
 					objectDefinition.getObjectDefinitionId());
 			}
@@ -602,10 +603,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	private void _registerRootObjectLayoutTabScreenNavigationCategories(
-			long rootObjectDefinitionId)
+			long objectDefinitionId)
 		throws PortalException {
 
-		Tree tree = _objectDefinitionTreeFactory.create(rootObjectDefinitionId);
+		Tree tree = _objectDefinitionTreeFactory.create(
+			false, true, objectDefinitionId);
 
 		Iterator<Node> iterator = tree.iterator();
 
@@ -613,31 +615,16 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			Node node = iterator.next();
 
 			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.fetchObjectDefinition(
+				_objectDefinitionLocalService.getObjectDefinition(
 					node.getPrimaryKey());
 
-			if (objectDefinition == null) {
-				continue;
-			}
+			List<ObjectRelationship> objectRelationships =
+				_objectRelationshipLocalService.getObjectRelationships(
+					objectDefinition.getObjectDefinitionId());
 
-			List<Node> childNodes = node.getChildNodes();
-
-			if (ListUtil.isEmpty(childNodes)) {
+			for (ObjectRelationship objectRelationship : objectRelationships) {
 				_registerRootObjectLayoutTabScreenNavigationCategory(
-					objectDefinition, null);
-
-				continue;
-			}
-
-			for (int i = childNodes.size() - 1; i >= 0; i--) {
-				Node childNode = childNodes.get(i);
-
-				Edge edge = childNode.getEdge();
-
-				_registerRootObjectLayoutTabScreenNavigationCategory(
-					objectDefinition,
-					_objectRelationshipLocalService.fetchObjectRelationship(
-						edge.getObjectRelationshipId()));
+					objectDefinition, objectRelationship);
 			}
 
 			_registerRootObjectLayoutTabScreenNavigationCategory(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionSettingImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionSettingImpl.java
@@ -17,9 +17,19 @@ public class ObjectDefinitionSettingImpl
 
 	@Override
 	public boolean isReadOnly() {
-		return Objects.equals(
-			getName(),
-			ObjectDefinitionSettingConstants.NAME_ROOT_OBJECT_DEFINITION_IDS);
+		if (Objects.equals(
+				getName(),
+				ObjectDefinitionSettingConstants.
+					NAME_ROOT_OBJECT_DEFINITION_EXTERNAL_REFERENCE_CODES) ||
+			Objects.equals(
+				getName(),
+				ObjectDefinitionSettingConstants.
+					NAME_ROOT_OBJECT_DEFINITION_IDS)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -2383,33 +2383,6 @@ public class ObjectDefinitionLocalServiceImpl
 				"at-least-one-object-field-must-be-added");
 		}
 
-		if ((objectDefinition.getStatus() == WorkflowConstants.STATUS_DRAFT) &&
-			objectDefinition.isRootNode()) {
-
-			for (ObjectRelationship objectRelationship :
-					_objectRelationshipLocalService.getObjectRelationships(
-						objectDefinition.getObjectDefinitionId())) {
-
-				int objectEntriesCount =
-					_objectEntryLocalService.getObjectEntriesCount(
-						objectRelationship.getObjectDefinitionId2());
-
-				if (objectEntriesCount > 0) {
-					throw new ObjectRelationshipEdgeException(
-						StringBundler.concat(
-							"There must be no unrelated object entries when ",
-							"both object definitions are published so that ",
-							"the object relationship can be an edge to a root ",
-							"context"),
-						StringBundler.concat(
-							"there-must-be-no-unrelated-object-entries-when-",
-							"both-object-definitions-are-published-so-that-",
-							"the-object-relationship-can-be-an-edge-to-a-root-",
-							"context"));
-				}
-			}
-		}
-
 		_validateFriendlyURLSeparator(objectDefinition);
 
 		objectDefinition.setActive(true);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -583,15 +583,11 @@ public class ObjectEntryServiceTest {
 			tree.iterator(TreeConstants.ITERATOR_TYPE_POST_ORDER),
 			_objectEntryLocalService,
 			objectEntry -> {
-				if (objectEntry.getRootObjectEntryId() ==
-						objectEntry.getObjectEntryId()) {
-
-					return;
+				if (objectEntry.isRootDescendantNode()) {
+					Assert.assertNotNull(
+						_objectEntryService.deleteObjectEntry(
+							objectEntry.getObjectEntryId()));
 				}
-
-				Assert.assertNotNull(
-					_objectEntryService.deleteObjectEntry(
-						objectEntry.getObjectEntryId()));
 			});
 
 		long rootObjectEntryId = objectEntryRootNode.getPrimaryKey();
@@ -741,15 +737,11 @@ public class ObjectEntryServiceTest {
 		TreeTestUtil.forEachNodeObjectEntry(
 			tree.iterator(), _objectEntryLocalService,
 			objectEntry -> {
-				if (objectEntry.getRootObjectEntryId() ==
-						objectEntry.getObjectEntryId()) {
-
-					return;
+				if (objectEntry.isRootDescendantNode()) {
+					Assert.assertNotNull(
+						_objectEntryService.getObjectEntry(
+							objectEntry.getObjectEntryId()));
 				}
-
-				Assert.assertNotNull(
-					_objectEntryService.getObjectEntry(
-						objectEntry.getObjectEntryId()));
 			});
 
 		long rootObjectEntryId = objectEntryRootNode.getPrimaryKey();


### PR DESCRIPTION
Related: 

- [LPD-66180](https://liferay.atlassian.net/browse/LPD-66180)
- [LPD-66681](https://liferay.atlassian.net/browse/LPD-66681)

[LPD-66180]: https://liferay.atlassian.net/browse/LPD-66180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-66681]: https://liferay.atlassian.net/browse/LPD-66681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ