### PR TITLE
LPD-66765 Remove empty model implementation from ObjectDefinition with WorkflowDefinitionLink

### DIFF
--- a/modules/apps/object/object-service/build.gradle
+++ b/modules/apps/object/object-service/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	compileOnly project(":apps:portal-security:portal-security-script-management-api")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-catapult-api")

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -184,9 +184,9 @@ import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContr
 import com.liferay.portal.service.impl.LayoutLocalServiceHelper;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
-import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionService;
 import com.liferay.sharing.security.permission.resource.SharingModelResourcePermissionConfigurator;
 import com.liferay.sharing.service.SharingEntryLocalService;
 import com.liferay.subscription.service.SubscriptionLocalService;
@@ -1806,10 +1806,21 @@ public class ObjectDefinitionLocalServiceImpl
 					objectDefinition.getCompanyId(), groupId,
 					objectDefinition.getClassName(), 0, 0, true);
 
+			String workflowDefinitionName =
+				workflowDefinitionLink.getWorkflowDefinitionName();
+
 			KaleoDefinition kaleoDefinition =
-				_kaleoDefinitionService.getOrAddEmptyKaleoDefinition(
-					workflowDefinitionLink.getWorkflowDefinitionName(),
-					serviceContext);
+				_kaleoDefinitionLocalService.fetchKaleoDefinition(
+					workflowDefinitionName, serviceContext);
+
+			if (kaleoDefinition == null) {
+				kaleoDefinition =
+					_kaleoDefinitionLocalService.addKaleoDefinition(
+						workflowDefinitionName, workflowDefinitionName,
+						workflowDefinitionName, null, null,
+						WorkflowDefinitionConstants.SCOPE_ALL, 0,
+						serviceContext);
+			}
 
 			if (existingWorkflowDefinitionLink == null) {
 				_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
@@ -3526,9 +3537,6 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private KaleoDefinitionLocalService _kaleoDefinitionLocalService;
-
-	@Reference
-	private KaleoDefinitionService _kaleoDefinitionService;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1779,7 +1779,6 @@ public class ObjectDefinitionLocalServiceImpl
 			return;
 		}
 
-		long groupId = 0;
 		Set<Long> oldWorkflowDefinitionLinkIds = new HashSet<>(
 			TransformUtil.transform(
 				_workflowDefinitionLinkLocalService.getWorkflowDefinitionLinks(
@@ -1793,18 +1792,6 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (WorkflowDefinitionLink workflowDefinitionLink :
 				workflowDefinitionLinks) {
-
-			if (!Objects.equals(
-					objectDefinition.getScope(),
-					ObjectDefinitionConstants.SCOPE_COMPANY)) {
-
-				groupId = workflowDefinitionLink.getGroupId();
-			}
-
-			WorkflowDefinitionLink existingWorkflowDefinitionLink =
-				_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
-					objectDefinition.getCompanyId(), groupId,
-					objectDefinition.getClassName(), 0, 0, true);
 
 			String workflowDefinitionName =
 				workflowDefinitionLink.getWorkflowDefinitionName();
@@ -1821,6 +1808,13 @@ public class ObjectDefinitionLocalServiceImpl
 						WorkflowDefinitionConstants.SCOPE_ALL, 0,
 						serviceContext);
 			}
+
+			long groupId = workflowDefinitionLink.getGroupId();
+
+			WorkflowDefinitionLink existingWorkflowDefinitionLink =
+				_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
+					objectDefinition.getCompanyId(), groupId,
+					objectDefinition.getClassName(), 0, 0, true);
 
 			if (existingWorkflowDefinitionLink == null) {
 				_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -92,7 +92,6 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassName;
@@ -147,7 +146,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
-import com.liferay.portal.workflow.kaleo.exception.NoSuchDefinitionException;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 import com.liferay.sharing.security.permission.SharingEntryAction;
@@ -745,8 +743,6 @@ public class ObjectDefinitionLocalServiceTest {
 	public void testAddObjectDefinitionWithMissingWorkflowDefinitionReference()
 		throws Exception {
 
-		// Lazy referencing disabled
-
 		WorkflowDefinitionLink workflowDefinitionLink =
 			_workflowDefinitionLinkLocalService.createWorkflowDefinitionLink(
 				0L);
@@ -758,42 +754,25 @@ public class ObjectDefinitionLocalServiceTest {
 		List<WorkflowDefinitionLink> workflowDefinitionLinks =
 			Collections.singletonList(workflowDefinitionLink);
 
-		String randomObjectDefinitionName =
-			ObjectDefinitionTestUtil.getRandomName();
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName(),
+				workflowDefinitionLinks);
 
-		AssertUtils.assertFailure(
-			NoSuchDefinitionException.class,
-			StringBundler.concat(
-				"No KaleoDefinition exists with the key {companyId=",
-				TestPropsValues.getCompanyId(), ", name=",
-				workflowDefinitionLink.getWorkflowDefinitionName(), "}"),
-			() -> ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				randomObjectDefinitionName, workflowDefinitionLinks));
+		workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.getWorkflowDefinitionLink(
+				TestPropsValues.getCompanyId(), 0,
+				objectDefinition.getClassName(), 0, 0, true);
 
-		// Lazy referencing enabled
+		Assert.assertNotNull(workflowDefinitionLink);
 
-		try (SafeCloseable safeCloseable =
-				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
+		KaleoDefinition kaleoDefinition =
+			_kaleoDefinitionLocalService.getKaleoDefinition(
+				workflowDefinitionLink.getWorkflowDefinitionName(),
+				ServiceContextTestUtil.getServiceContext());
 
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionTestUtil.addCustomObjectDefinition(
-					randomObjectDefinitionName, workflowDefinitionLinks);
-
-			workflowDefinitionLink =
-				_workflowDefinitionLinkLocalService.getWorkflowDefinitionLink(
-					TestPropsValues.getCompanyId(), 0,
-					objectDefinition.getClassName(), 0, 0, true);
-
-			Assert.assertNotNull(workflowDefinitionLink);
-
-			KaleoDefinition kaleoDefinition =
-				_kaleoDefinitionLocalService.getKaleoDefinition(
-					workflowDefinitionLink.getWorkflowDefinitionName(),
-					ServiceContextTestUtil.getServiceContext());
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_EMPTY, kaleoDefinition.getStatus());
-		}
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, kaleoDefinition.getStatus());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -1742,16 +1742,10 @@ public class ObjectEntryLocalServiceTest {
 		workflowDefinitionLink.setWorkflowDefinitionName(
 			RandomTestUtil.randomString());
 
-		ObjectDefinition objectDefinition = null;
-
-		try (SafeCloseable safeCloseable =
-				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
-
-			objectDefinition =
-				ObjectDefinitionTestUtil.addCustomObjectDefinition(
-					ObjectDefinitionTestUtil.getRandomName(),
-					List.of(workflowDefinitionLink));
-		}
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName(),
+				List.of(workflowDefinitionLink));
 
 		objectDefinition =
 			_objectDefinitionLocalService.publishCustomObjectDefinition(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -1731,7 +1731,7 @@ public class ObjectEntryLocalServiceTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
-	public void testAddObjectEntryWithEmptyWorkflowDefinition()
+	public void testAddObjectEntryWithDraftWorkflowDefinition()
 		throws Exception {
 
 		WorkflowDefinitionLink workflowDefinitionLink =

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalService.java
@@ -375,11 +375,6 @@ public interface KaleoDefinitionLocalService
 	public int getKaleoDefinitionsCount(
 		String name, ServiceContext serviceContext);
 
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String name, ServiceContext serviceContext)
-		throws PortalException;
-
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceUtil.java
@@ -469,14 +469,6 @@ public class KaleoDefinitionLocalServiceUtil {
 		return getService().getKaleoDefinitionsCount(name, serviceContext);
 	}
 
-	public static KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String name,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().getOrAddEmptyKaleoDefinition(name, serviceContext);
-	}
-
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionLocalServiceWrapper.java
@@ -537,16 +537,6 @@ public class KaleoDefinitionLocalServiceWrapper
 			name, serviceContext);
 	}
 
-	@Override
-	public KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String name,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _kaleoDefinitionLocalService.getOrAddEmptyKaleoDefinition(
-			name, serviceContext);
-	}
-
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionService.java
@@ -66,11 +66,6 @@ public interface KaleoDefinitionService extends BaseService {
 			String name, ServiceContext serviceContext)
 		throws PortalException;
 
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String externalReferenceCode, ServiceContext serviceContext)
-		throws PortalException;
-
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceUtil.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceUtil.java
@@ -64,15 +64,6 @@ public class KaleoDefinitionServiceUtil {
 		return getService().getKaleoDefinition(name, serviceContext);
 	}
 
-	public static KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String externalReferenceCode,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().getOrAddEmptyKaleoDefinition(
-			externalReferenceCode, serviceContext);
-	}
-
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceWrapper.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoDefinitionServiceWrapper.java
@@ -65,16 +65,6 @@ public class KaleoDefinitionServiceWrapper
 		return _kaleoDefinitionService.getKaleoDefinition(name, serviceContext);
 	}
 
-	@Override
-	public KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String externalReferenceCode,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _kaleoDefinitionService.getOrAddEmptyKaleoDefinition(
-			externalReferenceCode, serviceContext);
-	}
-
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 14.0.0

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/http/KaleoDefinitionServiceHttp.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/http/KaleoDefinitionServiceHttp.java
@@ -215,50 +215,6 @@ public class KaleoDefinitionServiceHttp {
 		}
 	}
 
-	public static com.liferay.portal.workflow.kaleo.model.KaleoDefinition
-			getOrAddEmptyKaleoDefinition(
-				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				KaleoDefinitionServiceUtil.class,
-				"getOrAddEmptyKaleoDefinition",
-				_getOrAddEmptyKaleoDefinitionParameterTypes4);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.portal.workflow.kaleo.model.KaleoDefinition)
-				returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
 	public static java.util.List
 		<com.liferay.portal.workflow.kaleo.model.KaleoDefinition>
 				getScopeKaleoDefinitions(
@@ -274,7 +230,7 @@ public class KaleoDefinitionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KaleoDefinitionServiceUtil.class, "getScopeKaleoDefinitions",
-				_getScopeKaleoDefinitionsParameterTypes5);
+				_getScopeKaleoDefinitionsParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, scope, active, start, end, orderByComparator,
@@ -325,7 +281,7 @@ public class KaleoDefinitionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KaleoDefinitionServiceUtil.class, "getScopeKaleoDefinitions",
-				_getScopeKaleoDefinitionsParameterTypes6);
+				_getScopeKaleoDefinitionsParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, scope, start, end, orderByComparator,
@@ -372,7 +328,7 @@ public class KaleoDefinitionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KaleoDefinitionServiceUtil.class, "updateKaleoDefinition",
-				_updateKaleoDefinitionParameterTypes7);
+				_updateKaleoDefinitionParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, kaleoDefinitionId, title,
@@ -424,23 +380,19 @@ public class KaleoDefinitionServiceHttp {
 		new Class[] {
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[]
-		_getOrAddEmptyKaleoDefinitionParameterTypes4 = new Class[] {
-			String.class, com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _getScopeKaleoDefinitionsParameterTypes5 =
+	private static final Class<?>[] _getScopeKaleoDefinitionsParameterTypes4 =
 		new Class[] {
 			String.class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _getScopeKaleoDefinitionsParameterTypes6 =
+	private static final Class<?>[] _getScopeKaleoDefinitionsParameterTypes5 =
 		new Class[] {
 			String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateKaleoDefinitionParameterTypes7 =
+	private static final Class<?>[] _updateKaleoDefinitionParameterTypes6 =
 		new Class[] {
 			String.class, long.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
@@ -155,13 +155,7 @@ public class KaleoDefinitionLocalServiceImpl
 		kaleoDefinition.setScope(scope);
 		kaleoDefinition.setVersion(version);
 		kaleoDefinition.setActive(false);
-
-		if (EmptyModelManagerUtil.isEmptyModel()) {
-			kaleoDefinition.setStatus(WorkflowConstants.STATUS_EMPTY);
-		}
-		else {
-			kaleoDefinition.setStatus(WorkflowConstants.STATUS_DRAFT);
-		}
+		kaleoDefinition.setStatus(WorkflowConstants.STATUS_DRAFT);
 
 		kaleoDefinition = kaleoDefinitionPersistence.update(kaleoDefinition);
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionLocalServiceImpl.java
@@ -5,8 +5,6 @@
 
 package com.liferay.portal.workflow.kaleo.service.impl;
 
-import com.liferay.exportimport.kernel.empty.model.EmptyModelManager;
-import com.liferay.exportimport.kernel.empty.model.EmptyModelManagerUtil;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -19,7 +17,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
-import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
 import com.liferay.portal.workflow.kaleo.definition.util.WorkflowDefinitionContentUtil;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
@@ -326,23 +323,6 @@ public class KaleoDefinitionLocalServiceImpl
 	}
 
 	@Override
-	public KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String name, ServiceContext serviceContext)
-		throws PortalException {
-
-		return _emptyModelManager.getOrAddEmptyModel(
-			KaleoDefinition.class, serviceContext.getCompanyId(),
-			() -> kaleoDefinitionLocalService.addKaleoDefinition(
-				name, name, name, null, null,
-				WorkflowDefinitionConstants.SCOPE_ALL, 0, serviceContext),
-			name,
-			(externalReferenceCode, companyId) -> fetchKaleoDefinition(
-				name, serviceContext),
-			(externalReferenceCode, companyId) -> getKaleoDefinition(
-				name, serviceContext));
-	}
-
-	@Override
 	public List<KaleoDefinition> getScopeKaleoDefinitions(
 		String scope, boolean active, int start, int end,
 		OrderByComparator<KaleoDefinition> orderByComparator,
@@ -429,9 +409,6 @@ public class KaleoDefinitionLocalServiceImpl
 	private String _getVersion(int version) {
 		return version + StringPool.PERIOD + 0;
 	}
-
-	@Reference
-	private EmptyModelManager _emptyModelManager;
 
 	@Reference
 	private KaleoConditionLocalService _kaleoConditionLocalService;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoDefinitionServiceImpl.java
@@ -89,28 +89,6 @@ public class KaleoDefinitionServiceImpl extends KaleoDefinitionServiceBaseImpl {
 	}
 
 	@Override
-	public KaleoDefinition getOrAddEmptyKaleoDefinition(
-			String externalReferenceCode, ServiceContext serviceContext)
-		throws PortalException {
-
-		KaleoDefinition kaleoDefinition =
-			_kaleoDefinitionLocalService.fetchKaleoDefinition(
-				externalReferenceCode, serviceContext);
-
-		if (kaleoDefinition != null) {
-			_kaleoDefinitionModelResourcePermission.check(
-				getPermissionChecker(), null, ActionKeys.VIEW);
-
-			return kaleoDefinition;
-		}
-
-		_checkPermissions(serviceContext);
-
-		return _kaleoDefinitionLocalService.getOrAddEmptyKaleoDefinition(
-			externalReferenceCode, serviceContext);
-	}
-
-	@Override
 	public List<KaleoDefinition> getScopeKaleoDefinitions(
 			String scope, boolean active, int start, int end,
 			OrderByComparator<KaleoDefinition> orderByComparator,

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionLocalServiceTest.java
@@ -6,16 +6,7 @@
 package com.liferay.portal.workflow.kaleo.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
-import com.liferay.portal.kernel.test.AssertUtils;
-import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.workflow.kaleo.exception.NoSuchDefinitionException;
@@ -67,37 +58,6 @@ public class KaleoDefinitionLocalServiceTest
 
 		_kaleoDefinitionLocalService.getKaleoDefinition(
 			kaleoDefinition.getKaleoDefinitionId());
-	}
-
-	@Test
-	@TestInfo("LPD-65037")
-	public void testGetOrAddEmptyKaleoDefinition() throws Exception {
-
-		// Lazy referencing disabled
-
-		String name = RandomTestUtil.randomString();
-
-		AssertUtils.assertFailure(
-			NoSuchDefinitionException.class,
-			StringBundler.concat(
-				"No KaleoDefinition exists with the key {companyId=",
-				TestPropsValues.getCompanyId(), ", name=", name, "}"),
-			() -> _kaleoDefinitionLocalService.getOrAddEmptyKaleoDefinition(
-				name, ServiceContextTestUtil.getServiceContext()));
-
-		// Lazy referencing enabled
-
-		try (SafeCloseable safeCloseable =
-				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
-
-			KaleoDefinition kaleoDefinition =
-				_kaleoDefinitionLocalService.getOrAddEmptyKaleoDefinition(
-					RandomTestUtil.randomString(),
-					ServiceContextTestUtil.getServiceContext());
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_EMPTY, kaleoDefinition.getStatus());
-		}
 	}
 
 	@Test

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionServiceImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoDefinitionServiceImplTest.java
@@ -6,12 +6,10 @@
 package com.liferay.portal.workflow.kaleo.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -21,7 +19,6 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
-import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -41,7 +38,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.workflow.configuration.WorkflowDefinitionConfiguration;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
-import com.liferay.portal.workflow.kaleo.exception.NoSuchDefinitionException;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionService;
@@ -159,62 +155,6 @@ public class KaleoDefinitionServiceImplTest {
 			kaleoDefinition,
 			_kaleoDefinitionService.getKaleoDefinition(
 				kaleoDefinition.getKaleoDefinitionId()));
-	}
-
-	@Test
-	@TestInfo("LPD-65037")
-	public void testGetOrAddEmptyKaleoDefinition() throws Exception {
-
-		// Lazy referencing disabled
-
-		String name = RandomTestUtil.randomString();
-
-		AssertUtils.assertFailure(
-			NoSuchDefinitionException.class,
-			StringBundler.concat(
-				"No KaleoDefinition exists with the key {companyId=",
-				TestPropsValues.getCompanyId(), ", name=", name, "}"),
-			() -> _kaleoDefinitionService.getOrAddEmptyKaleoDefinition(
-				name, ServiceContextTestUtil.getServiceContext()));
-
-		// Lazy referencing enabled
-
-		try (SafeCloseable safeCloseable =
-				LazyReferencingThreadLocal.setEnabledWithSafeCloseable(true)) {
-
-			// With permissions
-
-			KaleoDefinition kaleoDefinition =
-				_kaleoDefinitionService.getOrAddEmptyKaleoDefinition(
-					RandomTestUtil.randomString(),
-					ServiceContextTestUtil.getServiceContext());
-
-			// Without permissions
-
-			User user = UserTestUtil.addUser();
-
-			_setUpPermissionThreadLocal(user);
-
-			AssertUtils.assertFailure(
-				PrincipalException.MustHavePermission.class,
-				StringBundler.concat(
-					"User ", user.getUserId(), " must have ADD_DEFINITION, ",
-					WorkflowConstants.RESOURCE_NAME, " permission for null "),
-				() -> _kaleoDefinitionService.getOrAddEmptyKaleoDefinition(
-					RandomTestUtil.randomString(),
-					ServiceContextTestUtil.getServiceContext()));
-
-			// Without permissions, existing kaleo definition
-
-			AssertUtils.assertFailure(
-				PrincipalException.MustBeCompanyAdmin.class,
-				StringBundler.concat(
-					"User ", user.getUserId(), " must be the company ",
-					"administrator to perform the action"),
-				() -> _kaleoDefinitionService.getOrAddEmptyKaleoDefinition(
-					kaleoDefinition.getName(),
-					ServiceContextTestUtil.getServiceContext()));
-		}
 	}
 
 	@Test


### PR DESCRIPTION
- **LPD-66591 Fix Breadcrumb styles on CMS**
- **LPD-66591 Rollback to slash icon**
- **LPD-66591 SF**
- **LPD-66738 baseline**
- **LPD-65532 No longer needed**
- **LPD-65532 Make CreatorUtil public**
- **LPD-65532 Not needed now**
- **LPD-65532 Populate the creator in the DTO**
- **LPD-65532 Add dependencies**
- **LPD-65532 buildRest**
- **LPD-65532 Semver**
- **LPD-65532 We do not need to export all attributes for the Creator since we won't create the user when importing, just the ERC to know if the user exists and get its userId**
- **LPD-65532 We do not need to make CreatorUtil public now**
- **LPD-65532 Manual SF**
- **LPD-65532 Add the creator in the tests when exporting a nested page template set**
- **LPD-65532 Typo**
- **LPD-26487 Change styles**
- **LPD-57834 Auto SF**
- **LPD-57068 Auto SF**
- **LPD-57834 Auto SF**
- **LPD-64248 Turning LPD-35914 into an instance level FF**
- **LPD-64248 export-import-service: Make threadsafe**
- **LPD-64248 LPD-64248: Make these instance scoped, too**
- **LPD-64248 Using a service tracker for better performance**
- **LPD-64248 Using a company scoped service tracker**
- **LPD-64248 Registering a single company scoped BatchEnginePortletDataHandler**
- **LPD-64248 This is a registrar**
- **LPD-64248 Removing unnecessary wrong code**
- **LPD-64248 Inlining**
- **LPD-64248 Asserting that a company without the FF does not use the BatchEnginePortletDataHandler**
- **LPD-64248 Ensuring no services are registered if no FF enabled**
- **LPD-64248 Fixing NPE**
- **LPD-64248 Using setPortletId**
- **LPD-64248 Avoiding unnecessary service updates**
- **LPD-64248 Avoiding service leaks using properties instead of instanceof**
- **LPD-64248 Thread safety**
- **LPD-64248 Undo unnecessary change to BatchEnginePortletDataHandler**
- **LPD-64248 Undo unneeded change.**
- **LPD-64248 Fixing compilation issue**
- **LPD-64248 Fixing test as the internals have changed**
- **LPD-64248 Fixing newly merged test**
- **LPD-64248 SF**
- **LPD-64578 Adjust styles**
- **LPD-64578 Set the logo as decorative image**
- **LPD-66447 Add taglib requirements only if not in jakarta or javax JSTL core URIs**
- **LPD-66447 Add test to ensure taglib with javax JSTL core URI is not added to taglib requirements**
- **LPD-66447 Add additional test case for Jakarta JSTL core URIs**
- **LPD-66447 Rename**
- **LPD-66447 Extract into private method**
- **LPD-66447 Add message for assertion error**
- **LPD-66447 Consolidate tests**
- **LPD-66447 Add positive assertions**
- **LPD-66447 Ensure stream is closed automatically**
- **LPD-66447 Rename**
- **LPD-66447 Sort**
- **LPD-66447 SF**
- **LPD-66447 As used**
- **LPD-66447 SF**
- **LPD-66447 prep next**
- **LPD-58844 Auto SF**
- **LPD-58844 Auto SF**
- **LPD-66301 SF**
- **LPD-66446 Auto SF**
- **LPD-58909 These should be protected?**
- **LPD-58909 auto SF**
- **LPD-66583 Update test to expose issue with COLUMN_LENGTH placeholders.**
- **LPD-66583 Remove COLUMN_LENGTH placeholders before invoking DuplicateUniqueFinderRowsCleaner.**
- **LPD-66583 SF**
- **LRSD-10190 Remove legacy advisories banner from Sec Vul. page**
- **LRSD-8298 Update all HC article links to new article links**
- **LRSD-11136 Fix dynamic outline fragment**
- **LPD-63231 support sorting by 'usages' when previewing delete bulk action**
- **LPD-63231 update tests**
- **LPD-66202 Update commerce product relationship with publisher assets object**
- **LPD-66202 Fix header when publishing an app**
- **LPD-61504 Adding SystemEvent to the list of excluded tables for the data cleanup preupgrade processes**
- **LPD-61504 Replacing by LinkedHashMapBuilder so the upgrade processes are executed in the insertion order (alphabetically)**
- **LPD-61504 Adding dependency of CompanyDataCleanupPreupgradeProcess to AnalyticsMessageDataCleanupPreupgradeProcess to make sure we do not browse the AnaliticsMessage when it is going to be truncated**
- **LPD-61504 Updating CompanyDataCleanupPreupgradeProcessTest. Now that SystemEvent table is excluded we need to remove the inserted data manually**
- **LPD-66565 Add sample for the new utility**
- **LPD-66565 Add tests for the new utility**
- **LPD-66565 Implement `openItemSelectorModal` utility, that allows opening of Item Selector from any JS context**
- **LPD-66565 Improve type**
- **LPD-66610 Add permissions url to dropdown action**
- **LPD-64864 Don't show 'translate' action for folders**
- **LPD-66060 prep next**
- **LPD-66447 prep next**
- **LPD-66447 prep next**
- **LPD-66447 LPD-66060 prep next**
- **LPD-66447 LPD-66060 prep next**
- **LPD-66447 LPD-66060 regen**
- **LPD-64786 add url field to asset usage**
- **LPD-64786 buildREST**
- **LPD-64786 build url for Layout and ObjectEntry**
- **LPD-64786 cover the new 'url' field in the existing tests**
- **LPD-64786 Sort**
- **LPD-64948 Use latest environment versions on upstream-* routines**
- **LPD-66419 Revert Name parameter type to String and add i18N for the name localization**
- **LPD-66419 buildRest**
- **LPD-66419 Update implementation to use name and name_i18n**
- **LPD-66419 Update tests**
- **LPD-66419 baseline**
- **Revert "LPD-63756 Update playwright function"**
- **Revert "LPD-63756 Update poshi function"**
- **Revert "LPD-63756 Adapting test to the new API structure"**
- **Revert "LPD-66433 Fix method"**
- **LPD-66394 Create test to expose issue with FragmentEntryLink and vocabularyId in editable values.**
- **LPD-66394 Take into account vocabularyId in editable values.**
- **LRSD-10673 Update LFU logic to prevent users from updating closed or solution accepted JSM tickets**
- **LRSD-10673 SF**
- **LRSD-10673 SF**
- **LPD-58307 adding ExportImportReportEntry when staing is falling**
- **LPD-58307 integration test**
- **LPD-58307 sfr**
- **LPD-58307 renaming**
- **LPD-58307 Using concrete exception instead of the generic Exception**
- **LPD-58307 Unregister the service**
- **LPD-58307 entities that contains ExternalReferenceCode implements the ExternalReferenceCodeModel interface so it is better to use it**
- **LPD-58307 sf and clean code changes**
- **LPD-64970 Update modelName from 75 to 255**
- **LPD-64970 gw buildService**
- **LPD-64970 Upgrade process**
- **LPD-58307 rename integration test**
- **LPD-58307 Move to the exception.handler package**
- **LPD-58307 Sort**
- **LPD-58307 baseline**
- **LPD-58307 Avoid getting the group again inside the method**
- **LPD-58307 Log only one line if it fails, with more detail and the exception**
- **LPD-58307 Throw exception after handling it, as we need the process to keep working as it was when failed**
- **LPD-58307 Follow the existing pattern for the groupId = 0 if Company scoped in the Empty Report**
- **LPD-58307 Inline**
- **LPD-58307 Improve validations and assertions in the test. Previously, we were just testing an entry was being inserted**
- **LPD-58307 Test also for company group**
- **LPD-58307 Create Import context, not export, seemed to be wrong even if it was not failing**
- **LPD-58307 Not needed**
- **LPD-58307 Add annotation to ensure a new transaction is executed for the Error Report entry, as the main Export/Import transaction will be rollbacked when fails**
- **LPD-58307 buildService**
- **LPD-58307 Create a transaction to verify the report entry is inserted even though the transaction is rollbacked**
- **LPD-58307 getting the stacktrace from a common place**
- **LPD-58307 Version increase is required after rebasing**
- **LPD-58307 Wordsmith**
- **LPD-58307 SF**
- **LPD-58307 SF**
- **LPD-58307 Avoid NPE and call use getGroup instead of fetchGroup**
- **LPD-58307 SF**
- **LPD-58307 Rename**
- **LPD-58307 Rename**
- **LPD-58307 Rename to match service.xml**
- **LPD-58307 Rename to match service.xml**
- **LPD-64970 Rename field from error to errorMessage, requested by Brian**
- **LPD-64970 Update references**
- **LPD-64970 buildService**
- **LPD-64970 Rename field also in Elastic**
- **LPD-64970 Add upgrade step**
- **LPD-58307 Use the count from localservice and simplify to avoid transactionality issues in the tests**
- **LPD-65176 Add test to reveal the issue by simulating the use case: a tld file declaring a tag with a path to a .tag file instead of a Java class**
- **LPD-65176 Write the bundle jars to a temp file to make location meaningful to fulfill the logic that gets the bundle jar url from bundle.getLocation().**
- **LPD-65176 SF, extract common logic**
- **LPD-65176 Fix the issue. When tag file is declared in the tld file, create the TldResourcePath using the combination of the bundle (jar) URL, the path, and the relative path of the tld file in the jar. Otherwise, if the tag file's path starts with /META-INF/tags and the TldResourcePath's url doesn't point to a jar, Tomcat Jasper pre-pends "/WEB-INF/classes" to the tag file path, causing the file not able to be found in later processing.**
- **LPD-65176 SF**
- **LPD-59097 Home path is never null**
- **LPD-59097 SF, simplify**
- **LPD-59097 Extract process start logic out of sidecar**
- **LPD-59097 Persist sidecar process and start it early in bundle activator**
- **LPD-59097 SF, reorder**
- **LPD-66428 Adapt the code in EditInfoItemStrutsAction to support adding an entry with external reference code**
- **LPD-66428 Handle the exception for expiration date**
- **LPD-66428 baseline**
- **LPD-66428 Allow creating an entry with display date**
- **LPD-66428 Allow updating an entry with display date**
- **LPD-66428 Display the date time value correctly**
- **LPD-66428 Only include the external reference code (ERC) input if it's not empty, which enables users to update the ERC of an existing entry**
- **LPD-66428 Use the updated external reference code**
- **LPD-66428 Add integration test**
- **LPD-66428 Fix integration tests after adding the externalReferenceCode as an editable field**
- **LPD-66480 Bringing leandro's implementation**
- **LPD-66480 It SFs, compiles, deploys and works in the simplest possible way**
- **LPD-66480 Registering one servlet per company**
- **LPD-66480 Adding openapis as resources**
- **LPD-66480 Disclaimers**
- **LPD-66480 Adding tool to call a given endpoint from the openapis**
- **LPD-66480 Moving to the builder**
- **LPD-66480 Sometimes it was creating wrong relative urls**
- **LPD-66480 Exposing available openapis as a tool to enable discoverability**
- **LPD-66480 Adding initial support for authorization**
- **LPD-66480 Use reflection and subclassing to access MCP SDK internals and expose the request access token**
- **LPD-66480 Use the access token in endpoint calls**
- **LPD-66480 Fixing after rebase**
- **LPD-66480 SF**
- **LPD-66480 Calculating base URLs**
- **LPD-66480 Fake the OAuth registration endpoint**
- **LPD-66480 All the calls need the access token**
- **LPD-66480 Disabling refresh**
- **LPD-66480 Explain the tool call exceptions better**
- **LPD-66480 With this there is no longer a loop**
- **LPD-66480 SF**
- **LPD-66480 Encapsulating error handling**
- **LPD-66480 Allowing all present and future scopes for the MCPServer**
- **LPD-66480 Always return the latest so that the agent can refresh them when needed**
- **LPD-66480 Adding prompt to improve demos**
- **LPD-66480 Adding redirect_uris to the /register response**
- **LPD-66480 Updating redirect_uris on /register**
- **LPD-66480 Reactivity is now done through prompt instructions**
- **LPD-66480 TODO**
- **LPD-66480 SF**
- **LPD-66480 Demo prompts**
- **LPD-66480 With page size 100**
- **LPD-66480 Add prompts to MCP**
- **LPD-66480 Add listener to follow changes in MCP Prompt objects**
- **LPD-66480 Refactoring**
- **LPD-66480 Should be system**
- **LPD-66480 Not needed**
- **LPD-66480 Simplifying prompts for now with no arguments**
- **LPD-66480 Adding demo prompts**
- **LPD-66480 These instructions yield better results**
- **LPD-66480 Forcing the leading slash as AI sometimes misses it**
- **LPD-66480 Refactoring current prompt to make it easier to add new demos**
- **LPD-66480 Adding prompts for the ideas demo**
- **LPD-66480 Replacing OAuth2 with Authorization header until the missing RFCs are supported**
- **LPD-66480 Removing testing prompts**
- **LPD-66480 Hiding behind LPD-63311 FF**
- **LPD-66480 Be more polite**
- **LPD-66480 Improving app.bnd**
- **LPD-66480 SF**
- **LPD-66480 Avoiding new functions on every request**
- **LPD-66480 Removing 1 level of indentation**
- **LPD-66480 Using HttpUtil**
- **LPD-66480 Simplifying and moving to the servlet**
- **LPD-66480 Sort**
- **LPD-66480 Simplifying tool calls**
- **LPD-66480 Describing the tools in a JSON file**
- **LPD-66480 Inlining**
- **LPD-66480 Building by default**
- **LPD-66480 Thread safe**
- **LPD-66480 Using existing pattern**
- **LPD-66480 Sort**
- **LPD-66480 Using existing pattern**
- **LPD-66480 Adding to CODEOWNERS**
- **LPD-66480 Based on modules/apps/headless/app.bnd**
- **LPD-66480 Sort**
- **LPD-66480 Adding integration test**
- **LPD-66480 Consistency**
- **LPD-66480 Use dependencies pattern**
- **LPD-66480 See https://github.com/modelcontextprotocol/java-sdk/blob/7f16cd0b9dc72f5adc3358a903bebb0f909dda3e/mcp-core/src/main/java/io/modelcontextprotocol/server/McpServer.java#L438C16-L438C38**
- **LPD-66480 Rename**
- **LPD-66480 Rename**
- **LPD-66480 Sort**
- **LPD-66480 Use emptyList**
- **LPD-66480 SF**
- **LPD-66480 Auto SF**
- **LPD-66480 Rename**
- **LPD-66480 Rename**
- **LPD-66480 Sort**
- **LPD-66480 This is just a test**
- **LPD-66480 SF**
- **LPD-66480 Buy space**
- **LPD-63581 Migrate AssetsForms#VisitorBehaviorCardShowsExpectedAmountOfViews to playwright**
- **LPD-63581 SF**
- **LPD-63581 Remove migrated test**
- **LRCI-6437 Reduce js-unit downstream time**
- **LRCI-6437 Further reduce modules-semantic-versioning downstream build time**
- **LPD-66515 Fixing Add Sample Data. Test that covers the scenario: SetupWizardHSQL#HSQLtoPostgreSQLSampleDataEnabled**
- **LPD-66055 update imports.txt with new PropsValues and PropsUtil package**
- **LPD-56577 Message case with Liferay.Notice pattern**
- **LPD-56577 Test case for Liferay.Notice message case pattern**
- **LPD-56577 SF**
- **LPD-61573 add new automation to replace PluginPackage.REPOSITORY_XML_FILENAME_EXTENSION to xml**
- **LPD-61573 add new testcase for replacement from  PluginPackage.REPOSITORY_XML_FILENAME_EXTENSION to xml**
- **LPD-61573 SF**
- **LPD-57326 Move HashedFilesRegistry to portal-kernel**
- **LPD-57326 Replace tokens in legacy CSS files and portlets**
- **LPD-57326 Rename HashedFilesRegistry.get as getHashedFileURI**
- **LPD-57326 Disable until everything is merged**
- **LPD-57326 Move HashedFilesRegistry to another package**
- **LPD-57326 Move internal package**
- **LPD-57326 Move old and new classes to a new place**
- **LPD-57326 Let's rename it to getResource as in ServletContext to avoid confusion**
- **LPD-57326 Use generic interface**
- **LPD-57326 Sort**
- **LPD-57326 SF**
- **LPD-56577 Smaller**
- **LPD-55735 add custom claims json to oAuthClientEntry**
- **LPD-55735 gw buildService**
- **LPD-55735 create upgrade process for new column customClaimsJSON**
- **LPD-55735 adjust add and update oAuthClientEntry methods**
- **LPD-55735 gw buildService**
- **LPD-55735 adjust OAuthClientEntryUpgradeProcessTest**
- **LPD-55735  add or update user custom fields based on customClaims**
- **LPD-55735 adjust UpdateOAuthClientEntryMVCActionCommand**
- **LPD-55735 adjust OIDCUserInfoProcessorTest to test custom claims processing**
- **LPD-55735 SF**
- **LPD-55735 baseline**
- **LPD-55735 Simplify**
- **LPD-55735 SF**
- **LPD-62565 Playwright test for bulk folder default permission actions**
- **LPD-62565 Unit test for bulk default permission actions**
- **LPD-62565 Added integration test scenario without propagation**
- **LPD-62565 Fixed wrong conflict resolution**
- **LPD-65402 Fix unrelated playwright tests**
- **LPD-62565 Add more checks**
- **LPD-62565 Bulk permission for assets (yaml)**
- **LPD-62565 Bulk permission for assets**
- **LPD-62565 Add new keywords**
- **LPD-62565 Autogenerated Code (buildRest)**
- **LPD-62565 Autogenerated Code (buildLang)**
- **LPD-62565 Sort**
- **LPD-62565 SF**
- **LPD-62565 SF**
- **LPD-62456 Adding searchCountBySocial, to be used together with existing searchBySocial**
- **LPD-62456 auto build service**
- **LPD-62456 Add tests for searchBySocial and searchCountBySocial**
- **LPD-62456 Use the existing userLocalService.searchBySocial() method to directly access the userFinder instead of ElasticSearch**
- **LPD-62456 Using local service to avoid unnecessary user permission check**
- **LPD-62456 Fix tests**
- **LPD-62456 Add tests for sorting**
- **LPD-62456 Add new tests for asset library member**
- **LPD-62456 Test getting nested field "roles"**
- **LPD-62456 Can you write a detailed summary in the ticket for why we can use the local service. Thx.**
- **LPD-66480 Typo**
- **object-web 1.0.233 prep next**
- **portal-store-azure 5.0.19 prep next**
- **portal-template-freemarker 7.0.65 prep next**
- **portal-vulcan-impl 5.0.143 prep next**
- **LPD-66480 Auto SF**
- **LPD-66757 Remove unnecessary test, and fix the other**
- **LPD-66030 refactor pagination to be manipulated by requests**
- **LPD-66030 update unit tests**
- **LRCI-6440 Increase 'git grep' command timeout to 60 seconds**
- **LRCI-6440 When using 'git grep' to get JS unit files, denote file types to improve performance**
- **LRCI-6440 Improve performance for poshi file reading in job object by giving it 8 threads**
- **LRCI-6455 Temporarily increase timeout to 5 hours for 'recordTestrayCaseResults'; will lower once we make performance enhancements**
- **LRCI-6440 LRCI-6455 prep next**
- **LPD-61617 Fix endpoint url**
- **LPD-61617 Add functional test**
- **LPD-61617 SF sorting**
- **LPD-62785 create ref to make dropdown to be in focus after item selection in FilterDropdown**
- **LPD-62785 create ref to make dropdown to be in focus after item selection in RangeSelectorsDropdown**
- **LPD-62785 discard unit test and replace it to a new one in RangeSelectorsDropdown**
- **LPD-7870 add new automation for setPortlet method for classes who extends BasePanelApp**
- **LPD-7870 add new test case for setPortlet method for classes who extends BasePanelApp**
- **LPD-7870 delete UpgradeJavaBasePanelAppExtendedClassesCheck since now is covered by catchAll automation**
- **LPD-7870 SF**
- **LPD-60007 Not used**
- **LPD-60007 Allow the CookiesBannerConfigurationDisplayContext to use an httpServletRequest, but keep the renderRequest for the CookiesBannerDisplayContext since it is needed there**
- **LPD-60007 Add new Data and Privacy category which has the Cookie Manager page**
- **LPD-60007 buildLang**
- **LPD-60007 Wrap the cookies banner configuration in a clay sheet if we are displaying it on the page so it matches the style of other ScreenNavigationEntries. Otherwise, keep it as-is for the popup.**
- **LPD-60007 Do the same for Product Analytics**
- **LPD-60007 Make sure the PA configuration screen is only visible to admin users**
- **LPD-60007 Fix edge-case where making a selection on the product analytics banner then refreshing the page leads to a permanently hidden cookies banner, even if we haven't made a cookies consent selection**
- **LPD-60007 If we are on the Cookie Manager or Product Analytics page, hide the corresponding banner**
- **LPD-60007 Add tests**
- **LPD-60007 Apply FF**
- **LPD-60007 Remove renderRequest in favor of the httpServletRequest**
- **LPD-60007 Wordsmith**
- **LPD-60007 Regen**
- **LPD-60007 As used**
- **LPD-60007 Sort and match base class**
- **LPS-77699 Update Translations**
- **LPD-66765 Remove empty model implementation from ObjectDefinition with WorkflowDefinitionLink. We don't use it yet for definitions.**
- **LPD-66765 Adapt integration tests to stop using empty model implementation**
- **LPD-66765 No need to expose method to get or add empty KaleoDefinition**
- **LPD-66765 Create empty shells for KaleoDefinition as draft**
- **LPD-66765 buildService**
- **LPD-66765 Integration tests not needed anymore**
- **LPD-66765 Get groupId from the workflow definition link**
- **LPD-66765 Rename test to reflect workflow definition status**
