### PR TITLE
LPD-67866 [Test Fix] can edit picklist object field from draft object definition/can navigate to picklist portlet through manage picklist button

### DIFF
--- a/modules/test/playwright/tests/object-web/main/objectFields.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectFields.spec.ts
@@ -302,7 +302,9 @@ test.describe('Manage object fields through Model Builder', () => {
 			modelBuilderDiagramPage.objectDefinitionNodes
 		);
 
-		await page.getByText('Picklist', {exact: true}).click();
+		await page
+			.getByText(objectFields[0].label['en_US'], {exact: true})
+			.click();
 
 		const picklistFieldName = 'picklistField' + getRandomInt();
 
@@ -365,7 +367,9 @@ test.describe('Manage object fields through Model Builder', () => {
 			modelBuilderDiagramPage.objectDefinitionNodes
 		);
 
-		await page.getByText('Picklist', {exact: true}).click();
+		await page
+			.getByText(objectFields[0].label['en_US'], {exact: true})
+			.click();
 
 		const newTabPagePromise = new Promise<Page>((resolve) =>
 			page.once('popup', resolve)


### PR DESCRIPTION
Related issues: [LPD-67866](https://liferay.atlassian.net/browse/LPD-67866) and [LPD-67867](https://liferay.atlassian.net/browse/LPD-67867)

[LPD-67866]: https://liferay.atlassian.net/browse/LPD-67866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-67867]: https://liferay.atlassian.net/browse/LPD-67867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ