### PR TITLE
LPD-66725 | LPD-66525 Assignee object field improvements

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
@@ -104,6 +104,14 @@ export default function Assignee({
 					notFound: Liferay.Language.get('no-results-found'),
 				}}
 				onChange={(item: string) => {
+					if (!item) {
+						onChange({
+							target: {
+								value: null,
+							},
+						});
+					}
+
 					setSearch(item);
 				}}
 				onItemsChange={() => {}}

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
@@ -56,7 +56,20 @@ export default function Assignee({
 	const [search, setSearch] = useState(value?.name ?? '');
 	const [networkStatus, setNetworkStatus] = useState(4);
 
-	const {resource} = useResource({
+	const {
+		resource,
+	}: {
+		resource: {
+			items: {
+				embedded: {
+					externalReferenceCode: string;
+					image?: string;
+					name: string;
+				};
+				entryClassName: string;
+			}[];
+		};
+	} = useResource({
 		fetchOptions: {
 			credentials: 'include',
 			headers: new Headers({'x-csrf-token': Liferay.authToken}),

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
@@ -109,36 +109,25 @@ export default function Assignee({
 				onItemsChange={() => {}}
 				value={search}
 			>
-				{(item: {
-					embedded: {
-						externalReferenceCode: string;
-						image?: string;
-						name: string;
-					};
-					entryClassName: string;
-				}) => (
+				{({entryClassName, externalReferenceCode, image, name}) => (
 					<Autocomplete.Item
-						key={item.embedded.name}
+						key={name}
 						onClick={() => {
+							const newValue = {
+								externalReferenceCode,
+								name,
+								type: entryClassName.split('.').pop(),
+							};
+
 							onChange({
 								target: {
-									value: {
-										externalReferenceCode:
-											item.embedded.externalReferenceCode,
-										name: item.embedded.name,
-										type: item.entryClassName
-											.split('.')
-											.pop(),
-									},
+									value: newValue,
 								},
 							});
 						}}
-						textValue={item.embedded.name}
+						textValue={name}
 					>
-						<Option
-							image={item.embedded.image}
-							name={item.embedded.name}
-						/>
+						<Option image={image} name={name} />
 					</Autocomplete.Item>
 				)}
 			</Autocomplete>

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx
@@ -92,9 +92,17 @@ export default function Assignee({
 				aria-label={label}
 				defaultValue={value?.name ?? ''}
 				disabled={readOnly}
+				filterKey="name"
 				items={
 					resource
-						? resource.items.filter((item: any) => !!item.embedded)
+						? resource.items
+								.filter((item) => !!item.embedded)
+								.map((item) => {
+									return {
+										...item.embedded,
+										entryClassName: item.entryClassName,
+									};
+								})
 						: []
 				}
 				loadingState={networkStatus}

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Assignee/Assignee.spec.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Assignee/Assignee.spec.tsx
@@ -89,6 +89,31 @@ describe('Assignee object field', () => {
 		);
 	});
 
+	it('calls onChange with null value when input field is empty', () => {
+		(useResource as jest.Mock).mockReturnValue({resource: null});
+
+		const onChange = jest.fn();
+
+		const {getByRole} = render(
+			<Assignee
+				label="Assignee"
+				name="assignee"
+				onChange={onChange}
+				value={{
+					externalReferenceCode: '123',
+					name: 'Test Test',
+					type: 'User',
+				}}
+			/>
+		);
+
+		const input = getByRole('combobox');
+
+		fireEvent.change(input, {target: {value: ''}});
+
+		expect(onChange).toHaveBeenLastCalledWith({target: {value: null}});
+	});
+
 	it('calls onChange with the correct value when an item is selected', async () => {
 		(useResource as jest.Mock).mockReturnValue({
 			resource: mockResourceWithImage,

--- a/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
@@ -127,7 +127,8 @@ test.afterEach(async ({apiHelpers, page, pagesAdminPage, templatesPage}) => {
 });
 
 assigneeTest(
-	'can add and update an entry with assignee object field',
+	'can create, read, update and delete an entry with assignee object field',
+	{tag: ['@LPD-64955', '@LPD-66725', '@LPD-66525']},
 	async ({apiHelpers, page, viewObjectEntriesPage}) => {
 		const objectFields = generateObjectFields({
 			objectFieldBusinessTypes: ['Assignee'],
@@ -161,64 +162,102 @@ assigneeTest(
 			type: 'objectDefinition',
 		});
 
-		await viewObjectEntriesPage.goto(objectDefinition.className);
+		await test.step('create', async () => {
+			await viewObjectEntriesPage.goto(objectDefinition.className);
 
-		await viewObjectEntriesPage.clickAddObjectEntry(
-			objectDefinition.label['en_US']
-		);
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				objectDefinition.label['en_US']
+			);
 
-		const {objectEntry} = await generateObjectEntryValues({
-			objectEntryFormat: 'UI',
-			objectFields,
-			role: 'Asset Library Owner',
-		});
-
-		const objectFieldObjectEntryValues =
-			await viewObjectEntriesPage.fillObjectFields({
-				objectEntry,
-				objectFields,
-			});
-
-		await viewObjectEntriesPage.saveObjectEntryButton.click();
-
-		await expect(viewObjectEntriesPage.successMessage).toBeVisible();
-
-		await viewObjectEntriesPage.backButton.click();
-
-		for (const {entry} of objectFieldObjectEntryValues) {
-			await expect(
-				page.locator('td').getByText(entry, {exact: true})
-			).toBeVisible();
-		}
-
-		const {objectEntry: newObjectEntryValues} =
-			await generateObjectEntryValues({
+			const {objectEntry} = await generateObjectEntryValues({
 				objectEntryFormat: 'UI',
 				objectFields,
-				role: 'Site Owner',
+				role: 'Asset Library Owner',
 			});
 
-		await viewObjectEntriesPage.goto(objectDefinition.className);
+			const objectFieldObjectEntryValues =
+				await viewObjectEntriesPage.fillObjectFields({
+					objectEntry,
+					objectFields,
+				});
 
-		await viewObjectEntriesPage.frontendDatasetItems.first().click();
+			await viewObjectEntriesPage.saveObjectEntryButton.click();
 
-		const newObjectFieldObjectEntryValues =
-			await viewObjectEntriesPage.fillObjectFields({
-				objectEntry: newObjectEntryValues,
-				objectFields,
-			});
+			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
 
-		await viewObjectEntriesPage.saveObjectEntryButton.click();
+			await viewObjectEntriesPage.backButton.click();
 
-		await expect(viewObjectEntriesPage.successMessage).toBeVisible();
+			for (const {entry} of objectFieldObjectEntryValues) {
+				await expect(
+					page.locator('td').getByText(entry, {exact: true})
+				).toBeVisible();
+			}
+		});
 
-		await viewObjectEntriesPage.backButton.click();
+		const objectFieldLabel = objectFields[0].label['en_US'];
 
-		for (const {entry} of newObjectFieldObjectEntryValues) {
+		const assigneeLocator = page.getByRole('combobox', {
+			name: objectFieldLabel,
+		});
+
+		await test.step('read', async () => {
+			await viewObjectEntriesPage.frontendDatasetItems.first().click();
+
+			await assigneeLocator.click();
+
+			await assigneeLocator.blur();
+
+			expect(assigneeLocator).toHaveValue('Asset Library Owner');
+
+			await viewObjectEntriesPage.backButton.click();
+		});
+
+		await test.step('update', async () => {
+			const {objectEntry: newObjectEntryValues} =
+				await generateObjectEntryValues({
+					objectEntryFormat: 'UI',
+					objectFields,
+					role: 'Site Owner',
+				});
+
+			await viewObjectEntriesPage.frontendDatasetItems.first().click();
+
+			const newObjectFieldObjectEntryValues =
+				await viewObjectEntriesPage.fillObjectFields({
+					objectEntry: newObjectEntryValues,
+					objectFields,
+				});
+
+			await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
+
+			await viewObjectEntriesPage.backButton.click();
+
+			for (const {entry} of newObjectFieldObjectEntryValues) {
+				await expect(
+					page.locator('td').getByText(entry, {exact: true})
+				).toBeVisible();
+			}
+		});
+
+		await test.step('delete', async () => {
+			await viewObjectEntriesPage.frontendDatasetItems.first().click();
+
+			await assigneeLocator.fill('');
+
+			await page.keyboard.press('Escape');
+
+			await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+			await expect(viewObjectEntriesPage.successMessage).toBeVisible();
+
+			await viewObjectEntriesPage.backButton.click();
+
 			await expect(
-				page.locator('td').getByText(entry, {exact: true})
+				page.locator('td').getByText('', {exact: true}).first()
 			).toBeVisible();
-		}
+		});
 	}
 );
 


### PR DESCRIPTION
Technical details about: f344786b42a24ddf1556747a70c2b5301d667594:

Some errors were occurring in this field due to the absence of the `filterKey` property. The error consisted of a blank value being returned in [onChange](https://github.com/liferay-bpm/liferay-portal/blob/ba9d2ba803a68c8d511640bc697f5266cada47d8/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Assignee/Assignee.tsx#L94), which caused our field's value to be cleared.

Before this change our data structure was:

```
items: {
  embedded: {
	  externalReferenceCode: string;
	  image?: string;
	  name: string;
  };
  entryClassName: string;
}[];
```

Debugging the Clay functions [hasItems](https://github.com/igor-franca/clay/blob/cdca9dbe53c93245a62fad88d1e6f2bff251545c/packages/clay-autocomplete/src/Autocomplete.tsx#L183-L196) and [filterKey](https://github.com/igor-franca/clay/blob/cdca9dbe53c93245a62fad88d1e6f2bff251545c/packages/clay-shared/src/getLocatorValue.ts#L24) I could see that I couldn't use `embedded.name` as the filterKey parameter value, since the filterKey function can only access one level in the object's structure.

So I decided to create the map to update the field data structure to:

```
items: {
  entryClassName: string;
  externalReferenceCode: string;
  image?: string;
  name: string;
}[];
```